### PR TITLE
Basic Kotlin/Js support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven("https://dl.bintray.com/samgarasx/kotlin-js-wrappers")
     }
 
     tasks.withType<JavaCompile>().configureEach {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,6 +11,12 @@ kotlin {
         withJava()
     }
 
+    js {
+        browser {
+            useCommonJs()
+        }
+    }
+
     sourceSets {
         val commonMain by getting {
             kotlin.srcDirs("src/commonMain/generated")
@@ -45,6 +51,20 @@ kotlin {
             dependencies {
                 implementation(Libs.statelyIsolate)
                 implementation(Libs.AtomicFU.native)
+            }
+        }
+
+        val jsMain by getting {
+            dependencies {
+                implementation(kotlin("stdlib-js"))
+                implementation("com.github.samgarasx:kotlin-moment:2.24.0-pre.2-kotlin-1.3.72")
+                implementation(npm("moment", "2.24.0"))
+            }
+        }
+
+        val jsTest by getting {
+            dependencies {
+                implementation(kotlin("test-js"))
             }
         }
     }

--- a/core/src/jsMain/kotlin/io/islandtime/calendar/WeekSettings.kt
+++ b/core/src/jsMain/kotlin/io/islandtime/calendar/WeekSettings.kt
@@ -1,0 +1,27 @@
+package io.islandtime.calendar
+
+import io.islandtime.DayOfWeek
+import io.islandtime.locale.Locale
+import io.islandtime.locale.MLocale
+import io.islandtime.measures.days
+import moment.Moment
+import moment.moment
+import moment.now
+import kotlin.js.Date
+
+internal actual fun systemDefaultWeekSettings(): WeekSettings {
+    //TODO we have to figure out better ways to find the `minimumDaysInFirstWeek
+    return WeekSettings(
+        firstIslandDayOfWeek,
+        7
+        )
+}
+
+internal actual val Locale.firstDayOfWeek: DayOfWeek
+    get() = firstIslandDayOfWeek(this)
+
+internal fun firstIslandDayOfWeek(locale: Locale = MLocale()): DayOfWeek =
+    DayOfWeek.SUNDAY + locale.firstDayOfWeek().toInt().days
+
+internal val firstIslandDayOfWeek: DayOfWeek
+    get() = firstIslandDayOfWeek()

--- a/core/src/jsMain/kotlin/io/islandtime/clock/PlatformSystemClock.kt
+++ b/core/src/jsMain/kotlin/io/islandtime/clock/PlatformSystemClock.kt
@@ -1,0 +1,16 @@
+package io.islandtime.clock
+
+import io.islandtime.*
+import io.islandtime.measures.LongMilliseconds
+import io.islandtime.measures.milliseconds
+import moment.moment
+import moment.now
+
+internal actual object PlatformSystemClock {
+    //TODO FixedOffset will serve us well at the beginning
+    // but with the help of moment-timezone we can support them better func
+    actual fun currentZone() = TimeZone.FixedOffset("${kotlin.js.Date().getTimezoneOffset()}")
+
+    actual fun read() = moment.now().toLong().milliseconds
+
+}

--- a/core/src/jsMain/kotlin/io/islandtime/format/DateFormatSymbols.kt
+++ b/core/src/jsMain/kotlin/io/islandtime/format/DateFormatSymbols.kt
@@ -1,0 +1,136 @@
+package io.islandtime.format
+
+import io.islandtime.locale.MLocale
+
+class DateFormatSymbols private constructor(
+    private val locale: MLocale?
+) {
+
+    companion object {
+
+        fun getInstance(locale: MLocale? = null): DateFormatSymbols {
+            return DateFormatSymbols(locale)
+        }
+
+    }
+
+    val weekdays: Array<String> =
+        locale?.weekdays() ?: moment.weekdays()
+
+    val shortWeekdays: Array<String> =
+        locale?.weekdaysShort() ?: moment.weekdaysShort()
+
+    val months : Array<String> =
+        locale?.months() ?: moment.months()
+
+    val shortMonthsNames : Array<String> =
+        locale?.monthsShort() ?: moment.monthsShort()
+
+    val apPm : Array<String> =
+        //TODO not sure if there is something similar in javascript
+        APPM
+            .values()
+            .map { it.raw }
+            .toTypedArray()
+}
+
+enum class CalendarDayName(
+    val fullName: String,
+    val shortName: String
+
+) {
+    MONDAY(
+        fullName = "Monday",
+        shortName = "Mon"
+    ),
+    TUESDAY(
+        fullName = "Tuesday",
+        shortName = "Tue"
+    ),
+    WEDNESDAY(
+        fullName = "Wednesday",
+        shortName = "Wed"
+    ),
+    THURSDAY(
+        fullName = "Thursday",
+        shortName = "Thu"
+    ),
+    FRIDAY(
+        fullName = "Friday",
+        shortName = "Fri"
+    ),
+    SATURDAY(
+        fullName = "Saturday",
+        shortName = "Sat"
+    ),
+    SUNDAY(
+        fullName = "Sunday",
+        shortName = "Sun"
+    )
+}
+
+enum class CalendarMonthName(
+    val fullName: String,
+    val shortName: String
+
+) {
+    JANUARY(
+        fullName = "January",
+        shortName = "Jan"
+    ),
+    FEBRUARY(
+        fullName = "February",
+        shortName = "Feb"
+    ),
+    MARCH(
+        fullName = "March",
+        shortName = "Mar"
+    ),
+    APRIL(
+        fullName = "April",
+        shortName = "Apr"
+    ),
+    MAY(
+        fullName = "May",
+        shortName = "May"
+    ),
+    JUNE(
+        fullName = "June",
+        shortName = "Jun"
+    ),
+    JULY(
+        fullName = "July",
+        shortName = "Jul"
+    ),
+    AUGUST(
+        fullName = "August",
+        shortName = "Aug"
+    ),
+    SEPTEMBER(
+        fullName = "September",
+        shortName = "Sep"
+    ),
+    OCTOBER(
+        fullName = "October",
+        shortName = "Oct"
+    ),
+    NOVEMBER(
+        fullName = "November",
+        shortName = "Nov"
+    ),
+    DECEMBER(
+        fullName = "December",
+        shortName = "Dec"
+    )
+}
+
+enum class APPM (
+    val raw : String
+){
+    AM(
+        raw = "AM"
+    ),
+    PM(
+        raw = "PM"
+    )
+}

--- a/core/src/jsMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
+++ b/core/src/jsMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
@@ -1,0 +1,180 @@
+package io.islandtime.format
+
+import io.islandtime.DateTimeException
+import io.islandtime.base.DateTimeField
+import io.islandtime.locale.Locale
+import io.islandtime.locale.MLocale
+import kotlin.collections.HashMap
+
+actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
+    private val monthText = HashMap<Locale, HashMap<TextStyle, Array<String>>>()
+    private val parsableText = HashMap<ParsableTextKey, ParsableTextList>()
+    private val narrowEraSymbols = arrayOf("B", "A")
+    private val englishLongEraSymbols = arrayOf("Before Christ", "Anno Domini")
+
+    private val descendingTextComparator =
+        compareByDescending<Pair<String, Long>> { it.first.length }.thenBy { it.second }
+
+    private data class ParsableTextKey(
+        val field: DateTimeField,
+        val styles: Set<TextStyle>,
+        val locale: MLocale
+    )
+
+    override fun parsableTextFor(
+        field: DateTimeField,
+        styles: Set<TextStyle>,
+        locale: MLocale
+    ): ParsableTextList {
+        if (styles.isEmpty() || !supports(field)) {
+            return emptyList()
+        }
+
+        val key = ParsableTextKey(field, styles, locale)
+
+        return parsableText.getOrPut(key) {
+            val valueMap = mutableMapOf<String, MutableSet<Long>>()
+
+            styles.forEach { style ->
+                allTextFor(field, style, locale).forEachIndexed { index, symbol ->
+                    valueMap.getOrPut(symbol) { mutableSetOf() } += valueForArrayIndex(field, index)
+                }
+            }
+
+            valueMap.mapNotNull {
+                if (it.value.size == 1) {
+                    it.key to it.value.first()
+                } else {
+                    null
+                }
+            }.sortedWith(descendingTextComparator)
+        }
+    }
+
+    override fun dayOfWeekTextFor(value: Long, style: TextStyle, locale: MLocale): String? {
+        if (value !in 1L..7L) {
+            throw DateTimeException("'$value' is outside the supported day of week field range")
+        }
+
+        val symbols = DateFormatSymbols.getInstance(locale)
+        val index = if (value == 7L) 1 else value.toInt() + 1
+
+        return when (style) {
+            TextStyle.FULL,
+            TextStyle.FULL_STANDALONE -> symbols.weekdays[index]
+            TextStyle.SHORT,
+            TextStyle.SHORT_STANDALONE -> symbols.shortWeekdays[index]
+            TextStyle.NARROW,
+            TextStyle.NARROW_STANDALONE -> symbols.weekdays[index].substring(0, 1)
+        }
+    }
+
+    override fun monthTextFor(value: Long, style: TextStyle, locale: MLocale): String? {
+        if (value !in 1L..12L) {
+            throw DateTimeException("'$value' is outside the supported month of year field range")
+        }
+
+        return allMonthTextFor(style, locale)[value.toInt() - 1]
+    }
+
+    override fun amPmTextFor(value: Long, locale: MLocale): String? {
+        if (value !in 0L..1L) {
+            throw DateTimeException("'$value' is outside the supported AM/PM range")
+        }
+
+        return allAmPmTextFor(locale)[value.toInt()]
+    }
+
+    override fun eraTextFor(value: Long, style: TextStyle, locale: MLocale): String? {
+        if (value !in 0L..1L) {
+            throw DateTimeException("'$value' is outside the supported era field range")
+        }
+
+        return allEraTextFor(style, locale)[value.toInt()]
+    }
+
+    private fun supports(field: DateTimeField): Boolean {
+        return when (field) {
+            DateTimeField.MONTH_OF_YEAR,
+            DateTimeField.DAY_OF_WEEK,
+            DateTimeField.AM_PM_OF_DAY,
+            DateTimeField.ERA -> true
+            else -> false
+        }
+    }
+
+    private fun allTextFor(field: DateTimeField, style: TextStyle, locale: MLocale): Array<String> {
+        return when (field) {
+            DateTimeField.MONTH_OF_YEAR -> allMonthTextFor(style, locale)
+            DateTimeField.DAY_OF_WEEK -> allDayOfWeekTextFor(style, locale)
+            DateTimeField.AM_PM_OF_DAY -> allAmPmTextFor(locale)
+            DateTimeField.ERA -> allEraTextFor(style, locale)
+            else -> throw IllegalStateException("Unexpected field")
+        }
+    }
+
+    private fun valueForArrayIndex(field: DateTimeField, index: Int): Long {
+        return when (field) {
+            DateTimeField.MONTH_OF_YEAR,
+            DateTimeField.DAY_OF_WEEK -> index + 1L
+            else -> index.toLong()
+        }
+    }
+
+    private fun allDayOfWeekTextFor(style: TextStyle, locale: MLocale): Array<String> {
+        val symbols = DateFormatSymbols.getInstance(locale)
+
+        val array = when (style) {
+            TextStyle.FULL,
+            TextStyle.FULL_STANDALONE -> symbols.weekdays
+            TextStyle.SHORT,
+            TextStyle.SHORT_STANDALONE -> symbols.shortWeekdays
+            TextStyle.NARROW,
+            TextStyle.NARROW_STANDALONE -> symbols.weekdays
+                .map { if (it.isNotEmpty()) it.substring(0, 1) else it }
+                .toTypedArray()
+        }
+
+        return array
+    }
+
+    private fun allMonthTextFor(style: TextStyle, locale: MLocale): Array<String> {
+        return allMonthTextFor(locale).getValue(style)
+    }
+
+    private fun allMonthTextFor(locale: MLocale): HashMap<TextStyle, Array<String>> {
+        return monthText.getOrPut(locale) {
+            val symbols = DateFormatSymbols.getInstance(locale)
+            val fullArray = symbols.months
+            //TODO support LLLL
+            val fullStandaloneArray = symbols.months
+            val shortArray = symbols.shortMonthsNames
+            //TODO support LLL
+            val shortStandaloneArray = symbols.shortMonthsNames
+            val narrowArray = Array(fullStandaloneArray.size) { fullStandaloneArray[it].substring(0, 1) }
+
+            hashMapOf(
+                TextStyle.FULL to fullArray,
+                TextStyle.FULL_STANDALONE to fullStandaloneArray,
+                TextStyle.SHORT to shortArray,
+                TextStyle.SHORT_STANDALONE to shortStandaloneArray,
+                TextStyle.NARROW to narrowArray,
+                TextStyle.NARROW_STANDALONE to narrowArray
+            )
+        }
+    }
+
+    private fun allAmPmTextFor(locale: MLocale): Array<String> {
+        return DateFormatSymbols.getInstance(locale).apPm
+    }
+
+    private fun allEraTextFor(style: TextStyle, locale: MLocale): Array<String> {
+        return when (style) {
+            //TODO support other locales
+            TextStyle.FULL, TextStyle.FULL_STANDALONE -> englishLongEraSymbols
+            //TODO support other locales
+            TextStyle.SHORT, TextStyle.SHORT_STANDALONE -> narrowEraSymbols
+            TextStyle.NARROW, TextStyle.NARROW_STANDALONE -> narrowEraSymbols
+        }
+    }
+}

--- a/core/src/jsMain/kotlin/io/islandtime/format/NumberStyle.kt
+++ b/core/src/jsMain/kotlin/io/islandtime/format/NumberStyle.kt
@@ -1,0 +1,13 @@
+package io.islandtime.format
+
+import io.islandtime.locale.Locale
+
+actual val Locale.numberStyle: NumberStyle
+    get() {
+        return NumberStyle(
+            zeroDigit = '0',
+            plusSign = listOf('+'),
+            minusSign = listOf('-'),
+            decimalSeparator = listOf(',')
+        )
+    }

--- a/core/src/jsMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
+++ b/core/src/jsMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
@@ -1,0 +1,11 @@
+package io.islandtime.format
+
+import io.islandtime.TimeZone
+import io.islandtime.locale.Locale
+
+actual object PlatformTimeZoneTextProvider : TimeZoneTextProvider {
+    override fun timeZoneTextFor(zone: TimeZone, style: TimeZoneTextStyle, locale: Locale): String? {
+        //TODO we are using FIXED offset. later we may be able to support timezones
+        return null
+    }
+}

--- a/core/src/jsMain/kotlin/io/islandtime/internal/Math.kt
+++ b/core/src/jsMain/kotlin/io/islandtime/internal/Math.kt
@@ -1,0 +1,36 @@
+@file:Suppress("NewApi")
+
+package io.islandtime.internal
+
+
+//TODO replace with Math functions
+internal actual infix fun Long.floorMod(other: Long): Long = ((this % other) + other) % other
+internal actual infix fun Int.floorMod(other: Int): Int = ((this % other) + other) % other
+internal actual infix fun Long.floorMod(other: Int): Long = this floorMod other.toLong()
+
+internal actual infix fun Long.floorDiv(other: Long): Long = this / other
+internal actual infix fun Int.floorDiv(other: Int): Int = this / other
+internal actual infix fun Long.floorDiv(other: Int): Long = this floorDiv other.toLong()
+
+internal actual infix fun Long.plusExact(other: Long): Long = this + other
+internal actual infix fun Int.plusExact(other: Int): Int = this + other
+
+internal actual infix fun Long.minusExact(other: Long): Long = this - other
+internal actual infix fun Int.minusExact(other: Int): Int = this - other
+
+internal actual infix fun Long.timesExact(other: Long): Long = this * other
+internal actual infix fun Int.timesExact(other: Int): Int = this * other
+internal actual infix fun Long.timesExact(other: Int): Long = this timesExact other.toLong()
+
+internal actual fun Int.negateExact(): Int =
+    -(this)
+
+internal actual fun Long.negateExact(): Long =
+    -(this)
+
+internal actual fun Long.toIntExact(): Int =
+    if (this <= Int.MAX_VALUE || this >= Int.MIN_VALUE) {
+        this.toInt()
+    } else {
+        throw NumberFormatException()
+    }

--- a/core/src/jsMain/kotlin/io/islandtime/locale/Locale.kt
+++ b/core/src/jsMain/kotlin/io/islandtime/locale/Locale.kt
@@ -1,0 +1,16 @@
+package io.islandtime.locale
+
+import moment.localeData
+import moment.moment
+
+class MLocale(
+    locale: moment.Locale? = null
+) : moment.Locale by locale ?: moment().localeData()
+
+actual typealias Locale = MLocale
+
+actual fun defaultLocale(): Locale =
+    MLocale()
+
+internal actual fun localeOf(identifier: String): Locale =
+    MLocale(localeData(identifier))

--- a/core/src/jsMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
+++ b/core/src/jsMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
@@ -1,0 +1,20 @@
+@file:Suppress("NewApi")
+
+package io.islandtime.zone
+
+actual object PlatformTimeZoneRulesProvider : TimeZoneRulesProvider {
+
+    override val databaseVersion: String
+        get() = "1"
+
+    override val availableRegionIds: Set<String>
+        get() = setOf()
+
+    override fun hasRulesFor(regionId: String): Boolean {
+        return false
+    }
+
+    override fun rulesFor(regionId: String): TimeZoneRules {
+        return TODO()
+    }
+}

--- a/core/src/jsTest/kotlin/io/islandtime/calendar/JvmWeekSettingsTest.kt
+++ b/core/src/jsTest/kotlin/io/islandtime/calendar/JvmWeekSettingsTest.kt
@@ -1,0 +1,27 @@
+package io.islandtime.calendar
+
+import io.islandtime.DayOfWeek
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JvmWeekSettingsTest {
+
+    @Test
+    fun weekSettings_systemDefault_in_US() {
+        //TODO common test names have to be refactored to be run on Js env
+        // other wise compiler will complain
+        val settings = WeekSettings.systemDefault()
+
+        assertEquals(DayOfWeek.SUNDAY, settings.firstDayOfWeek)
+        assertEquals(1, settings.minimumDaysInFirstWeek)
+    }
+
+//    @Test
+//    fun `WeekSettings_systemDefault() in Germany`() {
+//        Locale.setDefault(Locale.GERMANY)
+//        val settings = WeekSettings.systemDefault()
+//
+//        assertEquals(DayOfWeek.MONDAY, settings.firstDayOfWeek)
+//        assertEquals(4, settings.minimumDaysInFirstWeek)
+//    }
+}


### PR DESCRIPTION
Added basic support for JS targets.

I call it basic because there are a ton of things to be improved. I mostly made it just work with the target.
The reason for going with the basic implementation is mainly because I'm Android dev and not sure how do JS devs prefer those Locale and TimeZone stuff.
With Moment-TimeZones we can add all the TimeZone db but I assume the size of the lib will come to concern.
I backed most of the expected functions with `momentJS` since I found it very popular. 
Also With the help of `FixedOffset` type provided by `Island-time`, I bypassed all the TimeZone rules.

There are two incomplete parts with this PR: JsTest, JsMath.
The work that needs to be done to get these working is a bit trivial. I did not know if the PR will be accepted or not so I decided to let you guys review first and see what you think then if decided I can fix all of them before merging.
One note about tests though: In order to make JSTest work I have to change all of the commonTest function names and remove spaces from them. As spaces in function names are not supported for Kotlin/JS.

Thanks in advance for taking the time and reviewing

