### PR TITLE
Split out time zone text from DateTimeTextProvider

### DIFF
--- a/core/src/commonMain/kotlin/io/islandtime/IslandTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/IslandTime.kt
@@ -2,6 +2,8 @@ package io.islandtime
 
 import io.islandtime.format.DateTimeTextProvider
 import io.islandtime.format.PlatformDateTimeTextProvider
+import io.islandtime.format.PlatformTimeZoneTextProvider
+import io.islandtime.format.TimeZoneTextProvider
 import io.islandtime.zone.PlatformTimeZoneRulesProvider
 import io.islandtime.zone.TimeZoneRulesProvider
 import kotlinx.atomicfu.atomic
@@ -15,6 +17,9 @@ object IslandTime {
 
     internal val dateTimeTextProvider: DateTimeTextProvider
         get() = settings.dateTimeTextProvider
+
+    internal val timeZoneTextProvider: TimeZoneTextProvider
+        get() = settings.timeZoneTextProvider
 
     @Suppress("ObjectPropertyName")
     private val _settings = atomic<Settings?>(null)
@@ -81,19 +86,26 @@ object IslandTime {
          * The date-time text provider to use.
          */
         var dateTimeTextProvider: DateTimeTextProvider
+
+        /**
+         * The time zone text provider to use.
+         */
+        var timeZoneTextProvider: TimeZoneTextProvider
     }
 
     private class InitializerImpl : Initializer {
         override var timeZoneRulesProvider: TimeZoneRulesProvider = PlatformTimeZoneRulesProvider
         override var dateTimeTextProvider: DateTimeTextProvider = PlatformDateTimeTextProvider
+        override var timeZoneTextProvider: TimeZoneTextProvider = PlatformTimeZoneTextProvider
 
         fun build(): Settings {
-            return Settings(timeZoneRulesProvider, dateTimeTextProvider)
+            return Settings(timeZoneRulesProvider, dateTimeTextProvider, timeZoneTextProvider)
         }
     }
 
     private data class Settings(
         val timeZoneRulesProvider: TimeZoneRulesProvider = PlatformTimeZoneRulesProvider,
-        val dateTimeTextProvider: DateTimeTextProvider = PlatformDateTimeTextProvider
+        val dateTimeTextProvider: DateTimeTextProvider = PlatformDateTimeTextProvider,
+        val timeZoneTextProvider: TimeZoneTextProvider = PlatformTimeZoneTextProvider
     )
 }

--- a/core/src/commonMain/kotlin/io/islandtime/TimeZone.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/TimeZone.kt
@@ -1,6 +1,6 @@
 package io.islandtime
 
-import io.islandtime.format.DateTimeTextProvider
+import io.islandtime.format.TimeZoneTextProvider
 import io.islandtime.format.TimeZoneTextStyle
 import io.islandtime.locale.Locale
 import io.islandtime.locale.defaultLocale
@@ -55,7 +55,7 @@ sealed class TimeZone : Comparable<TimeZone> {
 
     /**
      * The localized name of the time zone, if available for the locale in the specified style. The result depends on
-     * the configured [DateTimeTextProvider] and may differ between platforms.
+     * the configured [TimeZoneTextProvider] and may differ between platforms.
      *
      * Example output for the "America/New_York" ID and "en-US" locale:
      * - Standard: "Eastern Standard Time"
@@ -68,14 +68,14 @@ sealed class TimeZone : Comparable<TimeZone> {
      * @see displayName
      */
     fun localizedName(style: TimeZoneTextStyle, locale: Locale = defaultLocale()): String? {
-        return DateTimeTextProvider.timeZoneTextFor(this, style, locale)
+        return TimeZoneTextProvider.timeZoneTextFor(this, style, locale)
     }
 
     /**
      * A textual representation of the time zone, suitable for display purposes. The localized name will be returned, if
      * available for the locale in the specified style. If not, the [id] will be returned instead.
      *
-     * The result depends on the configured [DateTimeTextProvider] and may differ between platforms.
+     * The result depends on the configured [TimeZoneTextProvider] and may differ between platforms.
      *
      * Example output for the "America/New_York" ID and "en-US" locale:
      * - Standard: "Eastern Standard Time"

--- a/core/src/commonMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
@@ -4,7 +4,6 @@ import io.islandtime.IslandTime
 import io.islandtime.base.DateTimeField
 import io.islandtime.locale.Locale
 import io.islandtime.DateTimeException
-import io.islandtime.TimeZone
 
 typealias ParsableTextList = List<Pair<String, Long>>
 
@@ -104,16 +103,6 @@ interface DateTimeTextProvider {
      * @throws DateTimeException if the value is not `0` or `1`
      */
     fun eraTextFor(value: Long, style: TextStyle, locale: Locale): String? = null
-
-    /**
-     * Get the localized time zone text.
-     *
-     * @param zone the time zone
-     * @param style the style of the text
-     * @param locale the locale
-     * @return the localized time zone text or `null` if unavailable in the specified style
-     */
-    fun timeZoneTextFor(zone: TimeZone, style: TimeZoneTextStyle, locale: Locale): String? = null
 
     companion object : DateTimeTextProvider by IslandTime.dateTimeTextProvider
 }

