### PR TITLE
Fix publishing of atomicfu transitive dependency on native

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath(Libs.atomicfu)
+        classpath(Libs.AtomicFU.gradlePlugin)
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -16,7 +16,10 @@ object Libs {
         const val native = "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:${Versions.serialization}"
     }
 
-    const val atomicfu = "org.jetbrains.kotlinx:atomicfu-gradle-plugin:${Versions.atomicfu}"
+    object AtomicFU {
+        const val gradlePlugin = "org.jetbrains.kotlinx:atomicfu-gradle-plugin:${Versions.atomicfu}"
+        const val native = "org.jetbrains.kotlinx:atomicfu-native:${Versions.atomicfu}"
+    }
 
     object AndroidxTest {
         const val runner = "androidx.test:runner:${Versions.androidxTest}"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
         val darwinMain by getting {
             dependencies {
                 implementation(Libs.statelyIsolate)
+                implementation(Libs.AtomicFU.native)
             }
         }
     }


### PR DESCRIPTION
While the atomicfu plugin adds the dependency that's needed for native builds, apparently it wasn't getting published properly. Adding it explicitly seems to fix that.

Closes #65.