### PR TITLE
Fix overflow handling when parsing numbers

### DIFF
--- a/core/src/commonTest/kotlin/io/islandtime/parser/WholeNumberParserTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/parser/WholeNumberParserTest.kt
@@ -4,6 +4,7 @@ import io.islandtime.base.DateTimeField
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class WholeNumberParserTest {
     @Test
@@ -60,44 +61,68 @@ class WholeNumberParserTest {
     }
 
     @Test
-    fun `fixed length parser enforces NEVER sign style`() {
-        val dowParser = dateTimeParser {
-            wholeNumber(1) {
-                associateWith(DateTimeField.DAY_OF_WEEK)
-                enforceSignStyle(SignStyle.NEVER)
+    fun `enforces NEVER sign style`() {
+        listOf(
+            dateTimeParser {
+                wholeNumber(1) {
+                    associateWith(DateTimeField.DAY_OF_WEEK)
+                    enforceSignStyle(SignStyle.NEVER)
+                }
+            },
+            dateTimeParser {
+                wholeNumber {
+                    associateWith(DateTimeField.DAY_OF_WEEK)
+                    enforceSignStyle(SignStyle.NEVER)
+                }
             }
+        ).forEach { parser ->
+            assertFailsWith<DateTimeParseException> { parser.parse("+9") }
+            assertFailsWith<DateTimeParseException> { parser.parse("-9") }
         }
-
-        assertFailsWith<DateTimeParseException> { dowParser.parse("+9") }
-        assertFailsWith<DateTimeParseException> { dowParser.parse("-9") }
     }
 
     @Test
-    fun `fixed length parser enforces NEGATIVE_ONLY sign style`() {
-        val dowParser = dateTimeParser {
-            wholeNumber(1) {
-                associateWith(DateTimeField.DAY_OF_WEEK)
-                enforceSignStyle(SignStyle.NEGATIVE_ONLY)
+    fun `enforces NEGATIVE_ONLY sign style`() {
+        listOf(
+            dateTimeParser {
+                wholeNumber(1) {
+                    associateWith(DateTimeField.DAY_OF_WEEK)
+                    enforceSignStyle(SignStyle.NEGATIVE_ONLY)
+                }
+            },
+            dateTimeParser {
+                wholeNumber {
+                    associateWith(DateTimeField.DAY_OF_WEEK)
+                    enforceSignStyle(SignStyle.NEGATIVE_ONLY)
+                }
             }
+        ).forEach { parser ->
+            assertFailsWith<DateTimeParseException> { parser.parse("+9") }
+            assertEquals(9, parser.parse("9").fields[DateTimeField.DAY_OF_WEEK])
+            assertEquals(-9, parser.parse("-9").fields[DateTimeField.DAY_OF_WEEK])
         }
-
-        assertFailsWith<DateTimeParseException> { dowParser.parse("+9") }
-        assertEquals(9, dowParser.parse("9").fields[DateTimeField.DAY_OF_WEEK])
-        assertEquals(-9, dowParser.parse("-9").fields[DateTimeField.DAY_OF_WEEK])
     }
 
     @Test
-    fun `fixed length parser enforces ALWAYS sign style`() {
-        val dowParser = dateTimeParser {
-            wholeNumber(1) {
-                associateWith(DateTimeField.DAY_OF_WEEK)
-                enforceSignStyle(SignStyle.ALWAYS)
+    fun `enforces ALWAYS sign style`() {
+        listOf(
+            dateTimeParser {
+                wholeNumber(1) {
+                    associateWith(DateTimeField.DAY_OF_WEEK)
+                    enforceSignStyle(SignStyle.ALWAYS)
+                }
+            },
+            dateTimeParser {
+                wholeNumber {
+                    associateWith(DateTimeField.DAY_OF_WEEK)
+                    enforceSignStyle(SignStyle.ALWAYS)
+                }
             }
+        ).forEach { parser ->
+            assertEquals(9, parser.parse("+9").fields[DateTimeField.DAY_OF_WEEK])
+            assertFailsWith<DateTimeParseException> { parser.parse("9") }
+            assertEquals(-9, parser.parse("-9").fields[DateTimeField.DAY_OF_WEEK])
         }
-
-        assertEquals(9, dowParser.parse("+9").fields[DateTimeField.DAY_OF_WEEK])
-        assertFailsWith<DateTimeParseException> { dowParser.parse("9") }
-        assertEquals(-9, dowParser.parse("-9").fields[DateTimeField.DAY_OF_WEEK])
     }
 
     @Test
@@ -166,5 +191,52 @@ class WholeNumberParserTest {
 
         assertFailsWith<DateTimeParseException> { parser.parse("2001975") }
         assertFailsWith<DateTimeParseException> { parser.parse("-1934-034") }
+    }
+
+    @Test
+    fun `reports an error when there are no characters to parse`() {
+        listOf(
+            dateTimeParser {
+                +' '
+                wholeNumber(2)
+            }, dateTimeParser {
+                +' '
+                wholeNumber()
+            }
+        ).forEach { parser ->
+            val exception = assertFailsWith<DateTimeParseException> { parser.parse(" ") }
+            assertEquals(1, exception.errorIndex)
+            assertEquals(" ", exception.parsedString)
+        }
+    }
+
+    @Test
+    fun `throws an exception on overflow`() {
+        val parsers = listOf(
+            dateTimeParser {
+                +' '
+                wholeNumber(19) {
+                    onParsed { fields[DateTimeField.DURATION_OF_HOURS] = it }
+                }
+            }, dateTimeParser {
+                +' '
+                wholeNumber {
+                    onParsed { fields[DateTimeField.DURATION_OF_HOURS] = it }
+                }
+            }
+        )
+
+        listOf(
+            " 9223372036854775808",
+            " -9223372036854775809",
+            " +9300000000000000000"
+        ).forEach { text ->
+            parsers.forEach { parser ->
+                val exception = assertFailsWith<DateTimeParseException> { parser.parse(text) }
+                assertEquals(1, exception.errorIndex)
+                assertEquals(text, exception.parsedString)
+                assertTrue { exception.cause is ArithmeticException }
+            }
+        }
     }
 }


### PR DESCRIPTION
Make sure an exception is thrown if a number that exceeds the max Long value is parsed. Parsing will stop immediately even if the offending parser is part of an `anyOf` or `optional` operation.