--- a/core/src/commonMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
@@ -1,0 +1,26 @@
+package io.islandtime.format
+
+import io.islandtime.IslandTime
+import io.islandtime.TimeZone
+import io.islandtime.locale.Locale
+
+/**
+ * An abstraction that allows localized time zone names to be supplied from different data sources.
+ */
+interface TimeZoneTextProvider {
+    /**
+     * Get the localized time zone text.
+     *
+     * @param zone the time zone
+     * @param style the style of the text
+     * @param locale the locale
+     * @return the localized time zone text or `null` if unavailable in the specified style
+     */
+    fun timeZoneTextFor(zone: TimeZone, style: TimeZoneTextStyle, locale: Locale): String? = null
+
+    companion object : TimeZoneTextProvider by IslandTime.timeZoneTextProvider
+}
+/**
+ * The default provider of localized time zone text for the current platform.
+ */
+expect object PlatformTimeZoneTextProvider : TimeZoneTextProvider

--- a/core/src/commonTest/kotlin/io/islandtime/format/DateTimeTextProviderTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/format/DateTimeTextProviderTest.kt
@@ -1,7 +1,6 @@
 package io.islandtime.format
 
 import io.islandtime.DateTimeException
-import io.islandtime.TimeZone
 import io.islandtime.base.DateTimeField
 import io.islandtime.locale.localeOf
 import io.islandtime.test.AbstractIslandTimeTest
@@ -410,51 +409,5 @@ class DateTimeTextProviderTest : AbstractIslandTimeTest() {
             expected,
             DateTimeTextProvider.parsableTextFor(DateTimeField.ERA, TextStyle.FULL, en_US)
         )
-    }
-
-    @Test
-    fun `timeZoneTextFor() returns null when given a fixed offset time zone`() {
-        listOf(
-            TimeZone.FixedOffset("-04:00"),
-            TimeZone.FixedOffset("+00:00"),
-            TimeZone.FixedOffset("+14:00")
-        ).forEach { zone ->
-            TimeZoneTextStyle.values().forEach { style ->
-                assertNull(DateTimeTextProvider.timeZoneTextFor(zone, style, en_US))
-                assertNull(DateTimeTextProvider.timeZoneTextFor(zone, style, de_DE))
-            }
-        }
-    }
-
-    @Test
-    fun `timeZoneTextFor() returns a localized string when available`() {
-        val zone = TimeZone("America/New_York")
-
-        assertEquals(
-            "Eastern Standard Time",
-            DateTimeTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.STANDARD, en_US)
-        )
-        assertEquals(
-            "EST",
-            DateTimeTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.SHORT_STANDARD, en_US)
-        )
-        assertEquals(
-            "Eastern Daylight Time",
-            DateTimeTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.DAYLIGHT_SAVING, en_US)
-        )
-        assertEquals(
-            "EDT",
-            DateTimeTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.SHORT_DAYLIGHT_SAVING, en_US)
-        )
-    }
-
-    @Test
-    fun `timeZoneTextFor() returns null when the zone is invalid`() {
-        val zone = TimeZone("America/Boston")
-        assertFalse { zone.isValid }
-
-        TimeZoneTextStyle.values().forEach { style ->
-            assertNull(DateTimeTextProvider.timeZoneTextFor(zone, style, en_US))
-        }
     }
 }

