### PR TITLE
Bump Android minSdkVersion to 21

### DIFF
--- a/buildSrc/src/main/kotlin/android-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-library.gradle.kts
@@ -13,7 +13,7 @@ android {
     compileSdkVersion(29)
 
     defaultConfig {
-        minSdkVersion(15)
+        minSdkVersion(21)
     }
 
     compileOptions {

--- a/core/src/jvmMain/kotlin/io/islandtime/jvm/Conversions.kt
+++ b/core/src/jvmMain/kotlin/io/islandtime/jvm/Conversions.kt
@@ -1,5 +1,4 @@
 @file:JvmName("IslandTimeUtils")
-@file:Suppress("NewApi")
 
 package io.islandtime.jvm
 

--- a/core/src/jvmMain/kotlin/io/islandtime/locale/Locale.kt
+++ b/core/src/jvmMain/kotlin/io/islandtime/locale/Locale.kt
@@ -4,7 +4,6 @@ actual typealias Locale = java.util.Locale
 
 actual fun defaultLocale(): Locale = Locale.getDefault()
 
-@Suppress("NewApi")
 internal actual fun localeOf(identifier: String): Locale {
     return Locale.forLanguageTag(identifier)
 }

--- a/core/src/jvmMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
+++ b/core/src/jvmMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NewApi")
-
 package io.islandtime.zone
 
 import io.islandtime.DateTime

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ Island Time requires Java 8 or above.
 
 ### Android
 
-Island Time requires Android Gradle Plugin 4.0 or later and a minimum compile SDK of API 15.
+Island Time requires Android Gradle Plugin 4.0 or later and a minimum compile SDK of API 21.
 
 ## Gradle Setup
 


### PR DESCRIPTION
Mostly since we're not able to actually test anything under 21 with the current config, but leaves the door open to using some newer APIs.