### PR TITLE
Rename Unix epoch-related properties/functions for consistency

### DIFF
--- a/core/src/commonMain/kotlin/io/islandtime/Date.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/Date.kt
@@ -276,34 +276,44 @@ class Date(
     ) = Date(year, dayOfYear)
 
     companion object {
-        val MIN = Date(Year.MIN_VALUE, 1)
-        val MAX = Date(Year.MAX_VALUE, Year.MAX.lastDay)
+        /**
+         * The smallest supported [Date], which can be used as a "far past" sentinel.
+         */
+        val MIN = Date(Year.MIN_VALUE, Month.JANUARY, 1)
 
         /**
-         * Create the [Date] that falls a certain number of days from the Unix epoch of 1970-01-01
+         * The largest supported [Date], which can be used as a "far future" sentinel.
+         */
+        val MAX = Date(Year.MAX_VALUE, Month.DECEMBER, 31)
+
+        /**
+         * Create a [Date] from a duration of days relative to the Unix epoch of 1970-01-01.
          * @param days the number of days relative to the Unix epoch
-         * @return a new [Date]
          * @throws DateTimeException if outside of the supported date range
          */
-        fun fromDaysSinceUnixEpoch(days: LongDays): Date {
-            return fromUnixEpochDay(days.value)
-        }
+        fun fromDaysSinceUnixEpoch(days: LongDays): Date = fromDayOfUnixEpoch(days.value)
 
         /**
          * Create a [Date] from the day of the Unix epoch.
          * @param day the day of the Unix epoch
-         * @return a new [Date]
          * @throws DateTimeException if outside of the supported date range
          */
-        fun fromUnixEpochDay(day: Long): Date {
+        fun fromDayOfUnixEpoch(day: Long): Date {
             if (day !in -365243219162L..365241780471L) {
-                throw DateTimeException("The Unix epoch day '$day' is outside the supported range")
+                throw DateTimeException("The day '$day' of the Unix epoch is outside the supported range")
             }
 
             return withComponentizedDayOfUnixEpoch(day) { year, month, dayOfMonth ->
                 Date(year, month, dayOfMonth)
             }
         }
+
+        @Deprecated(
+            "Use fromDayOfUnixEpoch() instead.",
+            ReplaceWith("Date.fromDayOfUnixEpoch(day)"),
+            DeprecationLevel.WARNING
+        )
+        fun fromUnixEpochDay(day: Long): Date = fromDayOfUnixEpoch(day)
     }
 }
 
