### PR TITLE
Remove dependency on kotlin-reflect

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,7 +17,6 @@ kotlin {
 
             dependencies {
                 implementation(kotlin("stdlib-common"))
-                implementation(kotlin("reflect"))
             }
         }
 


### PR DESCRIPTION
Not needed anymore with Kotlin 1.3.70.