--- a/core/src/commonTest/kotlin/io/islandtime/format/TimeZoneTextProviderTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/format/TimeZoneTextProviderTest.kt
@@ -1,0 +1,58 @@
+package io.islandtime.format
+
+import io.islandtime.TimeZone
+import io.islandtime.locale.localeOf
+import io.islandtime.test.AbstractIslandTimeTest
+import kotlin.test.*
+
+@Suppress("PrivatePropertyName")
+class TimeZoneTextProviderTest : AbstractIslandTimeTest() {
+    private val en_US = localeOf("en-US")
+    private val de_DE = localeOf("de-DE")
+
+    @Test
+    fun `timeZoneTextFor() returns null when given a fixed offset time zone`() {
+        listOf(
+            TimeZone.FixedOffset("-04:00"),
+            TimeZone.FixedOffset("+00:00"),
+            TimeZone.FixedOffset("+14:00")
+        ).forEach { zone ->
+            TimeZoneTextStyle.values().forEach { style ->
+                assertNull(TimeZoneTextProvider.timeZoneTextFor(zone, style, en_US))
+                assertNull(TimeZoneTextProvider.timeZoneTextFor(zone, style, de_DE))
+            }
+        }
+    }
+
+    @Test
+    fun `timeZoneTextFor() returns a localized string when available`() {
+        val zone = TimeZone("America/New_York")
+
+        assertEquals(
+            "Eastern Standard Time",
+            TimeZoneTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.STANDARD, en_US)
+        )
+        assertEquals(
+            "EST",
+            TimeZoneTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.SHORT_STANDARD, en_US)
+        )
+        assertEquals(
+            "Eastern Daylight Time",
+            TimeZoneTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.DAYLIGHT_SAVING, en_US)
+        )
+        assertEquals(
+            "EDT",
+            TimeZoneTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.SHORT_DAYLIGHT_SAVING, en_US)
+        )
+    }
+
+    @Test
+    fun `timeZoneTextFor() returns null when the zone is invalid`() {
+        val zone = TimeZone("America/Boston")
+        assertFalse { zone.isValid }
+
+        TimeZoneTextStyle.values().forEach { style ->
+            assertNull(TimeZoneTextProvider.timeZoneTextFor(zone, style, en_US))
+        }
+    }
+}

--- a/core/src/darwinMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
@@ -2,7 +2,6 @@ package io.islandtime.format
 
 import co.touchlab.stately.collections.frozenHashMap
 import io.islandtime.DateTimeException
-import io.islandtime.TimeZone
 import io.islandtime.base.DateTimeField
 import io.islandtime.locale.Locale
 import platform.Foundation.*
@@ -20,7 +19,7 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
         val locale: Locale
     )
 
-    override fun parsableTextFor(field: DateTimeField, styles: Set<TextStyle>, locale: NSLocale): ParsableTextList {
+    override fun parsableTextFor(field: DateTimeField, styles: Set<TextStyle>, locale: Locale): ParsableTextList {
         if (styles.isEmpty() || !supports(field)) {
             return emptyList()
         }
@@ -81,25 +80,6 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
         }
 
         return allEraTextFor(style, locale)?.get(value.toInt())
-    }
-
-    override fun timeZoneTextFor(zone: TimeZone, style: TimeZoneTextStyle, locale: Locale): String? {
-        return if (zone is TimeZone.Region) {
-            NSTimeZone.timeZoneWithName(zone.id)?.run {
-                val darwinStyle = when (style) {
-                    TimeZoneTextStyle.STANDARD -> NSTimeZoneNameStyle.NSTimeZoneNameStyleStandard
-                    TimeZoneTextStyle.SHORT_STANDARD -> NSTimeZoneNameStyle.NSTimeZoneNameStyleShortStandard
-                    TimeZoneTextStyle.DAYLIGHT_SAVING -> NSTimeZoneNameStyle.NSTimeZoneNameStyleDaylightSaving
-                    TimeZoneTextStyle.SHORT_DAYLIGHT_SAVING -> NSTimeZoneNameStyle.NSTimeZoneNameStyleShortDaylightSaving
-                    TimeZoneTextStyle.GENERIC -> NSTimeZoneNameStyle.NSTimeZoneNameStyleGeneric
-                    TimeZoneTextStyle.SHORT_GENERIC -> NSTimeZoneNameStyle.NSTimeZoneNameStyleShortGeneric
-                }
-
-                localizedName(darwinStyle, locale)
-            }
-        } else {
-            null
-        }
     }
 
     private fun supports(field: DateTimeField): Boolean {

--- a/core/src/darwinMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
@@ -1,0 +1,26 @@
+package io.islandtime.format
+
+import io.islandtime.TimeZone
+import io.islandtime.locale.Locale
+import platform.Foundation.*
+
+actual object PlatformTimeZoneTextProvider : TimeZoneTextProvider {
+    override fun timeZoneTextFor(zone: TimeZone, style: TimeZoneTextStyle, locale: Locale): String? {
+        return if (zone is TimeZone.Region) {
+            NSTimeZone.timeZoneWithName(zone.id)?.run {
+                val darwinStyle = when (style) {
+                    TimeZoneTextStyle.STANDARD -> NSTimeZoneNameStyle.NSTimeZoneNameStyleStandard
+                    TimeZoneTextStyle.SHORT_STANDARD -> NSTimeZoneNameStyle.NSTimeZoneNameStyleShortStandard
+                    TimeZoneTextStyle.DAYLIGHT_SAVING -> NSTimeZoneNameStyle.NSTimeZoneNameStyleDaylightSaving
+                    TimeZoneTextStyle.SHORT_DAYLIGHT_SAVING -> NSTimeZoneNameStyle.NSTimeZoneNameStyleShortDaylightSaving
+                    TimeZoneTextStyle.GENERIC -> NSTimeZoneNameStyle.NSTimeZoneNameStyleGeneric
+                    TimeZoneTextStyle.SHORT_GENERIC -> NSTimeZoneNameStyle.NSTimeZoneNameStyleShortGeneric
+                }
+
+                localizedName(darwinStyle, locale)
+            }
+        } else {
+            null
+        }
+    }
+}

--- a/core/src/darwinTest/kotlin/io/islandtime/format/DarwinTimeZoneTextProviderTest.kt
+++ b/core/src/darwinTest/kotlin/io/islandtime/format/DarwinTimeZoneTextProviderTest.kt
@@ -6,7 +6,7 @@ import io.islandtime.test.AbstractIslandTimeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class DarwinDateTimeTextProviderTest : AbstractIslandTimeTest() {
+class DarwinTimeZoneTextProviderTest : AbstractIslandTimeTest() {
     @Suppress("PrivatePropertyName")
     private val en_US = localeOf("en-US")
 
@@ -16,11 +16,11 @@ class DarwinDateTimeTextProviderTest : AbstractIslandTimeTest() {
 
         assertEquals(
             "Eastern Time",
-            DateTimeTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.GENERIC, en_US)
+            TimeZoneTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.GENERIC, en_US)
         )
         assertEquals(
             "ET",
-            DateTimeTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.SHORT_GENERIC, en_US)
+            TimeZoneTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.SHORT_GENERIC, en_US)
         )
     }
 }

