### PR TITLE
Convert all existing deprecation warnings to errors

### DIFF
--- a/core/src/commonMain/kotlin/io/islandtime/Date.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/Date.kt
@@ -75,7 +75,7 @@ class Date(
     @Deprecated(
         "Use toYearMonth() instead.",
         ReplaceWith("this.toYearMonth()"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     inline val yearMonth: YearMonth
         get() = toYearMonth()
@@ -88,7 +88,7 @@ class Date(
     @Deprecated(
         "Use dayOfUnixEpoch instead.",
         ReplaceWith("this.dayOfUnixEpoch"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     val unixEpochDay: Long
         get() = dayOfUnixEpoch
@@ -303,7 +303,7 @@ class Date(
         @Deprecated(
             "Use fromDayOfUnixEpoch() instead.",
             ReplaceWith("Date.fromDayOfUnixEpoch(day)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochDay(day: Long): Date = fromDayOfUnixEpoch(day)
     }

--- a/core/src/commonMain/kotlin/io/islandtime/DateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/DateTime.kt
@@ -113,7 +113,7 @@ class DateTime(
     @Deprecated(
         "Use toYearMonth() instead.",
         ReplaceWith("this.toYearMonth()"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     inline val yearMonth: YearMonth get() = toYearMonth()
 
@@ -503,7 +503,7 @@ class DateTime(
     @Deprecated(
         "Use additionalNanosecondsSinceUnixEpoch instead.",
         ReplaceWith("this.additionalNanosecondsSinceUnixEpoch"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     val nanoOfSecondsSinceUnixEpoch: IntNanoseconds
         get() = additionalNanosecondsSinceUnixEpoch
@@ -530,7 +530,7 @@ class DateTime(
     @Deprecated(
         "Use secondOfUnixEpochAt() instead.",
         ReplaceWith("this.secondOfUnixEpochAt(offset)"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     fun unixEpochSecondAt(offset: UtcOffset): Long = secondOfUnixEpochAt(offset)
 
@@ -545,7 +545,7 @@ class DateTime(
     @Deprecated(
         "Use nanosecond instead.",
         ReplaceWith("this.nanosecond"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     val unixEpochNanoOfSecond: Int
         get() = nanosecond
@@ -553,7 +553,7 @@ class DateTime(
     @Deprecated(
         "Use millisecondOfUnixEpoch() instead.",
         ReplaceWith("this.millisecondOfUnixEpochAt(offset)"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     fun unixEpochMillisecondAt(offset: UtcOffset): Long = millisecondOfUnixEpochAt(offset)
 
@@ -566,7 +566,7 @@ class DateTime(
     @Deprecated(
         "Use toInstantAt() instead.",
         ReplaceWith("this.toInstantAt(offset)"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     fun instantAt(offset: UtcOffset): Instant = toInstantAt(offset)
 
@@ -632,7 +632,7 @@ class DateTime(
         @Deprecated(
             "Use fromMillisecondOfUnixEpoch() instead.",
             ReplaceWith("DateTime.fromMillisecondOfUnixEpoch(millisecond, offset)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochMillisecond(millisecond: Long, offset: UtcOffset): DateTime {
             return fromMillisecondOfUnixEpoch(millisecond, offset)
@@ -641,7 +641,7 @@ class DateTime(
         @Deprecated(
             "Use fromSecondOfUnixEpoch() instead.",
             ReplaceWith("DateTime.fromSecondOfUnixEpoch(second, nanosecondAdjustment, offset)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochSecond(second: Long, nanosecondAdjustment: Int = 0, offset: UtcOffset): DateTime {
             return fromSecondOfUnixEpoch(second, nanosecondAdjustment, offset)

--- a/core/src/commonMain/kotlin/io/islandtime/Instant.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/Instant.kt
@@ -259,7 +259,7 @@ class Instant private constructor(
         @Deprecated(
             "Use fromSecondOfUnixEpoch() instead.",
             ReplaceWith("Instant.fromSecondOfUnixEpoch(second)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochSecond(second: Long): Instant {
             return fromSecondOfUnixEpoch(second)
@@ -268,7 +268,7 @@ class Instant private constructor(
         @Deprecated(
             "Use fromSecondOfUnixEpoch() instead.",
             ReplaceWith("Instant.fromSecondOfUnixEpoch(second, nanosecondAdjustment)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochSecond(second: Long, nanosecondAdjustment: Int): Instant {
             return fromSecondOfUnixEpoch(second, nanosecondAdjustment)
@@ -277,7 +277,7 @@ class Instant private constructor(
         @Deprecated(
             "Use fromSecondOfUnixEpoch() instead.",
             ReplaceWith("Instant.fromSecondOfUnixEpoch(second, nanosecondAdjustment)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochSecond(second: Long, nanosecondAdjustment: Long): Instant {
             return fromSecondOfUnixEpoch(second, nanosecondAdjustment)
@@ -286,7 +286,7 @@ class Instant private constructor(
         @Deprecated(
             "Use fromMillisecondOfUnixEpoch() instead.",
             ReplaceWith("Instant.fromMillisecondOfUnixEpoch(millisecond)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochMillisecond(millisecond: Long): Instant {
             return fromMillisecondOfUnixEpoch(millisecond)

--- a/core/src/commonMain/kotlin/io/islandtime/OffsetDateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/OffsetDateTime.kt
@@ -141,21 +141,21 @@ class OffsetDateTime(
     @Deprecated(
         "Use toYearMonth() instead.",
         ReplaceWith("this.toYearMonth()"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     inline val yearMonth: YearMonth get() = toYearMonth()
 
     @Deprecated(
         "Use toOffsetTime() instead.",
         ReplaceWith("this.toOffsetTime()"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     inline val offsetTime: OffsetTime get() = toOffsetTime()
 
     @Deprecated(
         "Use toInstant() instead.",
         ReplaceWith("this.toInstant()"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     inline val instant: Instant get() = toInstant()
 
@@ -374,7 +374,7 @@ class OffsetDateTime(
         @Deprecated(
             "Use fromMillisecondOfUnixEpoch() instead.",
             ReplaceWith("OffsetDateTime.fromMillisecondOfUnixEpoch(millisecond, offset)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochMillisecond(millisecond: Long, offset: UtcOffset): OffsetDateTime {
             return fromMillisecondOfUnixEpoch(millisecond, offset)
@@ -383,7 +383,7 @@ class OffsetDateTime(
         @Deprecated(
             "Use fromSecondOfUnixEpoch() instead.",
             ReplaceWith("OffsetDateTime.fromSecondOfUnixEpoch(second, nanoOfSecond, offset)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochSecond(second: Long, nanoOfSecond: Int, offset: UtcOffset): OffsetDateTime {
             return fromSecondOfUnixEpoch(second, nanoOfSecond, offset)
@@ -409,7 +409,7 @@ infix fun Instant.at(offset: UtcOffset) = OffsetDateTime(this.toDateTimeAt(offse
 @Deprecated(
     "Use 'toOffsetDateTime()' instead.",
     ReplaceWith("this.toOffsetDateTime()"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun ZonedDateTime.asOffsetDateTime() = toOffsetDateTime()
 

--- a/core/src/commonMain/kotlin/io/islandtime/TimeZone.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/TimeZone.kt
@@ -212,7 +212,7 @@ fun UtcOffset.asTimeZone(): TimeZone = TimeZone.FixedOffset(this)
 @Deprecated(
     "Use TimeZone() instead.",
     ReplaceWith("TimeZone(this)"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun String.toTimeZone() = TimeZone(this)
 

--- a/core/src/commonMain/kotlin/io/islandtime/ZonedDateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ZonedDateTime.kt
@@ -84,7 +84,7 @@ class ZonedDateTime private constructor(
     @Deprecated(
         "Use toYearMonth() instead.",
         ReplaceWith("this.toYearMonth()"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     inline val yearMonth: YearMonth
         get() = toYearMonth()
@@ -95,7 +95,7 @@ class ZonedDateTime private constructor(
     @Deprecated(
         "Use toOffsetTime() instead.",
         ReplaceWith("this.toOffsetTime()"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     inline val offsetTime: OffsetTime
         get() = toOffsetTime()
@@ -103,7 +103,7 @@ class ZonedDateTime private constructor(
     @Deprecated(
         "Use toOffsetDateTime() instead.",
         ReplaceWith("this.toOffsetDateTime()"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     inline val offsetDateTime: OffsetDateTime
         get() = toOffsetDateTime()
@@ -114,7 +114,7 @@ class ZonedDateTime private constructor(
     @Deprecated(
         "Use toInstant() instead.",
         ReplaceWith("this.toInstant()"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     inline val instant: Instant
         get() = toInstant()
@@ -486,7 +486,7 @@ class ZonedDateTime private constructor(
         @Deprecated(
             "Use fromMillisecondOfUnixEpoch() instead.",
             ReplaceWith("ZonedDateTime.fromMillisecondOfUnixEpoch(millisecond, zone)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochMillisecond(millisecond: Long, zone: TimeZone): ZonedDateTime {
             return fromMillisecondOfUnixEpoch(millisecond, zone)
@@ -495,7 +495,7 @@ class ZonedDateTime private constructor(
         @Deprecated(
             "Use fromSecondOfUnixEpoch() instead.",
             ReplaceWith("ZonedDateTime.fromSecondOfUnixEpoch(second, nanoOfSecond, zone)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         fun fromUnixEpochSecond(second: Long, nanoOfSecond: Int, zone: TimeZone): ZonedDateTime {
             return fromSecondOfUnixEpoch(second, nanoOfSecond, zone)
@@ -638,7 +638,7 @@ fun Date.endOfDayAt(zone: TimeZone): ZonedDateTime {
         "this.toZonedDateTime(zone, PRESERVE_LOCAL_TIME)",
         "io.islandtime.OffsetConversionStrategy.PRESERVE_LOCAL_TIME"
     ),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.similarLocalTimeAt(zone: TimeZone): ZonedDateTime {
     return toZonedDateTime(zone, OffsetConversionStrategy.PRESERVE_LOCAL_TIME)
@@ -650,7 +650,7 @@ fun OffsetDateTime.similarLocalTimeAt(zone: TimeZone): ZonedDateTime {
         "this.toZonedDateTime(zone, PRESERVE_LOCAL_TIME)",
         "io.islandtime.OffsetConversionStrategy.PRESERVE_LOCAL_TIME"
     ),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.dateTimeAt(zone: TimeZone): ZonedDateTime {
     return toZonedDateTime(zone, OffsetConversionStrategy.PRESERVE_LOCAL_TIME)
@@ -662,7 +662,7 @@ fun OffsetDateTime.dateTimeAt(zone: TimeZone): ZonedDateTime {
         "this.toZonedDateTime(zone, PRESERVE_INSTANT)",
         "io.islandtime.OffsetConversionStrategy.PRESERVE_INSTANT"
     ),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.sameInstantAt(zone: TimeZone): ZonedDateTime {
     return toZonedDateTime(zone, OffsetConversionStrategy.PRESERVE_INSTANT)
@@ -674,7 +674,7 @@ fun OffsetDateTime.sameInstantAt(zone: TimeZone): ZonedDateTime {
         "this.toZonedDateTime(zone, PRESERVE_INSTANT)",
         "io.islandtime.OffsetConversionStrategy.PRESERVE_INSTANT"
     ),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.instantAt(zone: TimeZone): ZonedDateTime {
     return toZonedDateTime(zone, OffsetConversionStrategy.PRESERVE_INSTANT)

--- a/core/src/commonMain/kotlin/io/islandtime/base/TimePoint.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/base/TimePoint.kt
@@ -17,7 +17,7 @@ interface TimePoint<T> {
     @Deprecated(
         "Use additionalNanosecondsSinceUnixEpoch instead.",
         ReplaceWith("this.additionalNanosecondsSinceUnixEpoch"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     val nanoOfSecondsSinceUnixEpoch: IntNanoseconds get() = additionalNanosecondsSinceUnixEpoch
 
@@ -34,7 +34,7 @@ interface TimePoint<T> {
     @Deprecated(
         "Use secondOfUnixEpoch instead.",
         ReplaceWith("this.secondOfUnixEpoch"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     val unixEpochSecond: Long get() = secondOfUnixEpoch
 
@@ -46,7 +46,7 @@ interface TimePoint<T> {
     @Deprecated(
         "Use nanosecond instead.",
         ReplaceWith("this.nanosecond"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     val unixEpochNanoOfSecond: Int get() = nanosecond
 
@@ -58,7 +58,7 @@ interface TimePoint<T> {
     @Deprecated(
         "Use millisecondOfUnixEpoch instead.",
         ReplaceWith("this.millisecondOfUnixEpoch"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     val unixEpochMillisecond: Long get() = millisecondOfUnixEpoch
 

--- a/core/src/commonMain/kotlin/io/islandtime/measures/Duration.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/measures/Duration.kt
@@ -111,42 +111,42 @@ class Duration private constructor(
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(DAYS)", "io.islandtime.measures.TimeUnit.DAYS"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     fun truncatedToDays() = truncatedTo(DAYS)
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(HOURS)", "io.islandtime.measures.TimeUnit.HOURS"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     fun truncatedToHours() = truncatedTo(HOURS)
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(MINUTES)", "io.islandtime.measures.TimeUnit.MINUTES"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     fun truncatedToMinutes() = truncatedTo(MINUTES)
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(SECONDS)", "io.islandtime.measures.TimeUnit.SECONDS"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     fun truncatedToSeconds() = truncatedTo(SECONDS)
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(MILLISECONDS)", "io.islandtime.measures.TimeUnit.MILLISECONDS"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     fun truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(MICROSECONDS)", "io.islandtime.measures.TimeUnit.MICROSECONDS"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     fun truncatedToMicroseconds() = truncatedTo(MICROSECONDS)
 

--- a/core/src/commonMain/kotlin/io/islandtime/operators/Truncation.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/operators/Truncation.kt
@@ -9,7 +9,7 @@ import io.islandtime.measures.TimeUnit.*
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(HOURS)", "io.islandtime.measures.TimeUnit.HOURS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun Time.truncatedToHours() = truncatedTo(HOURS)
 
@@ -19,7 +19,7 @@ fun Time.truncatedToHours() = truncatedTo(HOURS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MINUTES)", "io.islandtime.measures.TimeUnit.MINUTES"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun Time.truncatedToMinutes() = truncatedTo(MINUTES)
 
@@ -29,7 +29,7 @@ fun Time.truncatedToMinutes() = truncatedTo(MINUTES)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(SECONDS)", "io.islandtime.measures.TimeUnit.SECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun Time.truncatedToSeconds() = truncatedTo(SECONDS)
 
@@ -39,7 +39,7 @@ fun Time.truncatedToSeconds() = truncatedTo(SECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MILLISECONDS)", "io.islandtime.measures.TimeUnit.MILLISECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun Time.truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 
@@ -49,7 +49,7 @@ fun Time.truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MICROSECONDS)", "io.islandtime.measures.TimeUnit.MICROSECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun Time.truncatedToMicroseconds() = truncatedTo(MICROSECONDS)
 
@@ -59,7 +59,7 @@ fun Time.truncatedToMicroseconds() = truncatedTo(MICROSECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(HOURS)", "io.islandtime.measures.TimeUnit.HOURS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun DateTime.truncatedToHours() = truncatedTo(HOURS)
 
@@ -69,7 +69,7 @@ fun DateTime.truncatedToHours() = truncatedTo(HOURS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(TimeUnit.MINUTES)", "io.islandtime.measures.TimeUnit"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun DateTime.truncatedToMinutes() = truncatedTo(MINUTES)
 
@@ -79,7 +79,7 @@ fun DateTime.truncatedToMinutes() = truncatedTo(MINUTES)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(SECONDS)", "io.islandtime.measures.TimeUnit.SECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun DateTime.truncatedToSeconds() = truncatedTo(SECONDS)
 
@@ -89,7 +89,7 @@ fun DateTime.truncatedToSeconds() = truncatedTo(SECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MILLISECONDS)", "io.islandtime.measures.TimeUnit.MILLISECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun DateTime.truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 
@@ -99,7 +99,7 @@ fun DateTime.truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MICROSECONDS)", "io.islandtime.measures.TimeUnit.MICROSECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun DateTime.truncatedToMicroseconds() = truncatedTo(MICROSECONDS)
 
@@ -109,7 +109,7 @@ fun DateTime.truncatedToMicroseconds() = truncatedTo(MICROSECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(HOURS)", "io.islandtime.measures.TimeUnit.HOURS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun ZonedDateTime.truncatedToHours() = truncatedTo(HOURS)
 
@@ -119,7 +119,7 @@ fun ZonedDateTime.truncatedToHours() = truncatedTo(HOURS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MINUTES)", "io.islandtime.measures.TimeUnit.MINUTES"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun ZonedDateTime.truncatedToMinutes() = truncatedTo(MINUTES)
 
@@ -129,7 +129,7 @@ fun ZonedDateTime.truncatedToMinutes() = truncatedTo(MINUTES)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(SECONDS)", "io.islandtime.measures.TimeUnit.SECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun ZonedDateTime.truncatedToSeconds() = truncatedTo(SECONDS)
 
@@ -139,7 +139,7 @@ fun ZonedDateTime.truncatedToSeconds() = truncatedTo(SECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MILLISECONDS)", "io.islandtime.measures.TimeUnit.MILLISECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun ZonedDateTime.truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 
@@ -149,7 +149,7 @@ fun ZonedDateTime.truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MICROSECONDS)", "io.islandtime.measures.TimeUnit.MICROSECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun ZonedDateTime.truncatedToMicroseconds() = truncatedTo(MICROSECONDS)
 
@@ -159,7 +159,7 @@ fun ZonedDateTime.truncatedToMicroseconds() = truncatedTo(MICROSECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(HOURS)", "io.islandtime.measures.TimeUnit.HOURS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetTime.truncatedToHours() = truncatedTo(HOURS)
 
@@ -169,7 +169,7 @@ fun OffsetTime.truncatedToHours() = truncatedTo(HOURS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MINUTES)", "io.islandtime.measures.TimeUnit.MINUTES"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetTime.truncatedToMinutes() = truncatedTo(MINUTES)
 
@@ -179,7 +179,7 @@ fun OffsetTime.truncatedToMinutes() = truncatedTo(MINUTES)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(SECONDS)", "io.islandtime.measures.TimeUnit.SECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetTime.truncatedToSeconds() = truncatedTo(SECONDS)
 
@@ -189,7 +189,7 @@ fun OffsetTime.truncatedToSeconds() = truncatedTo(SECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MILLISECONDS)", "io.islandtime.measures.TimeUnit.MILLISECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetTime.truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 
@@ -199,7 +199,7 @@ fun OffsetTime.truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MICROSECONDS)", "io.islandtime.measures.TimeUnit.MICROSECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetTime.truncatedToMicroseconds() = truncatedTo(MICROSECONDS)
 
@@ -209,7 +209,7 @@ fun OffsetTime.truncatedToMicroseconds() = truncatedTo(MICROSECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(HOURS)", "io.islandtime.measures.TimeUnit.HOURS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.truncatedToHours() = truncatedTo(HOURS)
 
@@ -219,7 +219,7 @@ fun OffsetDateTime.truncatedToHours() = truncatedTo(HOURS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MINUTES)", "io.islandtime.measures.TimeUnit.MINUTES"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.truncatedToMinutes() = truncatedTo(MINUTES)
 
@@ -229,7 +229,7 @@ fun OffsetDateTime.truncatedToMinutes() = truncatedTo(MINUTES)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(SECONDS)", "io.islandtime.measures.TimeUnit.SECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.truncatedToSeconds() = truncatedTo(SECONDS)
 
@@ -239,7 +239,7 @@ fun OffsetDateTime.truncatedToSeconds() = truncatedTo(SECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MILLISECONDS)", "io.islandtime.measures.TimeUnit.MILLISECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 
@@ -249,6 +249,6 @@ fun OffsetDateTime.truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
 @Deprecated(
     "Use truncatedTo() instead.",
     ReplaceWith("truncatedTo(MICROSECONDS)", "io.islandtime.measures.TimeUnit.MICROSECONDS"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.truncatedToMicroseconds() = truncatedTo(MICROSECONDS)

--- a/core/src/commonMain/kotlin/io/islandtime/operators/Week.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/operators/Week.kt
@@ -12,7 +12,7 @@ import io.islandtime.ranges.*
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 val Date.weekRange: DateRange
     get() = startOfWeek.let { it..it + 6.days }
@@ -20,21 +20,21 @@ val Date.weekRange: DateRange
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week(settings)", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun Date.weekRange(settings: WeekSettings): DateRange = startOfWeek(settings).let { it..it + 6.days }
 
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week(locale)", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun Date.weekRange(locale: Locale): DateRange = startOfWeek(locale).let { it..it + 6.days }
 
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 val DateTime.weekInterval: DateTimeInterval
     get() = startOfWeek.let { it until it + 7.days }
@@ -42,7 +42,7 @@ val DateTime.weekInterval: DateTimeInterval
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week(settings)", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun DateTime.weekInterval(settings: WeekSettings): DateTimeInterval {
     return startOfWeek(settings).let { it until it + 7.days }
@@ -51,7 +51,7 @@ fun DateTime.weekInterval(settings: WeekSettings): DateTimeInterval {
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week(locale)", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun DateTime.weekInterval(locale: Locale): DateTimeInterval {
     return startOfWeek(locale).let { it until it + 7.days }
@@ -60,7 +60,7 @@ fun DateTime.weekInterval(locale: Locale): DateTimeInterval {
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 val OffsetDateTime.weekInterval: OffsetDateTimeInterval
     get() = startOfWeek.let { it until it + 7.days }
@@ -68,7 +68,7 @@ val OffsetDateTime.weekInterval: OffsetDateTimeInterval
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week(settings)", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.weekInterval(settings: WeekSettings): OffsetDateTimeInterval {
     return startOfWeek(settings).let { it until it + 7.days }
@@ -77,7 +77,7 @@ fun OffsetDateTime.weekInterval(settings: WeekSettings): OffsetDateTimeInterval 
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week(locale)", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTime.weekInterval(locale: Locale): OffsetDateTimeInterval {
     return startOfWeek(locale).let { it until it + 7.days }
@@ -86,7 +86,7 @@ fun OffsetDateTime.weekInterval(locale: Locale): OffsetDateTimeInterval {
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 val ZonedDateTime.weekInterval: ZonedDateTimeInterval
     get() = startOfWeek.let { it until it + 7.days }
@@ -94,7 +94,7 @@ val ZonedDateTime.weekInterval: ZonedDateTimeInterval
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week(settings)", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun ZonedDateTime.weekInterval(settings: WeekSettings): ZonedDateTimeInterval {
     return startOfWeek(settings).let { it until it + 7.days }
@@ -103,7 +103,7 @@ fun ZonedDateTime.weekInterval(settings: WeekSettings): ZonedDateTimeInterval {
 @Deprecated(
     "Renamed to 'week'.",
     ReplaceWith("this.week(locale)", "io.islandtime.week"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun ZonedDateTime.weekInterval(locale: Locale): ZonedDateTimeInterval {
     return startOfWeek(locale).let { it until it + 7.days }

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/InstantInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/InstantInterval.kt
@@ -153,13 +153,13 @@ infix fun Instant.until(to: Instant) = InstantInterval(this, to)
 @Deprecated(
     "Use toInstantInterval() instead.",
     ReplaceWith("this.toInstantInterval()"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun OffsetDateTimeInterval.asInstantInterval(): InstantInterval = toInstantInterval()
 
 @Deprecated(
     "Use toInstantInterval() instead.",
     ReplaceWith("this.toInstantInterval()"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun ZonedDateTimeInterval.asInstantInterval(): InstantInterval = toInstantInterval()

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/ZonedDateTimeInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/ZonedDateTimeInterval.kt
@@ -217,7 +217,7 @@ infix fun ZonedDateTime.until(to: ZonedDateTime) = ZonedDateTimeInterval(this, t
 @Deprecated(
     "Use 'at' instead.",
     ReplaceWith("this at zone"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 fun DateRange.toZonedDateTimeInterval(zone: TimeZone): ZonedDateTimeInterval = this at zone
 


### PR DESCRIPTION
With 0.3.0 coming out soon, it's time to change the warnings to errors. The plan is to remove anything at error level later on to get rid of any cruft generated in the lead up to a 1.0 release.