### PR TITLE
Fix wrong index in StringParser's onEachChar{}

### DIFF
--- a/core/src/commonMain/kotlin/io/islandtime/parser/internal/Parsers.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/parser/internal/Parsers.kt
@@ -127,14 +127,12 @@ internal class StringParser(
 
         var currentPosition = position
 
-        while (currentPosition < text.length &&
-            (length.isEmpty() || currentPosition - position <= length.last)
-        ) {
+        while (currentPosition < text.length && (length.isEmpty() || currentPosition - position <= length.last)) {
             if (onEachChar.any {
                     it(
                         context.result,
                         text[currentPosition],
-                        currentPosition
+                        currentPosition - position
                     ) == StringParseAction.REJECT_AND_STOP
                 }
             ) {
@@ -144,7 +142,7 @@ internal class StringParser(
         }
 
         if (!length.isEmpty() && currentPosition - position !in length) {
-            return currentPosition.inv()
+            return position.inv()
         }
 
         onParsed.forEach { it(context.result, text.substring(position, currentPosition)) }

--- a/core/src/commonTest/kotlin/io/islandtime/parser/StringParserTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/parser/StringParserTest.kt
@@ -1,0 +1,111 @@
+package io.islandtime.parser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class StringParserTest {
+    @Test
+    fun `parser with no length restrictions`() {
+        val expectedCharMap = mapOf(
+            0 to 'T',
+            1 to 'e',
+            2 to 's',
+            3 to 't'
+        )
+
+        val parser = dateTimeParser {
+            +' '
+            string {
+                onEachChar { char, index ->
+                    assertEquals(char, expectedCharMap[index]!!)
+                    StringParseAction.ACCEPT_AND_CONTINUE
+                }
+                onParsed { timeZoneId = it }
+            }
+        }
+
+        val result = parser.parse(" Test")
+        assertTrue { result.fields.isEmpty() }
+        assertEquals("Test", result.timeZoneId)
+    }
+
+    @Test
+    fun `parsing can be stopped with REJECT_AND_STOP`() {
+        val parser = dateTimeParser {
+            +' '
+            string {
+                onEachChar { char, index ->
+                    assertEquals('.', char)
+                    assertEquals(0, index)
+                    StringParseAction.REJECT_AND_STOP
+                }
+                onParsed { timeZoneId = it }
+            }
+            +'.'
+        }
+
+        val result = parser.parse(" .")
+        assertTrue { result.fields.isEmpty() }
+        assertTrue { result.timeZoneId!!.isEmpty() }
+    }
+
+    @Test
+    fun `reports an error when there are no characters to parse`() {
+        val parser = dateTimeParser {
+            +' '
+            string {
+                onEachChar { _, _ ->  StringParseAction.ACCEPT_AND_CONTINUE }
+            }
+        }
+
+        val exception = assertFailsWith<DateTimeParseException> { parser.parse(" ") }
+        assertEquals(1, exception.errorIndex)
+        assertEquals(" ", exception.parsedString)
+    }
+
+    @Test
+    fun `reports an error when the min length isn't satisfied`() {
+        val parser = dateTimeParser {
+            +' '
+            string(2..10) {
+                onEachChar { char, _ ->
+                    if (char in 'A'..'Z') {
+                        StringParseAction.ACCEPT_AND_CONTINUE
+                    } else {
+                        StringParseAction.REJECT_AND_STOP
+                    }
+                }
+                onParsed { timeZoneId = it }
+            }
+            +'.'
+        }
+
+        val exception = assertFailsWith<DateTimeParseException> { parser.parse(" T.") }
+        assertEquals(1, exception.errorIndex)
+        assertEquals(" T.", exception.parsedString)
+    }
+
+    @Test
+    fun `reports an error when the max length isn't satisfied`() {
+        val parser = dateTimeParser {
+            +' '
+            string(1..4) {
+                onEachChar { char, _ ->
+                    if (char in 'A'..'Z') {
+                        StringParseAction.ACCEPT_AND_CONTINUE
+                    } else {
+                        StringParseAction.REJECT_AND_STOP
+                    }
+                }
+                onParsed { timeZoneId = it }
+            }
+            +'.'
+        }
+
+        val exception = assertFailsWith<DateTimeParseException> { parser.parse(" TESTS.") }
+        assertEquals(1, exception.errorIndex)
+        assertEquals(" TESTS.", exception.parsedString)
+    }
+}


### PR DESCRIPTION
The index was the overall position rather than the position within the string. The error index was also wrong when the length requirements weren't met. This is now fixed and more tests have been added.