--- a/core/src/jvmMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
+++ b/core/src/jvmMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
@@ -1,7 +1,6 @@
 package io.islandtime.format
 
 import io.islandtime.DateTimeException
-import io.islandtime.TimeZone
 import io.islandtime.base.DateTimeField
 import java.text.DateFormatSymbols
 import java.text.SimpleDateFormat
@@ -94,17 +93,6 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
         }
 
         return allEraTextFor(style, locale)[value.toInt()]
-    }
-
-    override fun timeZoneTextFor(zone: TimeZone, style: TimeZoneTextStyle, locale: Locale): String? {
-        return if (zone is TimeZone.FixedOffset || !zone.isValid || style.isGeneric()) {
-            null
-        } else {
-            val javaTzStyle = if (style.isShort()) java.util.TimeZone.SHORT else java.util.TimeZone.LONG
-            val isDaylightSaving = style.isDaylightSaving()
-
-            return java.util.TimeZone.getTimeZone(zone.id).getDisplayName(isDaylightSaving, javaTzStyle, locale)
-        }
     }
 
     private fun supports(field: DateTimeField): Boolean {

--- a/core/src/jvmMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
+++ b/core/src/jvmMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
@@ -1,0 +1,17 @@
+package io.islandtime.format
+
+import io.islandtime.TimeZone
+import java.util.*
+
+actual object PlatformTimeZoneTextProvider : TimeZoneTextProvider {
+    override fun timeZoneTextFor(zone: TimeZone, style: TimeZoneTextStyle, locale: Locale): String? {
+        return if (zone is TimeZone.FixedOffset || !zone.isValid || style.isGeneric()) {
+            null
+        } else {
+            val javaTzStyle = if (style.isShort()) java.util.TimeZone.SHORT else java.util.TimeZone.LONG
+            val isDaylightSaving = style.isDaylightSaving()
+
+            return java.util.TimeZone.getTimeZone(zone.id).getDisplayName(isDaylightSaving, javaTzStyle, locale)
+        }
+    }
+}

--- a/core/src/jvmTest/kotlin/io/islandtime/format/JvmTimeZoneTextProviderTest.kt
+++ b/core/src/jvmTest/kotlin/io/islandtime/format/JvmTimeZoneTextProviderTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 import kotlin.test.assertNull
 
 @Suppress("PrivatePropertyName")
-class JvmDateTimeTextProviderTest : AbstractIslandTimeTest() {
+class JvmTimeZoneTextProviderTest : AbstractIslandTimeTest() {
     private val en_US = localeOf("en-US")
     private val de_DE = localeOf("de-DE")
 
@@ -15,7 +15,7 @@ class JvmDateTimeTextProviderTest : AbstractIslandTimeTest() {
     fun `timeZoneTextFor() returns null for generic styles - limited by Android currently`() {
         val zone = TimeZone("America/New_York")
 
-        assertNull(DateTimeTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.GENERIC, en_US))
-        assertNull(DateTimeTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.SHORT_GENERIC, de_DE))
+        assertNull(TimeZoneTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.GENERIC, en_US))
+        assertNull(TimeZoneTextProvider.timeZoneTextFor(zone, TimeZoneTextStyle.SHORT_GENERIC, de_DE))
     }
 }


### PR DESCRIPTION
This makes it possible to swap out the time zone text provider independently, making it a bit less of an "all or nothing" deal.