### PR TITLE
Deprecate String.toTimeZone()

### DIFF
--- a/core/src/commonMain/kotlin/io/islandtime/TimeZone.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/TimeZone.kt
@@ -205,9 +205,11 @@ fun TimeZone(id: String): TimeZone {
  */
 fun UtcOffset.asTimeZone(): TimeZone = TimeZone.FixedOffset(this)
 
-/**
- * Convert a string to a [TimeZone].
- */
+@Deprecated(
+    "Use TimeZone() instead.",
+    ReplaceWith("TimeZone(this)"),
+    DeprecationLevel.WARNING
+)
 fun String.toTimeZone() = TimeZone(this)
 
 internal const val MAX_TIME_ZONE_STRING_LENGTH = 50

--- a/core/src/commonMain/kotlin/io/islandtime/ZonedDateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ZonedDateTime.kt
@@ -729,7 +729,7 @@ internal fun DateTimeParseResult.toZonedDateTime(): ZonedDateTime? {
     val offset = this.toUtcOffset()
 
     return if (dateTime != null && offset != null) {
-        val zone = timeZoneId?.toTimeZone() ?: offset.asTimeZone()
+        val zone = timeZoneId?.let { TimeZone(it) } ?: offset.asTimeZone()
 
         // Check if the offset is valid for the time zone as we understand it and if not, adjust the date-time and
         // offset to valid values while preserving the instant of the parsed value

--- a/core/src/commonTest/kotlin/io/islandtime/ZonedDateTimeTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/ZonedDateTimeTest.kt
@@ -16,7 +16,7 @@ class ZonedDateTimeTest : AbstractIslandTimeTest() {
         assertFailsWith<TimeZoneRulesException> {
             ZonedDateTime(
                 DateTime(2019, 5, 30, 18, 0),
-                "America/Boston".toTimeZone()
+                TimeZone("America/Boston")
             )
         }
     }
@@ -277,22 +277,22 @@ class ZonedDateTimeTest : AbstractIslandTimeTest() {
     fun `DEFAULT_SORT_ORDER compares based on instant, then date and time, and then zone`() {
         assertTrue {
             ZonedDateTime.DEFAULT_SORT_ORDER.compare(
-                Date(1969, 365) at Time(23, 0) at "America/Chicago".toTimeZone(),
+                Date(1969, 365) at Time(23, 0) at TimeZone("America/Chicago"),
                 Date(1970, 1) at Time(0, 0) at nyZone
             ) < 0
         }
 
         assertTrue {
             ZonedDateTime.DEFAULT_SORT_ORDER.compare(
-                Date(1970, 1) at Time(0, 0) at "Etc/GMT+5".toTimeZone(),
+                Date(1970, 1) at Time(0, 0) at TimeZone("Etc/GMT+5"),
                 Date(1970, 1) at Time(0, 0) at nyZone
             ) > 0
         }
 
         assertTrue {
             ZonedDateTime.DEFAULT_SORT_ORDER.compare(
-                Date(1969, 365) at Time(23, 0) at "Etc/GMT+5".toTimeZone(),
-                Date(1969, 365) at Time(23, 0) at "Etc/GMT+5".toTimeZone()
+                Date(1969, 365) at Time(23, 0) at TimeZone("Etc/GMT+5"),
+                Date(1969, 365) at Time(23, 0) at TimeZone("Etc/GMT+5")
             ) == 0
         }
     }
@@ -587,7 +587,7 @@ class ZonedDateTimeTest : AbstractIslandTimeTest() {
             "2019-11-03T01:30Z[Etc/UTC]",
             ZonedDateTime(
                 DateTime(2019, 11, 3, 1, 30),
-                "Etc/UTC".toTimeZone()
+                TimeZone("Etc/UTC")
             ).toString()
         )
 

--- a/core/src/commonTest/kotlin/io/islandtime/clock/ClockTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/clock/ClockTest.kt
@@ -3,7 +3,6 @@ package io.islandtime.clock
 import io.islandtime.Instant
 import io.islandtime.TimeZone
 import io.islandtime.measures.milliseconds
-import io.islandtime.toTimeZone
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -30,10 +29,10 @@ class ClockTest {
 
     @Test
     fun `SystemClock() with zone`() {
-        val clock = SystemClock("America/Denver".toTimeZone())
+        val clock = SystemClock(TimeZone("America/Denver"))
 
         assertTrue { clock.read() > 0L.milliseconds }
         assertTrue { clock.instant() > Instant.UNIX_EPOCH }
-        assertEquals("America/Denver".toTimeZone(), clock.zone)
+        assertEquals(TimeZone("America/Denver"), clock.zone)
     }
 }

--- a/core/src/commonTest/kotlin/io/islandtime/clock/NowTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/clock/NowTest.kt
@@ -38,7 +38,7 @@ class NowTest : AbstractIslandTimeTest() {
 
     @Test
     fun `Date_now() with offset`() {
-        val clock = FixedClock((-1).days, "Etc/GMT+1".toTimeZone())
+        val clock = FixedClock((-1).days, TimeZone("Etc/GMT+1"))
         assertEquals(Date(1969, Month.DECEMBER, 30), Date.now(clock))
     }
 
@@ -65,7 +65,7 @@ class NowTest : AbstractIslandTimeTest() {
 
     @Test
     fun `DateTime_now() with offset`() {
-        val clock = FixedClock((-1).days, "Etc/GMT+1".toTimeZone())
+        val clock = FixedClock((-1).days, TimeZone("Etc/GMT+1"))
         assertEquals(
             DateTime(1969, Month.DECEMBER, 30, 23, 0),
             DateTime.now(clock)
@@ -92,25 +92,25 @@ class NowTest : AbstractIslandTimeTest() {
 
     @Test
     fun `Time_now() with offset`() {
-        val clock1 = FixedClock((-1).days, "Etc/GMT+4".toTimeZone())
+        val clock1 = FixedClock((-1).days, TimeZone("Etc/GMT+4"))
         assertEquals(Time(20, 0), Time.now(clock1))
 
-        val clock2 = FixedClock((-1).days, "Etc/GMT-4".toTimeZone())
+        val clock2 = FixedClock((-1).days, TimeZone("Etc/GMT-4"))
         assertEquals(Time(4, 0), Time.now(clock2))
     }
 
     @Test
     fun `OffsetTime_now()`() {
-        val clock1 = FixedClock((-1).days, "Etc/GMT+4".toTimeZone())
+        val clock1 = FixedClock((-1).days, TimeZone("Etc/GMT+4"))
         assertEquals(OffsetTime(Time(20, 0), (-4).hours.asUtcOffset()), OffsetTime.now(clock1))
 
-        val clock2 = FixedClock((-1).days, "Etc/GMT-4".toTimeZone())
+        val clock2 = FixedClock((-1).days, TimeZone("Etc/GMT-4"))
         assertEquals(OffsetTime(Time(4, 0), 4.hours.asUtcOffset()), OffsetTime.now(clock2))
     }
 
     @Test
     fun `OffsetDateTime_now()`() {
-        val clock = FixedClock((-1).days, "Etc/GMT+1".toTimeZone())
+        val clock = FixedClock((-1).days, TimeZone("Etc/GMT+1"))
         assertEquals(
             OffsetDateTime(
                 DateTime(1969, Month.DECEMBER, 30, 23, 0),
@@ -131,11 +131,11 @@ class NowTest : AbstractIslandTimeTest() {
 
     @Test
     fun `ZonedDateTime_now()`() {
-        val clock = FixedClock((-1).days, "Etc/GMT+1".toTimeZone())
+        val clock = FixedClock((-1).days, TimeZone("Etc/GMT+1"))
         assertEquals(
             ZonedDateTime(
                 DateTime(1969, Month.DECEMBER, 30, 23, 0),
-                "Etc/GMT+1".toTimeZone()
+                TimeZone("Etc/GMT+1")
             ),
             ZonedDateTime.now(clock)
         )
@@ -144,7 +144,7 @@ class NowTest : AbstractIslandTimeTest() {
         assertEquals(
             ZonedDateTime(
                 DateTime(1969, Month.DECEMBER, 31, 0, 0),
-                "Etc/GMT+1".toTimeZone()
+                TimeZone("Etc/GMT+1")
             ),
             ZonedDateTime.now(clock)
         )

--- a/core/src/commonTest/kotlin/io/islandtime/operators/PreviousNextTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/operators/PreviousNextTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class PreviousNextTest : AbstractIslandTimeTest() {
-    private val nyZone = "America/New_York".toTimeZone()
+    private val nyZone = TimeZone("America/New_York")
 
     @Test
     fun `Date_next() returns the next date with a particular day of week`() {

--- a/core/src/commonTest/kotlin/io/islandtime/operators/StartEndTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/operators/StartEndTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class StartEndTest : AbstractIslandTimeTest() {
-    private val nyZone = "America/New_York".toTimeZone()
+    private val nyZone = TimeZone("America/New_York")
 
     @Test
     fun `Date_startOfYear returns the date at the start of this date's year`() {

--- a/core/src/commonTest/kotlin/io/islandtime/ranges/OffsetDateTimeIntervalTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/ranges/OffsetDateTimeIntervalTest.kt
@@ -60,8 +60,8 @@ class OffsetDateTimeIntervalTest : AbstractIslandTimeTest() {
         val end = DateTime.MAX at UtcOffset((-4).hours)
 
         assertTrue { start in start..end }
-        assertTrue { DateTime.MAX at "Etc/UTC".toTimeZone() in start..end }
-        assertTrue { DateTime.MAX at "America/Denver".toTimeZone() in start..end }
+        assertTrue { DateTime.MAX at TimeZone("Etc/UTC") in start..end }
+        assertTrue { DateTime.MAX at TimeZone("America/Denver") in start..end }
         assertTrue { Instant.MAX in start..end }
     }
 
@@ -72,8 +72,8 @@ class OffsetDateTimeIntervalTest : AbstractIslandTimeTest() {
 
         assertTrue { start in start..end }
         assertTrue { end in start..end }
-        assertTrue { DateTime.MIN at "Etc/UTC".toTimeZone() in start..end }
-        assertTrue { DateTime.MIN at "America/Denver".toTimeZone() in start..end }
+        assertTrue { DateTime.MIN at TimeZone("Etc/UTC") in start..end }
+        assertTrue { DateTime.MIN at TimeZone("America/Denver") in start..end }
         assertTrue { Instant.MIN in start..end }
     }
 

--- a/core/src/commonTest/kotlin/io/islandtime/ranges/ZonedDateTimeIntervalTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/ranges/ZonedDateTimeIntervalTest.kt
@@ -58,8 +58,8 @@ class ZonedDateTimeIntervalTest : AbstractIslandTimeTest() {
         val end = DateTime.MAX at nyZone
 
         assertTrue { start in start..end }
-        assertTrue { DateTime.MAX at "Etc/UTC".toTimeZone() in start..end }
-        assertTrue { DateTime.MAX at "America/Denver".toTimeZone() in start..end }
+        assertTrue { DateTime.MAX at TimeZone("Etc/UTC") in start..end }
+        assertTrue { DateTime.MAX at TimeZone("America/Denver") in start..end }
         assertTrue { Instant.MAX in start..end }
     }
 
@@ -70,8 +70,8 @@ class ZonedDateTimeIntervalTest : AbstractIslandTimeTest() {
 
         assertTrue { start in start..end }
         assertTrue { end in start..end }
-        assertTrue { DateTime.MIN at "Etc/UTC".toTimeZone() in start..end }
-        assertTrue { DateTime.MIN at "America/Denver".toTimeZone() in start..end }
+        assertTrue { DateTime.MIN at TimeZone("Etc/UTC") in start..end }
+        assertTrue { DateTime.MIN at TimeZone("America/Denver") in start..end }
         assertTrue { Instant.MIN in start..end }
     }
 

--- a/core/src/darwinMain/kotlin/io/islandtime/darwin/Conversions.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/darwin/Conversions.kt
@@ -253,7 +253,7 @@ fun NSTimeZone.toIslandUtcOffsetAt(date: NSDate): UtcOffset {
 /**
  * Convert an NSTimeZone` to an Island Time [TimeZone] with the same identifier.
  */
-fun NSTimeZone.toIslandTimeZone(): TimeZone = name.toTimeZone()
+fun NSTimeZone.toIslandTimeZone(): TimeZone = TimeZone(name)
 
 /**
  * Convert an Island Time [TimeZone] to an `NSTimeZone`.

--- a/core/src/darwinTest/kotlin/io/islandtime/darwin/ConversionsTest.kt
+++ b/core/src/darwinTest/kotlin/io/islandtime/darwin/ConversionsTest.kt
@@ -215,7 +215,7 @@ class ConversionsTest : AbstractIslandTimeTest() {
 
     @Test
     fun `convert NSDate to ZonedDateTime`() {
-        val zone = "America/New_York".toTimeZone()
+        val zone = TimeZone("America/New_York")
 
         assertEquals(
             Instant.UNIX_EPOCH at zone,

--- a/extensions/parcelize/src/main/kotlin/io/islandtime/extensions/parcelize/TimeZone.kt
+++ b/extensions/parcelize/src/main/kotlin/io/islandtime/extensions/parcelize/TimeZone.kt
@@ -2,7 +2,6 @@ package io.islandtime.extensions.parcelize
 
 import android.os.Parcel
 import io.islandtime.TimeZone
-import io.islandtime.toTimeZone
 import kotlinx.android.parcel.Parceler
 
 object TimeZoneParceler : Parceler<TimeZone> {
@@ -17,7 +16,7 @@ object TimeZoneParceler : Parceler<TimeZone> {
 
 object NullableTimeZoneParceler : Parceler<TimeZone?> {
     override fun create(parcel: Parcel): TimeZone? {
-        return parcel.readString()?.toTimeZone()
+        return parcel.readString()?.let { TimeZone(it) }
     }
 
     override fun TimeZone?.write(parcel: Parcel, flags: Int) {

--- a/extensions/serialization/src/commonMain/kotlin/io/islandtime/extensions/serialization/TimeZone.kt
+++ b/extensions/serialization/src/commonMain/kotlin/io/islandtime/extensions/serialization/TimeZone.kt
@@ -1,7 +1,6 @@
 package io.islandtime.extensions.serialization
 
 import io.islandtime.TimeZone
-import io.islandtime.toTimeZone
 import kotlinx.serialization.*
 
 object TimeZoneSerializer : KSerializer<TimeZone> {
@@ -13,6 +12,6 @@ object TimeZoneSerializer : KSerializer<TimeZone> {
     }
 
     override fun deserialize(decoder: Decoder): TimeZone {
-        return decoder.decodeString().toTimeZone()
+        return TimeZone(decoder.decodeString())
     }
 }


### PR DESCRIPTION
Doesn't seem like this really needs to be part of the API.