@@ -311,7 +321,6 @@ class Date(
  * Create a [Date] from a year and day of year
  * @param year the year
  * @param dayOfYear the day of the calendar year
- * @return a new [Date]
  * @throws DateTimeException if the year or day of year are invalid
  */
 @Suppress("FunctionName")
@@ -330,9 +339,9 @@ fun Date(year: Int, dayOfYear: Int): Date {
  * Convert an [Instant] into the [Date] represented by it at a particular UTC offset.
  */
 fun Instant.toDateAt(offset: UtcOffset): Date {
-    val adjustedSeconds = unixEpochSecond + offset.totalSeconds.value
-    val unixEpochDay = adjustedSeconds floorDiv SECONDS_PER_DAY
-    return Date.fromUnixEpochDay(unixEpochDay)
+    val adjustedSeconds = secondOfUnixEpoch + offset.totalSeconds.value
+    val dayOfUnixEpoch = adjustedSeconds floorDiv SECONDS_PER_DAY
+    return Date.fromDayOfUnixEpoch(dayOfUnixEpoch)
 }
 
 /**

--- a/core/src/commonMain/kotlin/io/islandtime/DateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/DateTime.kt
@@ -508,8 +508,7 @@ class DateTime(
      * value, so 1 nanosecond before the Unix epoch will be at a distance of 1 second.
      *
      * @param offset the offset from UTC
-     * @see nanoOfSecondsSinceUnixEpoch
-     * @see unixEpochSecondAt
+     * @see additionalNanosecondsSinceUnixEpoch
      */
     fun secondsSinceUnixEpochAt(offset: UtcOffset): LongSeconds {
         return (date.daysSinceUnixEpoch.inSecondsUnchecked.value +
@@ -517,13 +516,20 @@ class DateTime(
             offset.totalSeconds.value).seconds
     }
 
+    @Deprecated(
+        "Use additionalNanosecondsSinceUnixEpoch instead.",
+        ReplaceWith("this.additionalNanosecondsSinceUnixEpoch"),
+        DeprecationLevel.WARNING
+    )
+    val nanoOfSecondsSinceUnixEpoch: IntNanoseconds
+        get() = additionalNanosecondsSinceUnixEpoch
+
     /**
      * The number of additional nanoseconds that should be applied on top of the number of seconds since the Unix epoch
      * returned by [secondsSinceUnixEpochAt].
      * @see secondsSinceUnixEpochAt
-     * @see unixEpochNanoOfSecond
      */
-    val nanoOfSecondsSinceUnixEpoch: IntNanoseconds
+    val additionalNanosecondsSinceUnixEpoch: IntNanoseconds
         get() = nanosecond.nanoseconds
 
     /**
@@ -537,34 +543,48 @@ class DateTime(
             offset.totalSeconds.inMilliseconds.value).milliseconds
     }
 
+    @Deprecated(
+        "Use secondOfUnixEpochAt() instead.",
+        ReplaceWith("this.secondOfUnixEpochAt(offset)"),
+        DeprecationLevel.WARNING
+    )
+    fun unixEpochSecondAt(offset: UtcOffset): Long = secondOfUnixEpochAt(offset)
+
     /**
      * The second of the Unix epoch.
      *
      * @param offset the offset from UTC
-     * @see nanoOfSecondsSinceUnixEpoch
-     * @see unixEpochSecondAt
+     * @see additionalNanosecondsSinceUnixEpoch
      */
-    fun unixEpochSecondAt(offset: UtcOffset): Long = secondsSinceUnixEpochAt(offset).value
+    fun secondOfUnixEpochAt(offset: UtcOffset): Long = secondsSinceUnixEpochAt(offset).value
 
-    /**
-     * The nanosecond of the second of the Unix Epoch.
-     * @see nanoOfSecondsSinceUnixEpoch
-     * @see unixEpochSecondAt
-     */
-    val unixEpochNanoOfSecond: Int get() = nanosecond
+    @Deprecated(
+        "Use nanosecond instead.",
+        ReplaceWith("this.nanosecond"),
+        DeprecationLevel.WARNING
+    )
+    val unixEpochNanoOfSecond: Int
+        get() = nanosecond
+
+    @Deprecated(
+        "Use millisecondOfUnixEpoch() instead.",
+        ReplaceWith("this.millisecondOfUnixEpochAt(offset)"),
+        DeprecationLevel.WARNING
+    )
+    fun unixEpochMillisecondAt(offset: UtcOffset): Long = millisecondOfUnixEpochAt(offset)
 
     /**
      * The millisecond of the Unix epoch.
      * @param offset the offset from UTC
      */
-    fun unixEpochMillisecondAt(offset: UtcOffset): Long = millisecondsSinceUnixEpochAt(offset).value
+    fun millisecondOfUnixEpochAt(offset: UtcOffset): Long = millisecondsSinceUnixEpochAt(offset).value
 
     /**
      * The [Instant] represented by this date-time at a particular offset from UTC.
      * @param offset the offset from UTC
      */
     fun instantAt(offset: UtcOffset): Instant {
-        return Instant.fromUnixEpochSecond(unixEpochSecondAt(offset), nanosecond)
+        return Instant.fromSecondOfUnixEpoch(secondOfUnixEpochAt(offset), nanosecond)
     }
 
     companion object {
@@ -578,41 +598,70 @@ class DateTime(
          */
         val MAX = DateTime(Date.MAX, Time.MAX)
 
-        fun fromUnixEpochMillisecond(millisecond: Long, offset: UtcOffset): DateTime {
-            return fromMillisecondsSinceUnixEpoch(millisecond.milliseconds, offset)
-        }
-
-        fun fromMillisecondsSinceUnixEpoch(milliseconds: LongMilliseconds, offset: UtcOffset): DateTime {
-            val localMilliseconds = milliseconds + offset.totalSeconds
-            val localEpochDays = (localMilliseconds.value floorDiv MILLISECONDS_PER_DAY).days
+        /**
+         * Create a [DateTime] from a duration of milliseconds relative to the Unix epoch at [offset].
+         */
+        fun fromMillisecondsSinceUnixEpoch(millisecondsSinceUnixEpoch: LongMilliseconds, offset: UtcOffset): DateTime {
+            val localMilliseconds = millisecondsSinceUnixEpoch + offset.totalSeconds
+            val localEpochDay = localMilliseconds.value floorDiv MILLISECONDS_PER_DAY
             val nanosecondOfDay =
                 (localMilliseconds.value floorMod MILLISECONDS_PER_DAY).milliseconds.inNanosecondsUnchecked.value
-            val date = Date.fromDaysSinceUnixEpoch(localEpochDays)
+            val date = Date.fromDayOfUnixEpoch(localEpochDay)
             val time = Time.fromNanosecondOfDay(nanosecondOfDay)
             return DateTime(date, time)
         }
 
-        fun fromUnixEpochSecond(second: Long, nanosecondAdjustment: Int = 0, offset: UtcOffset): DateTime {
-            return fromSecondsSinceUnixEpoch(second.seconds, nanosecondAdjustment.nanoseconds, offset)
-        }
-
         /**
-         * Create the [DateTime] that falls a given number of seconds relative to the Unix epoch, plus some number of
-         * additional nanoseconds
+         * Create a [DateTime] from a duration of seconds relative to the Unix epoch at [offset], optionally, with some
+         * number of additional nanoseconds added to it.
          */
         fun fromSecondsSinceUnixEpoch(
-            seconds: LongSeconds,
+            secondsSinceUnixEpoch: LongSeconds,
             nanosecondAdjustment: IntNanoseconds = 0.nanoseconds,
             offset: UtcOffset
         ): DateTime {
-            val adjustedSeconds = seconds + (nanosecondAdjustment.value floorDiv NANOSECONDS_PER_SECOND).seconds
-            val nanosecondOfDay = nanosecondAdjustment.value floorMod NANOSECONDS_PER_SECOND
+            val adjustedSeconds =
+                secondsSinceUnixEpoch + (nanosecondAdjustment.value floorDiv NANOSECONDS_PER_SECOND).seconds
+            val nanosecond = nanosecondAdjustment.value floorMod NANOSECONDS_PER_SECOND
             val localSeconds = adjustedSeconds + offset.totalSeconds
-            val localEpochDays = (localSeconds.value floorDiv SECONDS_PER_DAY).days
+            val localEpochDay = (localSeconds.value floorDiv SECONDS_PER_DAY)
             val secondOfDay = (localSeconds.value floorMod SECONDS_PER_DAY).toInt()
-            val date = Date.fromDaysSinceUnixEpoch(localEpochDays)
-            val time = Time.fromSecondOfDay(secondOfDay, nanosecondOfDay)
+            val date = Date.fromDayOfUnixEpoch(localEpochDay)
+            val time = Time.fromSecondOfDay(secondOfDay, nanosecond)
             return DateTime(date, time)
+        }
+
+        /**
+         * Create a [DateTime] from the millisecond of the Unix epoch at [offset].
+         */
+        fun fromMillisecondOfUnixEpoch(millisecond: Long, offset: UtcOffset): DateTime {
+            return fromMillisecondsSinceUnixEpoch(millisecond.milliseconds, offset)
+        }
+
+        /**
+         * Create a [DateTime] from the second of the Unix epoch at [offset] and optionally, the nanosecond of the
+         * second.
+         */
+        fun fromSecondOfUnixEpoch(second: Long, nanosecond: Int = 0, offset: UtcOffset): DateTime {
+            return fromSecondsSinceUnixEpoch(second.seconds, nanosecond.nanoseconds, offset)
+        }
+
+        @Deprecated(
+            "Use fromMillisecondOfUnixEpoch() instead.",
+            ReplaceWith("DateTime.fromMillisecondOfUnixEpoch(millisecond, offset)"),
+            DeprecationLevel.WARNING
+        )
+        fun fromUnixEpochMillisecond(millisecond: Long, offset: UtcOffset): DateTime {
+            return fromMillisecondOfUnixEpoch(millisecond, offset)
+        }
+
+        @Deprecated(
+            "Use fromSecondOfUnixEpoch() instead.",
+            ReplaceWith("DateTime.fromSecondOfUnixEpoch(second, nanosecondAdjustment, offset)"),
+            DeprecationLevel.WARNING
+        )
+        fun fromUnixEpochSecond(second: Long, nanosecondAdjustment: Int = 0, offset: UtcOffset): DateTime {
+            return fromSecondOfUnixEpoch(second, nanosecondAdjustment, offset)
         }
     }
 }
@@ -630,10 +679,10 @@ fun Date.atTime(hour: Int, minute: Int, second: Int = 0, nanosecond: Int = 0): D
 }
 
 /**
- * Convert an instant into a [DateTime] at a particular offset from UTC.
+ * Convert to a [DateTime] at a particular offset from UTC.
  */
 fun Instant.toDateTimeAt(offset: UtcOffset): DateTime {
-    return DateTime.fromUnixEpochSecond(unixEpochSecond, unixEpochNanoOfSecond, offset)
+    return DateTime.fromSecondOfUnixEpoch(secondOfUnixEpoch, nanosecond, offset)
 }
 
 /**

--- a/core/src/commonMain/kotlin/io/islandtime/base/TimePoint.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/base/TimePoint.kt
@@ -10,41 +10,69 @@ import io.islandtime.measures.*
  */
 interface TimePoint<T> {
     /**
-     * The number of seconds since the Unix epoch of 1970-01-01T00:00Z
+     * The number of seconds since the Unix epoch of 1970-01-01T00:00Z.
      */
     val secondsSinceUnixEpoch: LongSeconds
 
-    /**
-     * The number of additional nanoseconds on top of [secondsSinceUnixEpoch]
-     */
-    val nanoOfSecondsSinceUnixEpoch: IntNanoseconds
+    @Deprecated(
+        "Use additionalNanosecondsSinceUnixEpoch instead.",
+        ReplaceWith("this.additionalNanosecondsSinceUnixEpoch"),
+        DeprecationLevel.WARNING
+    )
+    val nanoOfSecondsSinceUnixEpoch: IntNanoseconds get() = additionalNanosecondsSinceUnixEpoch
 
     /**
-     * The number of milliseconds since the Unix epoch of 1970-01-01T00:00Z
+     * The number of additional nanoseconds on top of [secondsSinceUnixEpoch].
+     */
+    val additionalNanosecondsSinceUnixEpoch: IntNanoseconds
+
+    /**
+     * The number of milliseconds since the Unix epoch of 1970-01-01T00:00Z.
      */
     val millisecondsSinceUnixEpoch: LongMilliseconds
 
-    /**
-     * The second of the Unix epoch
-     */
-    val unixEpochSecond: Long get() = secondsSinceUnixEpoch.value
+    @Deprecated(
+        "Use secondOfUnixEpoch instead.",
+        ReplaceWith("this.secondOfUnixEpoch"),
+        DeprecationLevel.WARNING
+    )
+    val unixEpochSecond: Long get() = secondOfUnixEpoch
 
     /**
-     * The nanosecond of the second of the Unix epoch
+     * The second of the Unix epoch.
      */
-    val unixEpochNanoOfSecond: Int get() = nanoOfSecondsSinceUnixEpoch.value
+    val secondOfUnixEpoch: Long get() = secondsSinceUnixEpoch.value
+
+    @Deprecated(
+        "Use nanosecond instead.",
+        ReplaceWith("this.nanosecond"),
+        DeprecationLevel.WARNING
+    )
+    val unixEpochNanoOfSecond: Int get() = nanosecond
 
     /**
-     * The millisecond of the Unix epoch
+     * The nanosecond of the second.
      */
-    val unixEpochMillisecond: Long get() = millisecondsSinceUnixEpoch.value
+    val nanosecond: Int get() = additionalNanosecondsSinceUnixEpoch.value
+
+    @Deprecated(
+        "Use millisecondOfUnixEpoch instead.",
+        ReplaceWith("this.millisecondOfUnixEpoch"),
+        DeprecationLevel.WARNING
+    )
+    val unixEpochMillisecond: Long get() = millisecondOfUnixEpoch
 
     /**
-     * Check if this time point represent the same instant as [other]. Unlike the equals operator, equality is
+     * The millisecond of the Unix epoch.
+     */
+    val millisecondOfUnixEpoch: Long get() = millisecondsSinceUnixEpoch.value
+
+    /**
+     * Check if this time point represents the same instant as [other]. Unlike the equals operator, equality is
      * determined solely by timeline order.
      */
     fun isSameInstantAs(other: TimePoint<*>): Boolean {
-        return unixEpochSecond == other.unixEpochSecond && unixEpochNanoOfSecond == other.unixEpochNanoOfSecond
+        return secondOfUnixEpoch == other.secondOfUnixEpoch && nanosecond == other.nanosecond
     }
 
     /**
@@ -52,15 +80,15 @@ interface TimePoint<T> {
      * [Comparable] interface since they don't necessarily have a natural order that's consistent with equals.
      */
     operator fun compareTo(other: TimePoint<*>): Int {
-        val second = unixEpochSecond
-        val otherSecond = other.unixEpochSecond
+        val second = secondOfUnixEpoch
+        val otherSecond = other.secondOfUnixEpoch
 
         val secondDiff = second.compareTo(otherSecond)
 
         return if (secondDiff != 0) {
             secondDiff
         } else {
-            unixEpochNanoOfSecond - other.unixEpochNanoOfSecond
+            nanosecond - other.nanosecond
         }
     }
 
@@ -94,6 +122,6 @@ interface TimePoint<T> {
         /**
          * Compare by timeline order.
          */
-        val TIMELINE_ORDER = compareBy<TimePoint<*>> { it.unixEpochSecond }.thenBy { it.unixEpochNanoOfSecond }
+        val TIMELINE_ORDER = compareBy<TimePoint<*>> { it.secondOfUnixEpoch }.thenBy { it.nanosecond }
     }
 }

--- a/core/src/commonMain/kotlin/io/islandtime/clock/Now.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/clock/Now.kt
@@ -51,7 +51,7 @@ fun Date.Companion.now(clock: Clock): Date {
     val offset = clock.zone.rules.offsetAt(milliseconds)
     val unixEpochSecond = (milliseconds.value floorDiv MILLISECONDS_PER_SECOND) + offset.totalSeconds.value
     val unixEpochDay = unixEpochSecond floorDiv SECONDS_PER_DAY
-    return fromUnixEpochDay(unixEpochDay)
+    return fromDayOfUnixEpoch(unixEpochDay)
 }
 
 /**

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/DateRange.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/DateRange.kt
@@ -133,7 +133,7 @@ class DateRange(
         /**
          * A range containing zero days.
          */
-        val EMPTY = DateRange(Date.fromUnixEpochDay(1L), Date.fromUnixEpochDay(0L))
+        val EMPTY = DateRange(Date.fromDayOfUnixEpoch(1L), Date.fromDayOfUnixEpoch(0L))
 
         /**
          * An unbounded (ie. infinite) range of dates.
@@ -218,7 +218,7 @@ fun DateRange.random(random: Random): Date {
     if (!isBounded()) throwUnboundedIntervalException()
 
     try {
-        return Date.fromUnixEpochDay(random.nextLong(start.unixEpochDay, endInclusive.unixEpochDay + 1))
+        return Date.fromDayOfUnixEpoch(random.nextLong(start.unixEpochDay, endInclusive.unixEpochDay + 1))
     } catch (e: IllegalArgumentException) {
         throw NoSuchElementException(e.message)
     }
@@ -233,7 +233,7 @@ fun DateRange.randomOrNull(random: Random): Date? {
     return if (isEmpty() || !isBounded()) {
         null
     } else {
-        Date.fromUnixEpochDay(random.nextLong(start.unixEpochDay, endInclusive.unixEpochDay + 1))
+        Date.fromDayOfUnixEpoch(random.nextLong(start.unixEpochDay, endInclusive.unixEpochDay + 1))
     }
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/DateTimeInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/DateTimeInterval.kt
@@ -196,8 +196,8 @@ class DateTimeInterval(
          * An empty interval.
          */
         val EMPTY = DateTimeInterval(
-            DateTime.fromUnixEpochSecond(0L, 0, UtcOffset.ZERO),
-            DateTime.fromUnixEpochSecond(0L, 0, UtcOffset.ZERO)
+            DateTime.fromSecondOfUnixEpoch(0L, 0, UtcOffset.ZERO),
+            DateTime.fromSecondOfUnixEpoch(0L, 0, UtcOffset.ZERO)
         )
 
         /**
@@ -294,9 +294,9 @@ fun DateTimeInterval.randomOrNull(): DateTime? = randomOrNull(Random)
 fun DateTimeInterval.random(random: Random): DateTime {
     return random(
         random,
-        secondGetter = { it.unixEpochSecondAt(UtcOffset.ZERO) },
-        nanosecondGetter = { it.unixEpochNanoOfSecond },
-        creator = { second, nanosecond -> DateTime.fromUnixEpochSecond(second, nanosecond, UtcOffset.ZERO) }
+        secondGetter = { it.secondOfUnixEpochAt(UtcOffset.ZERO) },
+        nanosecondGetter = { it.nanosecond },
+        creator = { second, nanosecond -> DateTime.fromSecondOfUnixEpoch(second, nanosecond, UtcOffset.ZERO) }
     )
 }
 
@@ -308,9 +308,9 @@ fun DateTimeInterval.random(random: Random): DateTime {
 fun DateTimeInterval.randomOrNull(random: Random): DateTime? {
     return randomOrNull(
         random,
-        secondGetter = { it.unixEpochSecondAt(UtcOffset.ZERO) },
-        nanosecondGetter = { it.unixEpochNanoOfSecond },
-        creator = { second, nanosecond -> DateTime.fromUnixEpochSecond(second, nanosecond, UtcOffset.ZERO) }
+        secondGetter = { it.secondOfUnixEpochAt(UtcOffset.ZERO) },
+        nanosecondGetter = { it.nanosecond },
+        creator = { second, nanosecond -> DateTime.fromSecondOfUnixEpoch(second, nanosecond, UtcOffset.ZERO) }
     )
 }
 
@@ -360,10 +360,12 @@ fun daysBetween(start: DateTime, endExclusive: DateTime): LongDays {
  * when working with [DateTime] directly.
  */
 fun durationBetween(start: DateTime, endExclusive: DateTime): Duration {
-    val secondDiff = endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO) -
-        start.secondsSinceUnixEpochAt(UtcOffset.ZERO)
+    val secondDiff =
+        endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO) - start.secondsSinceUnixEpochAt(UtcOffset.ZERO)
 
-    val nanoDiff = endExclusive.nanoOfSecondsSinceUnixEpoch minusWithOverflow start.nanoOfSecondsSinceUnixEpoch
+    val nanoDiff =
+        endExclusive.additionalNanosecondsSinceUnixEpoch minusWithOverflow start.additionalNanosecondsSinceUnixEpoch
+
     return durationOf(secondDiff, nanoDiff)
 }
 
@@ -395,9 +397,9 @@ fun minutesBetween(start: DateTime, endExclusive: DateTime): LongMinutes {
 fun secondsBetween(start: DateTime, endExclusive: DateTime): LongSeconds {
     return secondsBetween(
         start.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        start.nanoOfSecondsSinceUnixEpoch,
+        start.additionalNanosecondsSinceUnixEpoch,
         endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        endExclusive.nanoOfSecondsSinceUnixEpoch
+        endExclusive.additionalNanosecondsSinceUnixEpoch
     )
 }
 
@@ -411,9 +413,9 @@ fun secondsBetween(start: DateTime, endExclusive: DateTime): LongSeconds {
 fun millisecondsBetween(start: DateTime, endExclusive: DateTime): LongMilliseconds {
     return millisecondsBetween(
         start.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        start.nanoOfSecondsSinceUnixEpoch,
+        start.additionalNanosecondsSinceUnixEpoch,
         endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        endExclusive.nanoOfSecondsSinceUnixEpoch
+        endExclusive.additionalNanosecondsSinceUnixEpoch
     )
 }
 
@@ -427,9 +429,9 @@ fun millisecondsBetween(start: DateTime, endExclusive: DateTime): LongMillisecon
 fun microsecondsBetween(start: DateTime, endExclusive: DateTime): LongMicroseconds {
     return microsecondsBetween(
         start.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        start.nanoOfSecondsSinceUnixEpoch,
+        start.additionalNanosecondsSinceUnixEpoch,
         endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        endExclusive.nanoOfSecondsSinceUnixEpoch
+        endExclusive.additionalNanosecondsSinceUnixEpoch
     )
 }
 
@@ -443,9 +445,9 @@ fun microsecondsBetween(start: DateTime, endExclusive: DateTime): LongMicrosecon
 fun nanosecondsBetween(start: DateTime, endExclusive: DateTime): LongNanoseconds {
     return nanosecondsBetween(
         start.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        start.nanoOfSecondsSinceUnixEpoch,
+        start.additionalNanosecondsSinceUnixEpoch,
         endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        endExclusive.nanoOfSecondsSinceUnixEpoch
+        endExclusive.additionalNanosecondsSinceUnixEpoch
     )
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/InstantInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/InstantInterval.kt
@@ -133,7 +133,7 @@ fun InstantInterval.randomOrNull(): Instant? = randomOrNull(Random)
  * @see InstantInterval.randomOrNull
  */
 fun InstantInterval.random(random: Random): Instant {
-    return random(random, Instant.Companion::fromUnixEpochSecond)
+    return random(random, Instant.Companion::fromSecondOfUnixEpoch)
 }
 
 /**
@@ -142,7 +142,7 @@ fun InstantInterval.random(random: Random): Instant {
  * @see InstantInterval.random
  */
 fun InstantInterval.randomOrNull(random: Random): Instant? {
-    return randomOrNull(random, Instant.Companion::fromUnixEpochSecond)
+    return randomOrNull(random, Instant.Companion::fromSecondOfUnixEpoch)
 }
 
 /**

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/OffsetDateTimeInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/OffsetDateTimeInterval.kt
@@ -184,7 +184,7 @@ fun OffsetDateTimeInterval.randomOrNull(): OffsetDateTime? = randomOrNull(Random
  */
 fun OffsetDateTimeInterval.random(random: Random): OffsetDateTime {
     return random(random) { second, nanosecond ->
-        OffsetDateTime.fromUnixEpochSecond(second, nanosecond, start.offset)
+        OffsetDateTime.fromSecondOfUnixEpoch(second, nanosecond, start.offset)
     }
 }
 
@@ -195,7 +195,7 @@ fun OffsetDateTimeInterval.random(random: Random): OffsetDateTime {
  */
 fun OffsetDateTimeInterval.randomOrNull(random: Random): OffsetDateTime? {
     return randomOrNull(random) { second, nanosecond ->
-        OffsetDateTime.fromUnixEpochSecond(second, nanosecond, start.offset)
+        OffsetDateTime.fromSecondOfUnixEpoch(second, nanosecond, start.offset)
     }
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/TimePointInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/TimePointInterval.kt
@@ -140,7 +140,7 @@ abstract class TimePointInterval<T : TimePoint<T>> internal constructor(
 fun <T1, T2> durationBetween(start: TimePoint<T1>, endExclusive: TimePoint<T2>): Duration {
     val secondDiff = endExclusive.secondsSinceUnixEpoch - start.secondsSinceUnixEpoch
     val nanoDiff =
-        endExclusive.nanoOfSecondsSinceUnixEpoch minusWithOverflow start.nanoOfSecondsSinceUnixEpoch
+        endExclusive.additionalNanosecondsSinceUnixEpoch minusWithOverflow start.additionalNanosecondsSinceUnixEpoch
     return durationOf(secondDiff, nanoDiff)
 }
 
@@ -172,9 +172,9 @@ fun <T1, T2> minutesBetween(start: TimePoint<T1>, endExclusive: TimePoint<T2>): 
 fun <T1, T2> secondsBetween(start: TimePoint<T1>, endExclusive: TimePoint<T2>): LongSeconds {
     return secondsBetween(
         start.secondsSinceUnixEpoch,
-        start.nanoOfSecondsSinceUnixEpoch,
+        start.additionalNanosecondsSinceUnixEpoch,
         endExclusive.secondsSinceUnixEpoch,
-        endExclusive.nanoOfSecondsSinceUnixEpoch
+        endExclusive.additionalNanosecondsSinceUnixEpoch
     )
 }
 
@@ -188,9 +188,9 @@ fun <T1, T2> millisecondsBetween(
 ): LongMilliseconds {
     return millisecondsBetween(
         start.secondsSinceUnixEpoch,
-        start.nanoOfSecondsSinceUnixEpoch,
+        start.additionalNanosecondsSinceUnixEpoch,
         endExclusive.secondsSinceUnixEpoch,
-        endExclusive.nanoOfSecondsSinceUnixEpoch
+        endExclusive.additionalNanosecondsSinceUnixEpoch
     )
 }
 
@@ -204,9 +204,9 @@ fun <T1, T2> microsecondsBetween(
 ): LongMicroseconds {
     return microsecondsBetween(
         start.secondsSinceUnixEpoch,
-        start.nanoOfSecondsSinceUnixEpoch,
+        start.additionalNanosecondsSinceUnixEpoch,
         endExclusive.secondsSinceUnixEpoch,
-        endExclusive.nanoOfSecondsSinceUnixEpoch
+        endExclusive.additionalNanosecondsSinceUnixEpoch
     )
 }
 
@@ -220,8 +220,8 @@ fun <T1, T2> nanosecondsBetween(
 ): LongNanoseconds {
     return nanosecondsBetween(
         start.secondsSinceUnixEpoch,
-        start.nanoOfSecondsSinceUnixEpoch,
+        start.additionalNanosecondsSinceUnixEpoch,
         endExclusive.secondsSinceUnixEpoch,
-        endExclusive.nanoOfSecondsSinceUnixEpoch
+        endExclusive.additionalNanosecondsSinceUnixEpoch
     )
 }

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/ZonedDateTimeInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/ZonedDateTimeInterval.kt
@@ -197,7 +197,7 @@ fun ZonedDateTimeInterval.randomOrNull(): ZonedDateTime? = randomOrNull(Random)
  */
 fun ZonedDateTimeInterval.random(random: Random): ZonedDateTime {
     return random(random) { second, nanosecond ->
-        ZonedDateTime.fromUnixEpochSecond(second, nanosecond, start.zone)
+        ZonedDateTime.fromSecondOfUnixEpoch(second, nanosecond, start.zone)
     }
 }
 
@@ -208,7 +208,7 @@ fun ZonedDateTimeInterval.random(random: Random): ZonedDateTime {
  */
 fun ZonedDateTimeInterval.randomOrNull(random: Random): ZonedDateTime? {
     return randomOrNull(random) { second, nanosecond ->
-        ZonedDateTime.fromUnixEpochSecond(second, nanosecond, start.zone)
+        ZonedDateTime.fromSecondOfUnixEpoch(second, nanosecond, start.zone)
     }
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/internal/Common.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/internal/Common.kt
@@ -130,14 +130,14 @@ internal inline fun <T : TimePoint<T>> TimePointInterval<T>.random(
     random: Random,
     creator: (second: Long, nanosecond: Int) -> T
 ): T {
-    return random(random, { it.unixEpochSecond }, { it.unixEpochNanoOfSecond }, creator)
+    return random(random, { it.secondOfUnixEpoch }, { it.nanosecond }, creator)
 }
 
 internal inline fun <T : TimePoint<T>> TimePointInterval<T>.randomOrNull(
     random: Random,
     creator: (second: Long, nanosecond: Int) -> T
 ): T? {
-    return randomOrNull(random, { it.unixEpochSecond }, { it.unixEpochNanoOfSecond }, creator)
+    return randomOrNull(random, { it.secondOfUnixEpoch }, { it.nanosecond }, creator)
 }
 
 private inline fun <T> TimeInterval<T>.generateRandom(

--- a/core/src/commonTest/kotlin/io/islandtime/DateTimeTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/DateTimeTest.kt
@@ -24,10 +24,10 @@ class DateTimeTest : AbstractIslandTimeTest() {
     }
 
     @Test
-    fun `can be constructed from unix epoch millisecond`() {
+    fun `can be constructed from millisecond of unix epoch`() {
         assertEquals(
             Date(1970, Month.JANUARY, 1) at Time(1, 0),
-            DateTime.fromUnixEpochMillisecond(0L, 1.hours.asUtcOffset())
+            DateTime.fromMillisecondOfUnixEpoch(0L, 1.hours.asUtcOffset())
         )
 
         assertEquals(
@@ -38,7 +38,7 @@ class DateTimeTest : AbstractIslandTimeTest() {
         assertEquals(
             Date(1970, Month.JANUARY, 1) at
                 Time(1, 0, 0, 1_000_000),
-            DateTime.fromUnixEpochMillisecond(1L, 1.hours.asUtcOffset())
+            DateTime.fromMillisecondOfUnixEpoch(1L, 1.hours.asUtcOffset())
         )
 
         assertEquals(
@@ -50,7 +50,7 @@ class DateTimeTest : AbstractIslandTimeTest() {
         assertEquals(
             Date(1970, Month.JANUARY, 1) at
                 Time(0, 59, 59, 999_000_000),
-            DateTime.fromUnixEpochMillisecond(-1L, 1.hours.asUtcOffset())
+            DateTime.fromMillisecondOfUnixEpoch(-1L, 1.hours.asUtcOffset())
         )
 
         assertEquals(
@@ -61,10 +61,10 @@ class DateTimeTest : AbstractIslandTimeTest() {
     }
 
     @Test
-    fun `can be constructed from unix epoch second`() {
+    fun `can be constructed from second of unix epoch`() {
         assertEquals(
             Date(1970, Month.JANUARY, 1) at Time(1, 0),
-            DateTime.fromUnixEpochSecond(0L, 0, 1.hours.asUtcOffset())
+            DateTime.fromSecondOfUnixEpoch(0L, 0, 1.hours.asUtcOffset())
         )
 
         assertEquals(
@@ -75,7 +75,7 @@ class DateTimeTest : AbstractIslandTimeTest() {
         assertEquals(
             Date(1970, Month.JANUARY, 1) at
                 Time(1, 0, 0, 1),
-            DateTime.fromUnixEpochSecond(0L, 1, 1.hours.asUtcOffset())
+            DateTime.fromSecondOfUnixEpoch(0L, 1, 1.hours.asUtcOffset())
         )
 
         assertEquals(
@@ -87,7 +87,7 @@ class DateTimeTest : AbstractIslandTimeTest() {
         assertEquals(
             Date(1970, Month.JANUARY, 1) at
                 Time(0, 59, 59, 999_999_999),
-            DateTime.fromUnixEpochSecond(0L, -1, 1.hours.asUtcOffset())
+            DateTime.fromSecondOfUnixEpoch(0L, -1, 1.hours.asUtcOffset())
         )
 
         assertEquals(
@@ -205,25 +205,25 @@ class DateTimeTest : AbstractIslandTimeTest() {
         assertEquals(
             1L,
             (Date(1970, Month.JANUARY, 1) at Time(1, 0, 0, 1_999_999))
-                .unixEpochMillisecondAt(1.hours.asUtcOffset())
+                .millisecondOfUnixEpochAt(1.hours.asUtcOffset())
         )
 
         assertEquals(
             1L,
             (Date(1970, Month.JANUARY, 1) at Time(1, 0, 0, 1_000_000))
-                .unixEpochMillisecondAt(1.hours.asUtcOffset())
+                .millisecondOfUnixEpochAt(1.hours.asUtcOffset())
         )
 
         assertEquals(
             0L,
             (Date(1970, Month.JANUARY, 1) at Time(1, 0, 0, 999_999))
-                .unixEpochMillisecondAt(1.hours.asUtcOffset())
+                .millisecondOfUnixEpochAt(1.hours.asUtcOffset())
         )
 
         assertEquals(
             0L,
             (Date(1970, Month.JANUARY, 1) at Time(1, 0))
-                .unixEpochMillisecondAt(1.hours.asUtcOffset())
+                .millisecondOfUnixEpochAt(1.hours.asUtcOffset())
         )
 
         assertEquals(

--- a/core/src/commonTest/kotlin/io/islandtime/InstantTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/InstantTest.kt
@@ -15,44 +15,44 @@ class InstantTest : AbstractIslandTimeTest() {
             -31557014167219201L,
             31556889864403200L
         ).forEach {
-            assertFailsWith<DateTimeException> { Instant.fromUnixEpochSecond(it) }
-            assertFailsWith<DateTimeException> { Instant.fromUnixEpochSecond(it, 0) }
-            assertFailsWith<DateTimeException> { Instant.fromUnixEpochSecond(it, 0L) }
+            assertFailsWith<DateTimeException> { Instant.fromSecondOfUnixEpoch(it) }
+            assertFailsWith<DateTimeException> { Instant.fromSecondOfUnixEpoch(it, 0) }
+            assertFailsWith<DateTimeException> { Instant.fromSecondOfUnixEpoch(it, 0L) }
             assertFailsWith<DateTimeException> { Instant(it.seconds) }
             assertFailsWith<DateTimeException> { Instant(it.seconds, 0.nanoseconds) }
             assertFailsWith<DateTimeException> { Instant(it.seconds, 0L.nanoseconds) }
         }
 
         assertFailsWith<DateTimeException> {
-            Instant.fromUnixEpochSecond(-31557014167219200L, -1)
+            Instant.fromSecondOfUnixEpoch(-31557014167219200L, -1)
         }
 
         assertFailsWith<DateTimeException> {
-            Instant.fromUnixEpochSecond(-31557014167219200L, -1L)
+            Instant.fromSecondOfUnixEpoch(-31557014167219200L, -1L)
         }
 
         assertFailsWith<DateTimeException> {
-            Instant.fromUnixEpochSecond(31556889864403199L, 1_000_000_000)
+            Instant.fromSecondOfUnixEpoch(31556889864403199L, 1_000_000_000)
         }
 
         assertFailsWith<DateTimeException> {
-            Instant.fromUnixEpochSecond(31556889864403199L, 1_000_000_000L)
+            Instant.fromSecondOfUnixEpoch(31556889864403199L, 1_000_000_000L)
         }
     }
 
     @Test
     fun `millisecond properties return expected values`() {
-        assertEquals(0L, Instant.UNIX_EPOCH.unixEpochMillisecond)
+        assertEquals(0L, Instant.UNIX_EPOCH.millisecondOfUnixEpoch)
         assertEquals(0L.milliseconds, Instant.UNIX_EPOCH.millisecondsSinceUnixEpoch)
 
-        val instant = Instant.fromUnixEpochMillisecond(1566256047821L)
-        assertEquals(1566256047821L, instant.unixEpochMillisecond)
+        val instant = Instant.fromMillisecondOfUnixEpoch(1566256047821L)
+        assertEquals(1566256047821L, instant.millisecondOfUnixEpoch)
         assertEquals(1566256047821L.milliseconds, instant.millisecondsSinceUnixEpoch)
     }
 
     @Test
     fun `instants can be compared to each other`() {
-        assertTrue { Instant.UNIX_EPOCH < Instant.fromUnixEpochMillisecond(1566256047821L) }
+        assertTrue { Instant.UNIX_EPOCH < Instant.fromMillisecondOfUnixEpoch(1566256047821L) }
     }
 
     @Test
@@ -210,17 +210,17 @@ class InstantTest : AbstractIslandTimeTest() {
 
         assertEquals(
             "1970-01-01T00:00:00.000001Z",
-            Instant.fromUnixEpochSecond(0L, 1_000).toString()
+            Instant.fromSecondOfUnixEpoch(0L, 1_000).toString()
         )
 
         assertEquals(
             "1969-12-31T23:59:59.999999999Z",
-            Instant.fromUnixEpochSecond(0L, -1).toString()
+            Instant.fromSecondOfUnixEpoch(0L, -1).toString()
         )
 
         assertEquals(
             "2019-08-19T23:07:27.821Z",
-            Instant.fromUnixEpochMillisecond(1566256047821L).toString()
+            Instant.fromMillisecondOfUnixEpoch(1566256047821L).toString()
         )
 
         assertEquals(
@@ -268,12 +268,12 @@ class InstantTest : AbstractIslandTimeTest() {
     @Test
     fun `String_toInstant() parses ISO-8601 calendar date time strings in extended format by default`() {
         assertEquals(
-            Instant.fromUnixEpochMillisecond(0L),
+            Instant.fromMillisecondOfUnixEpoch(0L),
             "1970-01-01T00:00Z".toInstant()
         )
 
         assertEquals(
-            Instant.fromUnixEpochMillisecond(1566256047821L),
+            Instant.fromMillisecondOfUnixEpoch(1566256047821L),
             "2019-08-19T23:07:27.821Z".toInstant()
         )
 
@@ -291,12 +291,12 @@ class InstantTest : AbstractIslandTimeTest() {
     @Test
     fun `String_toInstant() parses ISO-8601 calendar date time strings in basic format with explicit parser`() {
         assertEquals(
-            Instant.fromUnixEpochMillisecond(0L),
+            Instant.fromMillisecondOfUnixEpoch(0L),
             "19700101 0000Z".toInstant(DateTimeParsers.Iso.INSTANT)
         )
 
         assertEquals(
-            Instant.fromUnixEpochMillisecond(1566256047821L),
+            Instant.fromMillisecondOfUnixEpoch(1566256047821L),
             "20190819T230727.821Z".toInstant(DateTimeParsers.Iso.INSTANT)
         )
     }

--- a/core/src/commonTest/kotlin/io/islandtime/OffsetDateTimeTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/OffsetDateTimeTest.kt
@@ -1,9 +1,6 @@
 package io.islandtime
 
-import io.islandtime.measures.days
-import io.islandtime.measures.hours
-import io.islandtime.measures.minutes
-import io.islandtime.measures.seconds
+import io.islandtime.measures.*
 import io.islandtime.parser.DateTimeParseException
 import io.islandtime.parser.DateTimeParsers
 import io.islandtime.test.AbstractIslandTimeTest
@@ -34,6 +31,78 @@ class OffsetDateTimeTest : AbstractIslandTimeTest() {
             assertEquals(2, minute)
             assertEquals(3, second)
             assertEquals(4, nanosecond)
+            assertEquals(UtcOffset.ZERO, offset)
+        }
+    }
+
+    @Test
+    fun `can be constructed from seconds since unix epoch`() {
+        OffsetDateTime.fromSecondsSinceUnixEpoch((-1L).seconds, offset = UtcOffset.ZERO).run {
+            assertEquals(1969, year)
+            assertEquals(365, dayOfYear)
+            assertEquals(23, hour)
+            assertEquals(59, minute)
+            assertEquals(59, second)
+            assertEquals(0, nanosecond)
+            assertEquals(UtcOffset.ZERO, offset)
+        }
+
+        OffsetDateTime.fromSecondsSinceUnixEpoch((-1L).seconds, 1.nanoseconds, UtcOffset.ZERO).run {
+            assertEquals(1969, year)
+            assertEquals(365, dayOfYear)
+            assertEquals(23, hour)
+            assertEquals(59, minute)
+            assertEquals(59, second)
+            assertEquals(1, nanosecond)
+            assertEquals(UtcOffset.ZERO, offset)
+        }
+    }
+
+    @Test
+    fun `can be constructed from milliseconds since unix epoch`() {
+        OffsetDateTime.fromMillisecondsSinceUnixEpoch(1L.milliseconds, (-1).hours.asUtcOffset()).run {
+            assertEquals(1969, year)
+            assertEquals(365, dayOfYear)
+            assertEquals(23, hour)
+            assertEquals(0, minute)
+            assertEquals(0, second)
+            assertEquals(1_000_000, nanosecond)
+            assertEquals((-1).hours.asUtcOffset(), offset)
+        }
+    }
+
+    @Test
+    fun `can be constructed from second of unix epoch`() {
+        OffsetDateTime.fromSecondOfUnixEpoch(-1L, offset = UtcOffset.ZERO).run {
+            assertEquals(1969, year)
+            assertEquals(365, dayOfYear)
+            assertEquals(23, hour)
+            assertEquals(59, minute)
+            assertEquals(59, second)
+            assertEquals(0, nanosecond)
+            assertEquals(UtcOffset.ZERO, offset)
+        }
+
+        OffsetDateTime.fromSecondOfUnixEpoch(0L, 1, UtcOffset.ZERO).run {
+            assertEquals(1970, year)
+            assertEquals(1, dayOfYear)
+            assertEquals(0, hour)
+            assertEquals(0, minute)
+            assertEquals(0, second)
+            assertEquals(1, nanosecond)
+            assertEquals(UtcOffset.ZERO, offset)
+        }
+    }
+
+    @Test
+    fun `can be constructed from millisecond of unix epoch`() {
+        OffsetDateTime.fromMillisecondOfUnixEpoch(1L, UtcOffset.ZERO).run {
+            assertEquals(1970, year)
+            assertEquals(1, dayOfYear)
+            assertEquals(0, hour)
+            assertEquals(0, minute)
+            assertEquals(0, second)
+            assertEquals(1_000_000, nanosecond)
             assertEquals(UtcOffset.ZERO, offset)
         }
     }

--- a/core/src/commonTest/kotlin/io/islandtime/ZonedDateTimeTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/ZonedDateTimeTest.kt
@@ -4,7 +4,7 @@ import io.islandtime.measures.*
 import io.islandtime.parser.DateTimeParseException
 import io.islandtime.parser.DateTimeParsers
 import io.islandtime.test.AbstractIslandTimeTest
-import io.islandtime.zone.*
+import io.islandtime.zone.TimeZoneRulesException
 import kotlin.test.*
 
 class ZonedDateTimeTest : AbstractIslandTimeTest() {
@@ -95,6 +95,78 @@ class ZonedDateTimeTest : AbstractIslandTimeTest() {
             assertEquals(4, nanosecond)
             assertEquals((-5).hours.asUtcOffset(), offset)
             assertEquals(nyZone, zone)
+        }
+    }
+
+    @Test
+    fun `can be constructed from seconds since unix epoch`() {
+        ZonedDateTime.fromSecondsSinceUnixEpoch((-1L).seconds, zone = TimeZone.UTC).run {
+            assertEquals(1969, year)
+            assertEquals(365, dayOfYear)
+            assertEquals(23, hour)
+            assertEquals(59, minute)
+            assertEquals(59, second)
+            assertEquals(0, nanosecond)
+            assertEquals(UtcOffset.ZERO, offset)
+        }
+
+        ZonedDateTime.fromSecondsSinceUnixEpoch((-1L).seconds, 1.nanoseconds, TimeZone.UTC).run {
+            assertEquals(1969, year)
+            assertEquals(365, dayOfYear)
+            assertEquals(23, hour)
+            assertEquals(59, minute)
+            assertEquals(59, second)
+            assertEquals(1, nanosecond)
+            assertEquals(UtcOffset.ZERO, offset)
+        }
+    }
+
+    @Test
+    fun `can be constructed from milliseconds since unix epoch`() {
+        ZonedDateTime.fromMillisecondsSinceUnixEpoch(1L.milliseconds, (-1).hours.asUtcOffset().asTimeZone()).run {
+            assertEquals(1969, year)
+            assertEquals(365, dayOfYear)
+            assertEquals(23, hour)
+            assertEquals(0, minute)
+            assertEquals(0, second)
+            assertEquals(1_000_000, nanosecond)
+            assertEquals((-1).hours.asUtcOffset(), offset)
+        }
+    }
+
+    @Test
+    fun `can be constructed from second of unix epoch`() {
+        ZonedDateTime.fromSecondOfUnixEpoch(-1L, zone = TimeZone.UTC).run {
+            assertEquals(1969, year)
+            assertEquals(365, dayOfYear)
+            assertEquals(23, hour)
+            assertEquals(59, minute)
+            assertEquals(59, second)
+            assertEquals(0, nanosecond)
+            assertEquals(UtcOffset.ZERO, offset)
+        }
+
+        ZonedDateTime.fromSecondOfUnixEpoch(0L, 1, TimeZone.UTC).run {
+            assertEquals(1970, year)
+            assertEquals(1, dayOfYear)
+            assertEquals(0, hour)
+            assertEquals(0, minute)
+            assertEquals(0, second)
+            assertEquals(1, nanosecond)
+            assertEquals(UtcOffset.ZERO, offset)
+        }
+    }
+
+    @Test
+    fun `can be constructed from millisecond of unix epoch`() {
+        ZonedDateTime.fromMillisecondOfUnixEpoch(1L, TimeZone.UTC).run {
+            assertEquals(1970, year)
+            assertEquals(1, dayOfYear)
+            assertEquals(0, hour)
+            assertEquals(0, minute)
+            assertEquals(0, second)
+            assertEquals(1_000_000, nanosecond)
+            assertEquals(UtcOffset.ZERO, offset)
         }
     }
 

--- a/core/src/commonTest/kotlin/io/islandtime/ranges/InstantIntervalTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/ranges/InstantIntervalTest.kt
@@ -47,7 +47,7 @@ class InstantIntervalTest : AbstractIslandTimeTest() {
         assertTrue { start in start..end }
         assertTrue { end in start..end }
         assertTrue { Instant.UNIX_EPOCH in start..end }
-        assertTrue { OffsetDateTime.fromUnixEpochSecond(0L, 0, UtcOffset.ZERO) in start..end }
+        assertTrue { OffsetDateTime.fromSecondOfUnixEpoch(0L, 0, UtcOffset.ZERO) in start..end }
     }
 
     @Test
@@ -58,7 +58,7 @@ class InstantIntervalTest : AbstractIslandTimeTest() {
         assertTrue { start in start..end }
         assertTrue { end in start..end }
         assertTrue { Instant.UNIX_EPOCH in start..end }
-        assertTrue { OffsetDateTime.fromUnixEpochSecond(0L, 0, UtcOffset.ZERO) in start..end }
+        assertTrue { OffsetDateTime.fromSecondOfUnixEpoch(0L, 0, UtcOffset.ZERO) in start..end }
     }
 
     @Test

--- a/core/src/darwinMain/kotlin/io/islandtime/darwin/Conversions.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/darwin/Conversions.kt
@@ -172,7 +172,7 @@ fun NSDateComponents.toIslandZonedDateTimeOrNull(): ZonedDateTime? {
  */
 fun <T> TimePoint<T>.toNSDate(): NSDate {
     return NSDate.dateWithTimeIntervalSince1970(
-        unixEpochSecond.toDouble() + unixEpochNanoOfSecond.toDouble() / NANOSECONDS_PER_SECOND
+        secondOfUnixEpoch.toDouble() + nanosecond.toDouble() / NANOSECONDS_PER_SECOND
     )
 }
 

--- a/core/src/jvmMain/kotlin/io/islandtime/jvm/Conversions.kt
+++ b/core/src/jvmMain/kotlin/io/islandtime/jvm/Conversions.kt
@@ -11,14 +11,14 @@ import io.islandtime.measures.*
  * Convert to an equivalent Island Time [Instant].
  */
 fun java.time.Instant.toIslandInstant(): Instant {
-    return Instant.fromUnixEpochSecond(epochSecond, nano)
+    return Instant.fromSecondOfUnixEpoch(epochSecond, nano)
 }
 
 /**
  * Convert to an equivalent Java `Instant`.
  */
 fun Instant.toJavaInstant(): java.time.Instant {
-    return java.time.Instant.ofEpochSecond(unixEpochSecond, unixEpochNanoOfSecond.toLong())
+    return java.time.Instant.ofEpochSecond(secondOfUnixEpoch, nanosecond.toLong())
 }
 
 /**

--- a/extensions/parcelize/src/main/kotlin/io/islandtime/extensions/parcelize/Instant.kt
+++ b/extensions/parcelize/src/main/kotlin/io/islandtime/extensions/parcelize/Instant.kt
@@ -1,7 +1,6 @@
 package io.islandtime.extensions.parcelize
 
 import android.os.Parcel
-import io.islandtime.Date
 import io.islandtime.Instant
 import kotlinx.android.parcel.Parceler
 
@@ -17,7 +16,7 @@ object NullableInstantParceler : Parceler<Instant?> {
     override fun create(parcel: Parcel): Instant? {
         return when (val second = parcel.readLong()) {
             Long.MIN_VALUE -> null
-            else -> Instant.fromUnixEpochSecond(second, parcel.readInt())
+            else -> Instant.fromSecondOfUnixEpoch(second, parcel.readInt())
         }
     }
 
@@ -31,10 +30,10 @@ object NullableInstantParceler : Parceler<Instant?> {
 }
 
 internal fun Parcel.readInstant(): Instant {
-    return Instant.fromUnixEpochSecond(readLong(), readInt())
+    return Instant.fromSecondOfUnixEpoch(readLong(), readInt())
 }
 
 internal fun Parcel.writeInstant(instant: Instant) {
-    writeLong(instant.unixEpochSecond)
-    writeInt(instant.unixEpochNanoOfSecond)
+    writeLong(instant.secondOfUnixEpoch)
+    writeInt(instant.nanosecond)
 }

--- a/extensions/threetenabp/src/main/kotlin/io/islandtime/extensions/threetenabp/Conversions.kt
+++ b/extensions/threetenabp/src/main/kotlin/io/islandtime/extensions/threetenabp/Conversions.kt
@@ -9,14 +9,14 @@ import io.islandtime.measures.*
  * Convert to an equivalent Island Time [Instant].
  */
 fun org.threeten.bp.Instant.toIslandInstant(): Instant {
-    return Instant.fromUnixEpochSecond(epochSecond, nano)
+    return Instant.fromSecondOfUnixEpoch(epochSecond, nano)
 }
 
 /**
  * Convert to an equivalent Java `Instant`.
  */
 fun Instant.toJavaInstant(): org.threeten.bp.Instant {
-    return org.threeten.bp.Instant.ofEpochSecond(unixEpochSecond, unixEpochNanoOfSecond.toLong())
+    return org.threeten.bp.Instant.ofEpochSecond(secondOfUnixEpoch, nanosecond.toLong())
 }
 
 /**


### PR DESCRIPTION
This makes the naming more consistent with the other properties/functions, such as `Time.fromSecondOfDay()` or `dayOfYear`.