### PR TITLE
Fix interval random() behavior and add randomOrNull()

### DIFF
--- a/core/src/commonMain/kotlin/io/islandtime/ranges/DateRange.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/DateRange.kt
@@ -1,15 +1,10 @@
 package io.islandtime.ranges
 
 import io.islandtime.*
-import io.islandtime.MAX_DATE_STRING_LENGTH
-import io.islandtime.appendDate
 import io.islandtime.base.DateTimeField
 import io.islandtime.internal.MONTHS_PER_YEAR
 import io.islandtime.measures.*
-import io.islandtime.monthsSinceYear0
 import io.islandtime.parser.*
-import io.islandtime.parser.expectingGroupCount
-import io.islandtime.parser.throwParserFieldResolutionException
 import io.islandtime.ranges.internal.throwUnboundedIntervalException
 import kotlin.random.Random
 import kotlin.random.nextLong
@@ -201,18 +196,47 @@ fun String.toDateRange(
 
 /**
  * Return a random date within the range using the default random number generator.
+ * @throws NoSuchElementException if the range is empty
+ * @throws UnsupportedOperationException if the range is unbounded
+ * @see DateRange.randomOrNull
  */
 fun DateRange.random(): Date = random(Random)
 
 /**
+ * Return a random date within the range using the default random number generator or `null` if the
+ * range is empty or unbounded.
+ * @see DateRange.random
+ */
+fun DateRange.randomOrNull(): Date? = randomOrNull(Random)
+
+/**
  * Return a random date within the range using the supplied random number generator.
+ * @throws NoSuchElementException if the range is empty
+ * @throws UnsupportedOperationException if the range is unbounded
+ * @see DateRange.randomOrNull
  */
 fun DateRange.random(random: Random): Date {
+    if (isUnbounded()) throwUnboundedIntervalException()
+
     try {
         val longRange = first.unixEpochDay..last.unixEpochDay
         return Date.fromUnixEpochDay(random.nextLong(longRange))
     } catch (e: IllegalArgumentException) {
         throw NoSuchElementException(e.message)
+    }
+}
+
+/**
+ * Return a random date within the range using the supplied random number generator or `null` if
+ * the range is empty or unbounded.
+ * @see DateRange.random
+ */
+fun DateRange.randomOrNull(random: Random): Date? {
+    return if (isEmpty() || isUnbounded()) {
+        null
+    } else {
+        val longRange = first.unixEpochDay..last.unixEpochDay
+        Date.fromUnixEpochDay(random.nextLong(longRange))
     }
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/DateTimeInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/DateTimeInterval.kt
@@ -297,11 +297,14 @@ fun DateTimeInterval.randomOrNull(): DateTime? = randomOrNull(Random)
  * @see DateTimeInterval.randomOrNull
  */
 fun DateTimeInterval.random(random: Random): DateTime {
-    return when {
-        isUnbounded() -> throwUnboundedIntervalException()
-        isEmpty() -> throw NoSuchElementException()
-        else -> randomInternal(random)
-    }
+    return random(
+        random,
+        secondGetter = { it.unixEpochSecondAt(UtcOffset.ZERO) },
+        nanosecondGetter = { it.unixEpochNanoOfSecond },
+        creator = { second, nanosecond ->
+            DateTime.fromUnixEpochSecond(second, nanosecond, UtcOffset.ZERO)
+        }
+    )
 }
 
 /**
@@ -310,11 +313,14 @@ fun DateTimeInterval.random(random: Random): DateTime {
  * @see DateTimeInterval.random
  */
 fun DateTimeInterval.randomOrNull(random: Random): DateTime? {
-    return if (isEmpty() || isUnbounded()) {
-        null
-    } else {
-        randomInternal(random)
-    }
+    return randomOrNull(
+        random,
+        secondGetter = { it.unixEpochSecondAt(UtcOffset.ZERO) },
+        nanosecondGetter = { it.unixEpochNanoOfSecond },
+        creator = { second, nanosecond ->
+            DateTime.fromUnixEpochSecond(second, nanosecond, UtcOffset.ZERO)
+        }
+    )
 }
 
 /**
@@ -459,15 +465,4 @@ internal fun adjustedEndDate(start: DateTime, endExclusive: DateTime): Date {
         endExclusive.date < start.date && endExclusive.time > start.time -> endExclusive.date + 1.days
         else -> endExclusive.date
     }
-}
-
-private fun DateTimeInterval.randomInternal(random: Random): DateTime {
-    return randomInternal(
-        random,
-        secondGetter = { it.unixEpochSecondAt(UtcOffset.ZERO) },
-        nanosecondGetter = { it.unixEpochNanoOfSecond },
-        creator = { second, nanosecond ->
-            DateTime.fromUnixEpochSecond(second, nanosecond, UtcOffset.ZERO)
-        }
-    )
 }

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/InstantInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/InstantInterval.kt
@@ -5,8 +5,8 @@ import io.islandtime.base.DateTimeField
 import io.islandtime.measures.nanoseconds
 import io.islandtime.parser.*
 import io.islandtime.ranges.internal.buildIsoString
-import io.islandtime.ranges.internal.randomInternal
-import io.islandtime.ranges.internal.throwUnboundedIntervalException
+import io.islandtime.ranges.internal.random
+import io.islandtime.ranges.internal.randomOrNull
 import kotlin.random.Random
 
 /**
@@ -29,7 +29,8 @@ class InstantInterval(
     /**
      * Convert this interval to a string in ISO-8601 extended format.
      */
-    override fun toString() = buildIsoString(MAX_INSTANT_STRING_LENGTH, StringBuilder::appendInstant)
+    override fun toString() =
+        buildIsoString(MAX_INSTANT_STRING_LENGTH, StringBuilder::appendInstant)
 
     companion object {
         /**
@@ -133,10 +134,8 @@ fun InstantInterval.randomOrNull(): Instant? = randomOrNull(Random)
  * @see InstantInterval.randomOrNull
  */
 fun InstantInterval.random(random: Random): Instant {
-    return when {
-        isUnbounded() -> throwUnboundedIntervalException()
-        isEmpty() -> throw NoSuchElementException()
-        else -> randomInternal(random)
+    return random(random) { second, nanosecond ->
+        Instant.fromUnixEpochSecond(second, nanosecond)
     }
 }
 
@@ -146,10 +145,8 @@ fun InstantInterval.random(random: Random): Instant {
  * @see InstantInterval.random
  */
 fun InstantInterval.randomOrNull(random: Random): Instant? {
-    return if (isEmpty() || isUnbounded()) {
-        null
-    } else {
-        randomInternal(random)
+    return randomOrNull(random) { second, nanosecond ->
+        Instant.fromUnixEpochSecond(second, nanosecond)
     }
 }
 
@@ -202,11 +199,4 @@ fun ZonedDateTimeInterval.asInstantInterval(): InstantInterval {
             startInstant until endInstant
         }
     }
-}
-
-private fun InstantInterval.randomInternal(random: Random): Instant {
-    return randomInternal(
-        random,
-        creator = { second, nanosecond -> Instant.fromUnixEpochSecond(second, nanosecond) }
-    )
 }

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/OffsetDateTimeInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/OffsetDateTimeInterval.kt
@@ -4,10 +4,7 @@ import io.islandtime.*
 import io.islandtime.base.DateTimeField
 import io.islandtime.measures.*
 import io.islandtime.parser.*
-import io.islandtime.ranges.internal.MAX_INCLUSIVE_END_DATE_TIME
-import io.islandtime.ranges.internal.buildIsoString
-import io.islandtime.ranges.internal.randomInternal
-import io.islandtime.ranges.internal.throwUnboundedIntervalException
+import io.islandtime.ranges.internal.*
 import kotlin.random.Random
 
 /**
@@ -189,10 +186,8 @@ fun OffsetDateTimeInterval.randomOrNull(): OffsetDateTime? = randomOrNull(Random
  * @see OffsetDateTimeInterval.randomOrNull
  */
 fun OffsetDateTimeInterval.random(random: Random): OffsetDateTime {
-    return when {
-        isUnbounded() -> throwUnboundedIntervalException()
-        isEmpty() -> throw NoSuchElementException()
-        else -> randomInternal(random)
+    return random(random) { second, nanosecond ->
+        OffsetDateTime.fromUnixEpochSecond(second, nanosecond, start.offset)
     }
 }
 
@@ -202,10 +197,8 @@ fun OffsetDateTimeInterval.random(random: Random): OffsetDateTime {
  * @see OffsetDateTimeInterval.random
  */
 fun OffsetDateTimeInterval.randomOrNull(random: Random): OffsetDateTime? {
-    return if (isEmpty() || isUnbounded()) {
-        null
-    } else {
-        randomInternal(random)
+    return randomOrNull(random) { second, nanosecond ->
+        OffsetDateTime.fromUnixEpochSecond(second, nanosecond, start.offset)
     }
 }
 
@@ -257,13 +250,4 @@ fun daysBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): LongDays {
 private fun adjustedEndDateTime(start: OffsetDateTime, endExclusive: OffsetDateTime): DateTime {
     val offsetDelta = start.offset.totalSeconds - endExclusive.offset.totalSeconds
     return endExclusive.dateTime + offsetDelta
-}
-
-private fun OffsetDateTimeInterval.randomInternal(random: Random): OffsetDateTime {
-    return randomInternal(
-        random,
-        creator = { second, nanosecond ->
-            OffsetDateTime.fromUnixEpochSecond(second, nanosecond, start.offset)
-        }
-    )
 }

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/TimePointInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/TimePointInterval.kt
@@ -25,7 +25,7 @@ abstract class TimePointInterval<T : TimePoint<T>> internal constructor(
 
     override fun equals(other: Any?): Boolean {
         return other is TimePointInterval<*> && (isEmpty() && other.isEmpty() ||
-            ((hasUnboundedStart() && other.hasUnboundedStart()) ||  _start == other._start) &&
+            ((hasUnboundedStart() && other.hasUnboundedStart()) || _start == other._start) &&
             ((hasUnboundedEnd() && other.hasUnboundedEnd()) || _endExclusive == other._endExclusive))
     }
 
@@ -139,7 +139,8 @@ abstract class TimePointInterval<T : TimePoint<T>> internal constructor(
  */
 fun <T1, T2> durationBetween(start: TimePoint<T1>, endExclusive: TimePoint<T2>): Duration {
     val secondDiff = endExclusive.secondsSinceUnixEpoch - start.secondsSinceUnixEpoch
-    val nanoDiff = endExclusive.nanoOfSecondsSinceUnixEpoch minusWithOverflow start.nanoOfSecondsSinceUnixEpoch
+    val nanoDiff =
+        endExclusive.nanoOfSecondsSinceUnixEpoch minusWithOverflow start.nanoOfSecondsSinceUnixEpoch
     return durationOf(secondDiff, nanoDiff)
 }
 
@@ -181,7 +182,10 @@ fun <T1, T2> secondsBetween(start: TimePoint<T1>, endExclusive: TimePoint<T2>): 
  * Get the number of whole milliseconds between two time points.
  * @throws ArithmeticException if the result overflows
  */
-fun <T1, T2> millisecondsBetween(start: TimePoint<T1>, endExclusive: TimePoint<T2>): LongMilliseconds {
+fun <T1, T2> millisecondsBetween(
+    start: TimePoint<T1>,
+    endExclusive: TimePoint<T2>
+): LongMilliseconds {
     return millisecondsBetween(
         start.secondsSinceUnixEpoch,
         start.nanoOfSecondsSinceUnixEpoch,
@@ -194,7 +198,10 @@ fun <T1, T2> millisecondsBetween(start: TimePoint<T1>, endExclusive: TimePoint<T
  * Get the number of whole microseconds between two time points.
  *  @throws ArithmeticException if the result overflows
  */
-fun <T1, T2> microsecondsBetween(start: TimePoint<T1>, endExclusive: TimePoint<T2>): LongMicroseconds {
+fun <T1, T2> microsecondsBetween(
+    start: TimePoint<T1>,
+    endExclusive: TimePoint<T2>
+): LongMicroseconds {
     return microsecondsBetween(
         start.secondsSinceUnixEpoch,
         start.nanoOfSecondsSinceUnixEpoch,
@@ -207,7 +214,10 @@ fun <T1, T2> microsecondsBetween(start: TimePoint<T1>, endExclusive: TimePoint<T
  * Get the number of nanoseconds between two time points.
  * @throws ArithmeticException if the result overflows
  */
-fun <T1, T2> nanosecondsBetween(start: TimePoint<T1>, endExclusive: TimePoint<T2>): LongNanoseconds {
+fun <T1, T2> nanosecondsBetween(
+    start: TimePoint<T1>,
+    endExclusive: TimePoint<T2>
+): LongNanoseconds {
     return nanosecondsBetween(
         start.secondsSinceUnixEpoch,
         start.nanoOfSecondsSinceUnixEpoch,

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/ZonedDateTimeInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/ZonedDateTimeInterval.kt
@@ -4,10 +4,7 @@ import io.islandtime.*
 import io.islandtime.base.DateTimeField
 import io.islandtime.measures.*
 import io.islandtime.parser.*
-import io.islandtime.ranges.internal.MAX_INCLUSIVE_END_DATE_TIME
-import io.islandtime.ranges.internal.buildIsoString
-import io.islandtime.ranges.internal.randomInternal
-import io.islandtime.ranges.internal.throwUnboundedIntervalException
+import io.islandtime.ranges.internal.*
 import kotlin.random.Random
 
 /**
@@ -201,10 +198,8 @@ fun ZonedDateTimeInterval.randomOrNull(): ZonedDateTime? = randomOrNull(Random)
  * @see ZonedDateTimeInterval.randomOrNull
  */
 fun ZonedDateTimeInterval.random(random: Random): ZonedDateTime {
-    return when {
-        isUnbounded() -> throwUnboundedIntervalException()
-        isEmpty() -> throw NoSuchElementException()
-        else -> randomInternal(random)
+    return random(random) { second, nanosecond ->
+        ZonedDateTime.fromUnixEpochSecond(second, nanosecond, start.zone)
     }
 }
 
@@ -214,10 +209,8 @@ fun ZonedDateTimeInterval.random(random: Random): ZonedDateTime {
  * @see ZonedDateTimeInterval.random
  */
 fun ZonedDateTimeInterval.randomOrNull(random: Random): ZonedDateTime? {
-    return if (isEmpty() || isUnbounded()) {
-        null
-    } else {
-        randomInternal(random)
+    return randomOrNull(random) { second, nanosecond ->
+        ZonedDateTime.fromUnixEpochSecond(second, nanosecond, start.zone)
     }
 }
 
@@ -295,13 +288,4 @@ fun weeksBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): LongWeeks {
  */
 fun daysBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): LongDays {
     return daysBetween(start.dateTime, endExclusive.adjustedTo(start.zone).dateTime)
-}
-
-private fun ZonedDateTimeInterval.randomInternal(random: Random): ZonedDateTime {
-    return randomInternal(
-        random,
-        creator = { second, nanosecond ->
-            ZonedDateTime.fromUnixEpochSecond(second, nanosecond, start.zone)
-        }
-    )
 }

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/internal/Common.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/internal/Common.kt
@@ -105,21 +105,18 @@ internal inline fun <T> TimeInterval<T>.randomInternal(
     val untilSecond = secondGetter(endExclusive)
     val untilNanosecond = nanosecondGetter(endExclusive)
 
-    val second =
-        if (fromSecond == untilSecond) {
-            fromSecond
-        } else {
-            random.nextLong(fromSecond, if (untilNanosecond == 0) untilSecond else untilSecond + 1)
-        }
+    val randomSecond = getRandomSecond(random, fromSecond, untilSecond, untilNanosecond)
 
-    val nanosecond = when {
-        fromSecond == untilSecond -> random.nextInt(fromNanosecond, untilNanosecond)
-        second == fromSecond -> random.nextInt(fromNanosecond, NANOSECONDS_PER_SECOND)
-        second == untilSecond -> random.nextInt(0, untilNanosecond)
-        else -> random.nextInt(0, NANOSECONDS_PER_SECOND)
-    }
+    val randomNanosecond = getRandomNanosecond(
+        random,
+        randomSecond,
+        fromSecond,
+        fromNanosecond,
+        untilSecond,
+        untilNanosecond
+    )
 
-    return creator(second, nanosecond)
+    return creator(randomSecond, randomNanosecond)
 }
 
 internal inline fun <T : TimePoint<T>> TimePointInterval<T>.randomInternal(
@@ -131,4 +128,36 @@ internal fun throwUnboundedIntervalException(): Nothing {
     throw UnsupportedOperationException(
         "An interval cannot be represented as a period or duration unless it is bounded"
     )
+}
+
+private fun getRandomSecond(
+    random: Random,
+    fromSecond: Long,
+    untilSecond: Long,
+    untilNanosecond: Int
+): Long {
+    return if (fromSecond == untilSecond) {
+        fromSecond
+    } else {
+        random.nextLong(
+            fromSecond,
+            if (untilNanosecond == 0) untilSecond else untilSecond + 1
+        )
+    }
+}
+
+private fun getRandomNanosecond(
+    random: Random,
+    randomSecond: Long,
+    fromSecond: Long,
+    fromNanosecond: Int,
+    untilSecond: Long,
+    untilNanosecond: Int
+): Int {
+    return when {
+        fromSecond == untilSecond -> random.nextInt(fromNanosecond, untilNanosecond)
+        randomSecond == fromSecond -> random.nextInt(fromNanosecond, NANOSECONDS_PER_SECOND)
+        randomSecond == untilSecond -> random.nextInt(0, untilNanosecond)
+        else -> random.nextInt(0, NANOSECONDS_PER_SECOND)
+    }
 }

--- a/core/src/commonTest/kotlin/io/islandtime/ranges/DateRangeTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/ranges/DateRangeTest.kt
@@ -184,6 +184,32 @@ class DateRangeTest : AbstractIslandTimeTest() {
     }
 
     @Test
+    fun `random() throws an exception when the range is empty`() {
+        assertFailsWith<NoSuchElementException> { DateRange.EMPTY.random() }
+    }
+
+    @Test
+    fun `random() throws an exception when the range is unbounded`() {
+        assertFailsWith<UnsupportedOperationException> { DateRange.UNBOUNDED.random() }
+    }
+
+    @Test
+    fun `randomOrNull() returns null when the range is empty`() {
+        assertNull(DateRange.EMPTY.randomOrNull())
+    }
+
+    @Test
+    fun `randomOrNull() returns null when the range is unbounded`() {
+        assertNull(DateRange.UNBOUNDED.randomOrNull())
+    }
+
+    @Test
+    fun `randomOrNull() returns a date within range`() {
+        val range = Date(2018, Month.FEBRUARY, 20)..Date(2018, Month.FEBRUARY, 20)
+        assertTrue { range.randomOrNull()!! in range }
+    }
+
+    @Test
     fun `length properties throw an exception when the range isn't bounded`() {
         listOf(
             DateRange.UNBOUNDED,

--- a/core/src/commonTest/kotlin/io/islandtime/ranges/DateTimeIntervalTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/ranges/DateTimeIntervalTest.kt
@@ -110,14 +110,6 @@ class DateTimeIntervalTest : AbstractIslandTimeTest() {
     }
 
     @Test
-    fun `random() returns a date-time within the interval`() {
-        val start = Date(2019, Month.NOVEMBER, 1) at MIDNIGHT
-        val end = Date(2019, Month.NOVEMBER, 2) at MIDNIGHT
-        val interval = start until end
-        assertTrue { interval.random() in interval }
-    }
-
-    @Test
     fun `random() throws an exception when the interval is empty`() {
         assertFailsWith<NoSuchElementException> { DateTimeInterval.EMPTY.random() }
     }
@@ -138,11 +130,33 @@ class DateTimeIntervalTest : AbstractIslandTimeTest() {
     }
 
     @Test
-    fun `randomOrNull() returns a date-time within the interval`() {
-        val start = Date(2019, Month.NOVEMBER, 1) at MIDNIGHT
-        val end = start + 1.nanoseconds
-        val interval = start until end
-        assertTrue { interval.randomOrNull()!! in interval }
+    fun `random() and randomOrNull() return a date-time within the interval`() {
+        listOf(
+            Date(2019, Month.NOVEMBER, 1) at MIDNIGHT,
+            Date(2019, Month.NOVEMBER, 1) at Time(0, 0, 0, 1),
+            Date(2019, Month.NOVEMBER, 1) at Time.MAX
+        ).forEach { start ->
+            val interval = start until start + 1.nanoseconds
+            assertEquals(start, interval.random())
+            assertEquals(start, interval.randomOrNull())
+        }
+
+        listOf(
+            Date(2019, Month.NOVEMBER, 1) at MIDNIGHT,
+            Date(2019, Month.NOVEMBER, 1) at Time(0, 0, 0, 1),
+            Date(2019, Month.NOVEMBER, 1) at Time.MAX
+        ).forEach { start ->
+            listOf(
+                start + 1.nanoseconds,
+                start + 1.seconds,
+                start + 1.seconds + 1.nanoseconds,
+                start + 1.seconds + 999_999_999.nanoseconds
+            ).forEach { end ->
+                val interval = start until end
+                assertTrue { interval.random() in interval }
+                assertTrue { interval.randomOrNull()!! in interval }
+            }
+        }
     }
 
     @Test

--- a/core/src/commonTest/kotlin/io/islandtime/ranges/InstantIntervalTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/ranges/InstantIntervalTest.kt
@@ -69,7 +69,11 @@ class InstantIntervalTest : AbstractIslandTimeTest() {
         assertFalse { Instant(3L.days.inSeconds, (-1).nanoseconds) in start..end }
         assertFalse { Instant((-3L).days.inSeconds, 1.nanoseconds) in start..end }
         assertFalse {
-            OffsetDateTime.fromSecondsSinceUnixEpoch(2L.days.inSeconds, 1.nanoseconds, UtcOffset.ZERO) in start..end
+            OffsetDateTime.fromSecondsSinceUnixEpoch(
+                2L.days.inSeconds,
+                1.nanoseconds,
+                UtcOffset.ZERO
+            ) in start..end
         }
     }
 
@@ -140,9 +144,18 @@ class InstantIntervalTest : AbstractIslandTimeTest() {
             Instant((-1L).days.inSeconds) until Instant(1L.days.inSeconds),
             "1969-12-31T00:00Z/1970-01-02T00:00Z".toInstantInterval()
         )
-        assertEquals(Instant.MIN until Instant(1L.days.inSeconds), "../1970-01-02T00:00Z".toInstantInterval())
-        assertEquals(Instant((-1L).days.inSeconds) until Instant.MAX, "1969-12-31T00:00Z/..".toInstantInterval())
-        assertEquals(Instant((-1L).days.inSeconds)..Instant.MAX, "1969-12-31T00:00Z/..".toInstantInterval())
+        assertEquals(
+            Instant.MIN until Instant(1L.days.inSeconds),
+            "../1970-01-02T00:00Z".toInstantInterval()
+        )
+        assertEquals(
+            Instant((-1L).days.inSeconds) until Instant.MAX,
+            "1969-12-31T00:00Z/..".toInstantInterval()
+        )
+        assertEquals(
+            Instant((-1L).days.inSeconds)..Instant.MAX,
+            "1969-12-31T00:00Z/..".toInstantInterval()
+        )
         assertEquals(InstantInterval.UNBOUNDED, "../..".toInstantInterval())
     }
 
@@ -151,6 +164,38 @@ class InstantIntervalTest : AbstractIslandTimeTest() {
         val range = Instant((-2L).days.inSeconds)..Instant(2L.days.inSeconds)
         val randomInstant = range.random()
         assertTrue { randomInstant in range }
+    }
+
+    @Test
+    fun `random() returns a instant within the interval`() {
+        val interval = Instant((-2L).days.inSeconds) until Instant(2L.days.inSeconds)
+        assertTrue { interval.random() in interval }
+    }
+
+    @Test
+    fun `random() throws an exception when the interval is empty`() {
+        assertFailsWith<NoSuchElementException> { InstantInterval.EMPTY.random() }
+    }
+
+    @Test
+    fun `random() throws an exception when the interval is unbounded`() {
+        assertFailsWith<UnsupportedOperationException> { InstantInterval.UNBOUNDED.random() }
+    }
+
+    @Test
+    fun `randomOrNull() returns null when the interval is empty`() {
+        assertNull(InstantInterval.EMPTY.randomOrNull())
+    }
+
+    @Test
+    fun `randomOrNull() returns null when the interval is unbounded`() {
+        assertNull(InstantInterval.UNBOUNDED.randomOrNull())
+    }
+
+    @Test
+    fun `randomOrNull() returns a date within the interval`() {
+        val interval = Instant((2L).days.inSeconds)..Instant(2L.days.inSeconds)
+        assertTrue { interval.randomOrNull()!! in interval }
     }
 
     @Test
@@ -188,7 +233,10 @@ class InstantIntervalTest : AbstractIslandTimeTest() {
 
     @Test
     fun `convert unbounded DateRange to InstantInterval`() {
-        assertEquals(InstantInterval.UNBOUNDED, DateRange.UNBOUNDED.toInstantIntervalAt(TimeZone.UTC))
+        assertEquals(
+            InstantInterval.UNBOUNDED,
+            DateRange.UNBOUNDED.toInstantIntervalAt(TimeZone.UTC)
+        )
     }
 
     @Test
@@ -225,19 +273,24 @@ class InstantIntervalTest : AbstractIslandTimeTest() {
 
     @Test
     fun `convert unbounded OffsetDateTimeInterval to InstantInterval`() {
-        assertEquals(InstantInterval.UNBOUNDED, OffsetDateTimeInterval.UNBOUNDED.asInstantInterval())
+        assertEquals(
+            InstantInterval.UNBOUNDED,
+            OffsetDateTimeInterval.UNBOUNDED.asInstantInterval()
+        )
     }
 
     @Test
     fun `convert half-bounded OffsetDateTimeInterval to InstantInterval`() {
-        val offsetDateTimeInterval1 = "1968-10-05T05:00-05:00".toOffsetDateTime() until OffsetDateTime.MAX
+        val offsetDateTimeInterval1 =
+            "1968-10-05T05:00-05:00".toOffsetDateTime() until OffsetDateTime.MAX
 
         assertEquals(
             "1968-10-05T10:00Z".toInstant() until Instant.MAX,
             offsetDateTimeInterval1.asInstantInterval()
         )
 
-        val offsetDateTimeInterval2 = OffsetDateTime.MIN until "2000-01-03T10:00-05:00".toOffsetDateTime()
+        val offsetDateTimeInterval2 =
+            OffsetDateTime.MIN until "2000-01-03T10:00-05:00".toOffsetDateTime()
 
         assertEquals(
             Instant.MIN until "2000-01-03T15:00Z".toInstant(),
@@ -479,7 +532,10 @@ class InstantIntervalTest : AbstractIslandTimeTest() {
     fun `nanosecondsBetween() returns zero when both instants are the same`() {
         assertEquals(
             0L.nanoseconds,
-            nanosecondsBetween(Instant(1L.seconds, 1.nanoseconds), Instant(1L.seconds, 1.nanoseconds))
+            nanosecondsBetween(
+                Instant(1L.seconds, 1.nanoseconds),
+                Instant(1L.seconds, 1.nanoseconds)
+            )
         )
     }
 

--- a/core/src/commonTest/kotlin/io/islandtime/ranges/OffsetDateTimeIntervalTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/ranges/OffsetDateTimeIntervalTest.kt
@@ -100,13 +100,43 @@ class OffsetDateTimeIntervalTest : AbstractIslandTimeTest() {
     }
 
     @Test
-    fun `random() returns a zoned date-time within range`() {
+    fun `random() returns a date-time within the interval`() {
         val start = Date(2019, Month.NOVEMBER, 1) at MIDNIGHT at UtcOffset((-4).hours)
         val end = Date(2019, Month.NOVEMBER, 20) at MIDNIGHT at UtcOffset((-5).hours)
-        val range = start..end
-        val randomInstant = range.random()
-        assertTrue { randomInstant in range }
-        assertEquals(UtcOffset((-4).hours), randomInstant.offset)
+        val interval = start until end
+        val randomOffsetDateTime = interval.random()
+        assertTrue { randomOffsetDateTime in interval }
+        assertEquals(UtcOffset((-4).hours), randomOffsetDateTime.offset)
+    }
+
+    @Test
+    fun `random() throws an exception when the interval is empty`() {
+        assertFailsWith<NoSuchElementException> { OffsetDateTimeInterval.EMPTY.random() }
+    }
+
+    @Test
+    fun `random() throws an exception when the interval is unbounded`() {
+        assertFailsWith<UnsupportedOperationException> { OffsetDateTimeInterval.UNBOUNDED.random() }
+    }
+
+    @Test
+    fun `randomOrNull() returns null when the interval is empty`() {
+        assertNull(OffsetDateTimeInterval.EMPTY.randomOrNull())
+    }
+
+    @Test
+    fun `randomOrNull() returns null when the interval is unbounded`() {
+        assertNull(OffsetDateTimeInterval.UNBOUNDED.randomOrNull())
+    }
+
+    @Test
+    fun `randomOrNull() returns a date-time within the interval`() {
+        val start = Date(2019, Month.NOVEMBER, 1) at MIDNIGHT at UtcOffset((-4).hours)
+        val end = (start + 1.nanoseconds).adjustedTo(UtcOffset((-5).hours))
+        val interval = start until end
+        val randomOffsetDateTime = interval.randomOrNull()!!
+        assertTrue { randomOffsetDateTime in interval }
+        assertEquals(UtcOffset((-4).hours), randomOffsetDateTime.offset)
     }
 
     @Test
@@ -130,7 +160,10 @@ class OffsetDateTimeIntervalTest : AbstractIslandTimeTest() {
 
         assertEquals(
             periodOf(1.years, 1.months, 1.days),
-            periodBetween("2018-09-10T09:15-06:00".toOffsetDateTime(), "2019-10-11T09:15-07:00".toOffsetDateTime())
+            periodBetween(
+                "2018-09-10T09:15-06:00".toOffsetDateTime(),
+                "2019-10-11T09:15-07:00".toOffsetDateTime()
+            )
         )
     }
 
@@ -411,9 +444,25 @@ class OffsetDateTimeIntervalTest : AbstractIslandTimeTest() {
             }
         }
 
-        assertFailsWith<DateTimeParseException> { "2001/2002-11-04T13:23+01".toOffsetDateTimeInterval(customParser) }
-        assertFailsWith<DateTimeParseException> { "2001-10-03T00:01-04/2002".toOffsetDateTimeInterval(customParser) }
-        assertFailsWith<DateTimeParseException> { "/2002-11-04T13:23-04".toOffsetDateTimeInterval(customParser) }
-        assertFailsWith<DateTimeParseException> { "2001-10-03T00:01-07/".toOffsetDateTimeInterval(customParser) }
+        assertFailsWith<DateTimeParseException> {
+            "2001/2002-11-04T13:23+01".toOffsetDateTimeInterval(
+                customParser
+            )
+        }
+        assertFailsWith<DateTimeParseException> {
+            "2001-10-03T00:01-04/2002".toOffsetDateTimeInterval(
+                customParser
+            )
+        }
+        assertFailsWith<DateTimeParseException> {
+            "/2002-11-04T13:23-04".toOffsetDateTimeInterval(
+                customParser
+            )
+        }
+        assertFailsWith<DateTimeParseException> {
+            "2001-10-03T00:01-07/".toOffsetDateTimeInterval(
+                customParser
+            )
+        }
     }
 }

--- a/core/src/commonTest/kotlin/io/islandtime/ranges/ZonedDateTimeIntervalTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/ranges/ZonedDateTimeIntervalTest.kt
@@ -97,13 +97,43 @@ class ZonedDateTimeIntervalTest : AbstractIslandTimeTest() {
     }
 
     @Test
-    fun `random() returns a zoned date-time within range`() {
-        val start = Date(2019, Month.NOVEMBER, 1) at MIDNIGHT at "America/New_York".toTimeZone()
-        val end = Date(2019, Month.NOVEMBER, 20) at MIDNIGHT at "America/New_York".toTimeZone()
-        val range = start..end
-        val randomInstant = range.random()
-        assertTrue { randomInstant in range }
-        assertEquals("America/New_York".toTimeZone(), randomInstant.zone)
+    fun `random() returns a date-time within the interval`() {
+        val start = Date(2019, Month.NOVEMBER, 1) at MIDNIGHT at TimeZone("America/New_York")
+        val end = Date(2019, Month.NOVEMBER, 2) at MIDNIGHT at TimeZone("America/New_York")
+        val interval = start until end
+        val randomZonedDateTime = interval.random()
+        assertTrue { randomZonedDateTime in interval }
+        assertEquals(TimeZone("America/New_York"), randomZonedDateTime.zone)
+    }
+
+    @Test
+    fun `random() throws an exception when the interval is empty`() {
+        assertFailsWith<NoSuchElementException> { ZonedDateTimeInterval.EMPTY.random() }
+    }
+
+    @Test
+    fun `random() throws an exception when the interval is unbounded`() {
+        assertFailsWith<UnsupportedOperationException> { ZonedDateTimeInterval.UNBOUNDED.random() }
+    }
+
+    @Test
+    fun `randomOrNull() returns null when the interval is empty`() {
+        assertNull(ZonedDateTimeInterval.EMPTY.randomOrNull())
+    }
+
+    @Test
+    fun `randomOrNull() returns null when the interval is unbounded`() {
+        assertNull(ZonedDateTimeInterval.UNBOUNDED.randomOrNull())
+    }
+
+    @Test
+    fun `randomOrNull() returns a date-time within the interval`() {
+        val start = Date(2019, Month.NOVEMBER, 1) at MIDNIGHT at TimeZone("America/New_York")
+        val end = (start + 1.nanoseconds).adjustedTo(TimeZone("Europe/London"))
+        val interval = start until end
+        val randomZonedDateTime = interval.randomOrNull()!!
+        assertTrue { randomZonedDateTime in interval }
+        assertEquals(TimeZone("America/New_York"), randomZonedDateTime.zone)
     }
 
     @Test


### PR DESCRIPTION
On the `TimeInterval` types, an unexpected exception can be generated when either the second or nanosecond of the Unix epoch is the same between the start and end. The logic has been updated to handle some of the corner cases better.

A `randomOrNull()` extension function has also been added to each range/interval, mirroring the Kotlin stdlib.