### PR TITLE
Revamp duration unit API

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,3 @@ dependencies {
     implementation("com.android.tools.build:gradle:4.1.3")
     implementation("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.16.1")
 }
-
-kotlinDslPluginOptions {
-    experimentalWarning.set(false)
-}

--- a/buildSrc/src/main/kotlin/multiplatform-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiplatform-library.gradle.kts
@@ -57,15 +57,20 @@ publishing {
     }
 }
 
+jacoco {
+    toolVersion = "0.8.7"
+}
+
 afterEvaluate {
     tasks.withType<JacocoReport>().configureEach {
         classDirectories.setFrom(
-            fileTree("${buildDir}/classes/kotlin/jvm/") {
-                exclude("**/*Test*.*")
-            }
+            fileTree("${buildDir}/classes/kotlin/jvm/") { exclude("**/*Test*.*") }
         )
 
-        sourceDirectories.setFrom(kotlin.sourceSets["commonMain"].kotlin.sourceDirectories)
+        sourceDirectories.setFrom(
+            listOf("commonMain", "jvmMain").flatMap { kotlin.sourceSets[it].kotlin.sourceDirectories }
+        )
+
         executionData.setFrom("${buildDir}/jacoco/jvmTest.exec")
     }
 }

--- a/core/MODULE.md
+++ b/core/MODULE.md
@@ -36,7 +36,7 @@ Platform-independent locale.
 
 # Package io.islandtime.measures
 
-Classes related to the measurement of time, including `Duration`, `Period`, and more specific units, such as `IntHours` or `LongYears`.
+Classes related to the measurement of time, including `Duration`, `Period`, and more specific units, such as `Hours` or `Years`.
 
 # Package io.islandtime.parser
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,6 +9,10 @@ kotlin {
     }
 
     sourceSets {
+        all {
+            resources.setSrcDirs(emptyList<String>())
+        }
+
         val commonMain by getting {
             kotlin.srcDirs("src/commonMain/generated")
 
@@ -22,6 +26,10 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
             }
+        }
+
+        val jvmMain by getting {
+            resources.srcDirs("src/jvmMain/resources")
         }
 
         val jvmTest by getting {

--- a/core/src/commonMain/generated/io/islandtime/_DateProperties.kt
+++ b/core/src/commonMain/generated/io/islandtime/_DateProperties.kt
@@ -14,8 +14,8 @@ import io.islandtime.`internal`.weekOfYearImpl
 import io.islandtime.calendar.WeekSettings
 import io.islandtime.calendar.weekSettings
 import io.islandtime.locale.Locale
-import io.islandtime.measures.IntDays
-import io.islandtime.measures.IntWeeks
+import io.islandtime.measures.Days
+import io.islandtime.measures.Weeks
 import io.islandtime.measures.days
 import io.islandtime.ranges.DateRange
 import io.islandtime.ranges.DateTimeInterval
@@ -182,19 +182,19 @@ public val Date.isLeapDay: Boolean
 /**
  * The length of this date's month in days.
  */
-public val Date.lengthOfMonth: IntDays
+public val Date.lengthOfMonth: Days
   get() = month.lengthIn(year)
 
 /**
  * The length of this date's year in days.
  */
-public val Date.lengthOfYear: IntDays
+public val Date.lengthOfYear: Days
   get() = lengthOfYear(year)
 
 /**
  * The length of the ISO week-based year that this date falls in, either 52 or 53 weeks.
  */
-public val Date.lengthOfWeekBasedYear: IntWeeks
+public val Date.lengthOfWeekBasedYear: Weeks
   get() = lengthOfWeekBasedYear(weekBasedYear)
 
 /**
@@ -391,19 +391,19 @@ public val DateTime.isInLeapDay: Boolean
 /**
  * The length of this date-time's month in days.
  */
-public val DateTime.lengthOfMonth: IntDays
+public val DateTime.lengthOfMonth: Days
   inline get() = date.lengthOfMonth
 
 /**
  * The length of this date-time's year in days.
  */
-public val DateTime.lengthOfYear: IntDays
+public val DateTime.lengthOfYear: Days
   inline get() = date.lengthOfYear
 
 /**
  * The length of the ISO week-based year that this date-time falls in, either 52 or 53 weeks.
  */
-public val DateTime.lengthOfWeekBasedYear: IntWeeks
+public val DateTime.lengthOfWeekBasedYear: Weeks
   inline get() = date.lengthOfWeekBasedYear
 
 /**
@@ -586,19 +586,19 @@ public val OffsetDateTime.isInLeapDay: Boolean
 /**
  * The length of this date-time's month in days.
  */
-public val OffsetDateTime.lengthOfMonth: IntDays
+public val OffsetDateTime.lengthOfMonth: Days
   inline get() = dateTime.lengthOfMonth
 
 /**
  * The length of this date-time's year in days.
  */
-public val OffsetDateTime.lengthOfYear: IntDays
+public val OffsetDateTime.lengthOfYear: Days
   inline get() = dateTime.lengthOfYear
 
 /**
  * The length of the ISO week-based year that this date-time falls in, either 52 or 53 weeks.
  */
-public val OffsetDateTime.lengthOfWeekBasedYear: IntWeeks
+public val OffsetDateTime.lengthOfWeekBasedYear: Weeks
   inline get() = dateTime.lengthOfWeekBasedYear
 
 /**
@@ -783,19 +783,19 @@ public val ZonedDateTime.isInLeapDay: Boolean
 /**
  * The length of this date-time's month in days.
  */
-public val ZonedDateTime.lengthOfMonth: IntDays
+public val ZonedDateTime.lengthOfMonth: Days
   inline get() = dateTime.lengthOfMonth
 
 /**
  * The length of this date-time's year in days.
  */
-public val ZonedDateTime.lengthOfYear: IntDays
+public val ZonedDateTime.lengthOfYear: Days
   inline get() = dateTime.lengthOfYear
 
 /**
  * The length of the ISO week-based year that this date-time falls in, either 52 or 53 weeks.
  */
-public val ZonedDateTime.lengthOfWeekBasedYear: IntWeeks
+public val ZonedDateTime.lengthOfWeekBasedYear: Weeks
   inline get() = dateTime.lengthOfWeekBasedYear
 
 /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Centuries.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Centuries.kt
@@ -17,6 +17,7 @@ import io.islandtime.`internal`.MONTHS_PER_CENTURY
 import io.islandtime.`internal`.YEARS_PER_CENTURY
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -85,16 +86,31 @@ public value class IntCenturies(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.centuries"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.centuries"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.centuries"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntCenturies): Int = `value`.compareTo(other.`value`)
@@ -300,16 +316,31 @@ public value class LongCenturies(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.centuries"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.centuries"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.centuries"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongCenturies): Int = `value`.compareTo(other.`value`)
@@ -439,6 +470,11 @@ public value class LongCenturies(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Centuries.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Centuries.kt
@@ -18,6 +18,7 @@ import io.islandtime.`internal`.YEARS_PER_CENTURY
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -27,291 +28,70 @@ import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 import kotlin.math.absoluteValue
 
-/**
- * A number of centuries.
- */
+@Deprecated(
+  message = "Replace with Centuries.",
+  replaceWith = ReplaceWith("Centuries"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntCenturies = Centuries
+
+@Deprecated(
+  message = "Replace with Centuries.",
+  replaceWith = ReplaceWith("Centuries"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongCenturies = Centuries
+
 @JvmInline
-public value class IntCenturies(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntCenturies> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntCenturies
-    get() = IntCenturies(absExact(`value`))
-
-  /**
-   * Converts this duration to months.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inMonths: IntMonths
-    get() = (`value` timesExact MONTHS_PER_CENTURY).months
-
-  /**
-   * Converts this duration to months without checking for overflow.
-   */
-  internal val inMonthsUnchecked: IntMonths
-    get() = (`value` * MONTHS_PER_CENTURY).months
-
-  /**
-   * Converts this duration to years.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inYears: IntYears
-    get() = (`value` timesExact YEARS_PER_CENTURY).years
-
-  /**
-   * Converts this duration to years without checking for overflow.
-   */
-  internal val inYearsUnchecked: IntYears
-    get() = (`value` * YEARS_PER_CENTURY).years
-
-  /**
-   * Converts this duration to decades.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inDecades: IntDecades
-    get() = (`value` timesExact DECADES_PER_CENTURY).decades
-
-  /**
-   * Converts this duration to decades without checking for overflow.
-   */
-  internal val inDecadesUnchecked: IntDecades
-    get() = (`value` * DECADES_PER_CENTURY).decades
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.centuries"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.centuries"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.centuries"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntCenturies): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return when (`value`) {
-       0 -> "P0Y"
-       Int.MIN_VALUE -> "-P2147483648Y"
-       else -> buildString {
-         if (`value` < 0) { append('-') }
-         append("P")
-         append(`value`.absoluteValue timesExact 100)
-         append('Y')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntCenturies = IntCenturies(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntCenturies = IntCenturies(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): IntCenturies = IntCenturies(`value` timesExact scalar)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongCenturies = this.toLongCenturies() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntCenturies {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntCenturies(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongCenturies = this.toLongCenturies() / scalar
-
-  public operator fun rem(scalar: Int): IntCenturies = IntCenturies(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongCenturies = this.toLongCenturies() % scalar
-
-  public operator fun plus(months: IntMonths): IntMonths = this.inMonths + months
-
-  public operator fun minus(months: IntMonths): IntMonths = this.inMonths - months
-
-  public operator fun plus(months: LongMonths): LongMonths = this.toLongCenturies().inMonths +
-      months
-
-  public operator fun minus(months: LongMonths): LongMonths = this.toLongCenturies().inMonths -
-      months
-
-  public operator fun plus(years: IntYears): IntYears = this.inYears + years
-
-  public operator fun minus(years: IntYears): IntYears = this.inYears - years
-
-  public operator fun plus(years: LongYears): LongYears = this.toLongCenturies().inYears + years
-
-  public operator fun minus(years: LongYears): LongYears = this.toLongCenturies().inYears - years
-
-  public operator fun plus(decades: IntDecades): IntDecades = this.inDecades + decades
-
-  public operator fun minus(decades: IntDecades): IntDecades = this.inDecades - decades
-
-  public operator fun plus(decades: LongDecades): LongDecades = this.toLongCenturies().inDecades +
-      decades
-
-  public operator fun minus(decades: LongDecades): LongDecades = this.toLongCenturies().inDecades -
-      decades
-
-  public operator fun plus(centuries: IntCenturies): IntCenturies = IntCenturies(`value` plusExact
-      centuries.value)
-
-  public operator fun minus(centuries: IntCenturies): IntCenturies = IntCenturies(`value` minusExact
-      centuries.value)
-
-  public operator fun plus(centuries: LongCenturies): LongCenturies =
-      LongCenturies(`value`.toLong() plusExact centuries.value)
-
-  public operator fun minus(centuries: LongCenturies): LongCenturies =
-      LongCenturies(`value`.toLong() minusExact centuries.value)
-
-  /**
-   * Converts this duration to [LongCenturies].
-   */
-  public fun toLongCenturies(): LongCenturies = LongCenturies(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntCenturies = IntCenturies(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntCenturies = IntCenturies(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of centuries.
- */
-public val Int.centuries: IntCenturies
-  get() = IntCenturies(this)
-
-/**
- * Multiplies this value by a duration of centuries.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(centuries: IntCenturies): IntCenturies = centuries * this
-
-/**
- * Multiplies this value by a duration of centuries.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(centuries: IntCenturies): LongCenturies = centuries * this
-
-/**
- * A number of centuries.
- */
-@JvmInline
-public value class LongCenturies(
+public value class Centuries(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongCenturies> {
+) : Comparable<Centuries> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongCenturies
-    get() = LongCenturies(absExact(`value`))
+  public val absoluteValue: Centuries
+    get() = Centuries(absExact(value))
 
   /**
-   * Converts this duration to months.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to months. @throws ArithmeticException if overflow occurs
    */
-  public val inMonths: LongMonths
-    get() = (`value` timesExact MONTHS_PER_CENTURY).months
+  public val inMonths: Months
+    get() = Months(value timesExact MONTHS_PER_CENTURY)
 
   /**
    * Converts this duration to months without checking for overflow.
    */
-  internal val inMonthsUnchecked: LongMonths
-    get() = (`value` * MONTHS_PER_CENTURY).months
+  internal val inMonthsUnchecked: Months
+    get() = Months(value * MONTHS_PER_CENTURY)
 
   /**
-   * Converts this duration to years.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to years. @throws ArithmeticException if overflow occurs
    */
-  public val inYears: LongYears
-    get() = (`value` timesExact YEARS_PER_CENTURY).years
+  public val inYears: Years
+    get() = Years(value timesExact YEARS_PER_CENTURY)
 
   /**
    * Converts this duration to years without checking for overflow.
    */
-  internal val inYearsUnchecked: LongYears
-    get() = (`value` * YEARS_PER_CENTURY).years
+  internal val inYearsUnchecked: Years
+    get() = Years(value * YEARS_PER_CENTURY)
 
   /**
-   * Converts this duration to decades.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to decades. @throws ArithmeticException if overflow occurs
    */
-  public val inDecades: LongDecades
-    get() = (`value` timesExact DECADES_PER_CENTURY).decades
+  public val inDecades: Decades
+    get() = Decades(value timesExact DECADES_PER_CENTURY)
 
   /**
    * Converts this duration to decades without checking for overflow.
    */
-  internal val inDecadesUnchecked: LongDecades
-    get() = (`value` * DECADES_PER_CENTURY).decades
+  internal val inDecadesUnchecked: Decades
+    get() = Decades(value * DECADES_PER_CENTURY)
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -321,7 +101,7 @@ public value class LongCenturies(
     replaceWith = ReplaceWith("this == 0L.centuries"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -331,7 +111,7 @@ public value class LongCenturies(
     replaceWith = ReplaceWith("this < 0L.centuries"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -341,168 +121,170 @@ public value class LongCenturies(
     replaceWith = ReplaceWith("this > 0L.centuries"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongCenturies): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Centuries): Int = value.compareTo(other.value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return when (`value`) {
+     return when (value) {
        0L -> "P0Y"
        Long.MIN_VALUE -> "-P9223372036854775808Y"
        else -> buildString {
-         if (`value` < 0) { append('-') }
+         if (value < 0) { append('-') }
          append("P")
-         append(`value`.absoluteValue timesExact 100)
+         append(value.absoluteValue timesExact 100)
          append('Y')
        }
      }
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongCenturies = LongCenturies(`value`.negateExact())
+  public operator fun unaryMinus(): Centuries = Centuries(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongCenturies = LongCenturies(-`value`)
+  internal fun negateUnchecked(): Centuries = Centuries(-value)
+
+  public operator fun plus(months: Months): Months = this.inMonths + months
+
+  public operator fun minus(months: Months): Months = this.inMonths - months
+
+  public operator fun plus(years: Years): Years = this.inYears + years
+
+  public operator fun minus(years: Years): Years = this.inYears - years
+
+  public operator fun plus(decades: Decades): Decades = this.inDecades + decades
+
+  public operator fun minus(decades: Decades): Decades = this.inDecades - decades
+
+  public operator fun plus(centuries: Centuries): Centuries = Centuries(value plusExact
+      centuries.value)
+
+  public operator fun minus(centuries: Centuries): Centuries = Centuries(value minusExact
+      centuries.value)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongCenturies = LongCenturies(`value` timesExact scalar)
+  public operator fun times(scalar: Int): Centuries = Centuries(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongCenturies = LongCenturies(`value` timesExact scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongCenturies {
+  public operator fun div(scalar: Int): Centuries {
      return if (scalar == -1) {
        -this
      } else {
-       LongCenturies(`value` / scalar)
+       Centuries(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongCenturies {
+  public operator fun rem(scalar: Int): Centuries = Centuries(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Centuries = Centuries(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Centuries {
      return if (scalar == -1L) {
        -this
      } else {
-       LongCenturies(`value` / scalar)
+       Centuries(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongCenturies = LongCenturies(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongCenturies = LongCenturies(`value` % scalar)
-
-  public operator fun plus(months: IntMonths): LongMonths = this.inMonths + months
-
-  public operator fun minus(months: IntMonths): LongMonths = this.inMonths - months
-
-  public operator fun plus(months: LongMonths): LongMonths = this.inMonths + months
-
-  public operator fun minus(months: LongMonths): LongMonths = this.inMonths - months
-
-  public operator fun plus(years: IntYears): LongYears = this.inYears + years
-
-  public operator fun minus(years: IntYears): LongYears = this.inYears - years
-
-  public operator fun plus(years: LongYears): LongYears = this.inYears + years
-
-  public operator fun minus(years: LongYears): LongYears = this.inYears - years
-
-  public operator fun plus(decades: IntDecades): LongDecades = this.inDecades + decades
-
-  public operator fun minus(decades: IntDecades): LongDecades = this.inDecades - decades
-
-  public operator fun plus(decades: LongDecades): LongDecades = this.inDecades + decades
-
-  public operator fun minus(decades: LongDecades): LongDecades = this.inDecades - decades
-
-  public operator fun plus(centuries: IntCenturies): LongCenturies = LongCenturies(`value` plusExact
-      centuries.value)
-
-  public operator fun minus(centuries: IntCenturies): LongCenturies =
-      LongCenturies(`value` minusExact centuries.value)
-
-  public operator fun plus(centuries: LongCenturies): LongCenturies =
-      LongCenturies(`value` plusExact centuries.value)
-
-  public operator fun minus(centuries: LongCenturies): LongCenturies =
-      LongCenturies(`value` minusExact centuries.value)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Centuries = Centuries(value % scalar)
 
   /**
-   * Converts this duration to [IntCenturies].
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  public fun toIntCenturies(): IntCenturies = IntCenturies(`value`.toIntExact())
-
-  /**
-   * Converts this duration to [IntCenturies] without checking for overflow.
-   */
-  @PublishedApi
-  internal fun toIntCenturiesUnchecked(): IntCenturies = IntCenturies(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntCenturies]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntCenturies(): Centuries = this
+
+  /**
+   * Converts this duration to [IntCenturies] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntCenturiesUnchecked(): Centuries = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongCenturies = LongCenturies(Long.MIN_VALUE)
+    public val MIN: Centuries = Centuries(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongCenturies = LongCenturies(Long.MAX_VALUE)
+    public val MAX: Centuries = Centuries(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of centuries.
  */
-public val Long.centuries: LongCenturies
-  get() = LongCenturies(this)
+public val Int.centuries: Centuries
+  get() = Centuries(this)
 
 /**
- * Multiplies this value by a duration of centuries.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of centuries. @throws ArithmeticException if overflow occurs
  */
-public operator fun Int.times(centuries: LongCenturies): LongCenturies = centuries * this
+public operator fun Int.times(centuries: Centuries): Centuries = centuries * this
 
 /**
- * Multiplies this value by a duration of centuries.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of centuries.
  */
-public operator fun Long.times(centuries: LongCenturies): LongCenturies = centuries * this
+public val Long.centuries: Centuries
+  get() = Centuries(this)
+
+/**
+ * Multiplies this value by a duration of centuries. @throws ArithmeticException if overflow occurs
+ */
+public operator fun Long.times(centuries: Centuries): Centuries = centuries * this

--- a/core/src/commonMain/generated/io/islandtime/measures/_Days.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Days.kt
@@ -21,6 +21,7 @@ import io.islandtime.`internal`.NANOSECONDS_PER_DAY
 import io.islandtime.`internal`.SECONDS_PER_DAY
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -130,16 +131,31 @@ public value class IntDays(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.days"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.days"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.days"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntDays): Int = `value`.compareTo(other.`value`)
@@ -444,16 +460,31 @@ public value class LongDays(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.days"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.days"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.days"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongDays): Int = `value`.compareTo(other.`value`)
@@ -635,6 +666,11 @@ public value class LongDays(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Days.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Days.kt
@@ -19,9 +19,11 @@ import io.islandtime.`internal`.MILLISECONDS_PER_DAY
 import io.islandtime.`internal`.MINUTES_PER_DAY
 import io.islandtime.`internal`.NANOSECONDS_PER_DAY
 import io.islandtime.`internal`.SECONDS_PER_DAY
+import io.islandtime.`internal`.deprecatedToError
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -34,428 +36,120 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Duration as KotlinDuration
 import kotlin.time.DurationUnit as KotlinDurationUnit
 
-/**
- * A number of days.
- */
+@Deprecated(
+  message = "Replace with Days.",
+  replaceWith = ReplaceWith("Days"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntDays = Days
+
+@Deprecated(
+  message = "Replace with Days.",
+  replaceWith = ReplaceWith("Days"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongDays = Days
+
 @JvmInline
-public value class IntDays(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntDays> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntDays
-    get() = IntDays(absExact(`value`))
-
-  /**
-   * Converts this duration to nanoseconds.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value`.toLong() timesExact NANOSECONDS_PER_DAY).nanoseconds
-
-  /**
-   * Converts this duration to nanoseconds without checking for overflow.
-   */
-  internal val inNanosecondsUnchecked: LongNanoseconds
-    get() = (`value`.toLong() * NANOSECONDS_PER_DAY).nanoseconds
-
-  /**
-   * Converts this duration to microseconds.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value`.toLong() timesExact MICROSECONDS_PER_DAY).microseconds
-
-  /**
-   * Converts this duration to microseconds without checking for overflow.
-   */
-  internal val inMicrosecondsUnchecked: LongMicroseconds
-    get() = (`value`.toLong() * MICROSECONDS_PER_DAY).microseconds
-
-  /**
-   * Converts this duration to milliseconds.
-   */
-  public val inMilliseconds: LongMilliseconds
-    get() = (`value`.toLong() * MILLISECONDS_PER_DAY).milliseconds
-
-  /**
-   * Converts this duration to seconds.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inSeconds: IntSeconds
-    get() = (`value` timesExact SECONDS_PER_DAY).seconds
-
-  /**
-   * Converts this duration to seconds without checking for overflow.
-   */
-  internal val inSecondsUnchecked: IntSeconds
-    get() = (`value` * SECONDS_PER_DAY).seconds
-
-  /**
-   * Converts this duration to minutes.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inMinutes: IntMinutes
-    get() = (`value` timesExact MINUTES_PER_DAY).minutes
-
-  /**
-   * Converts this duration to minutes without checking for overflow.
-   */
-  internal val inMinutesUnchecked: IntMinutes
-    get() = (`value` * MINUTES_PER_DAY).minutes
-
-  /**
-   * Converts this duration to hours.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inHours: IntHours
-    get() = (`value` timesExact HOURS_PER_DAY).hours
-
-  /**
-   * Converts this duration to hours without checking for overflow.
-   */
-  internal val inHoursUnchecked: IntHours
-    get() = (`value` * HOURS_PER_DAY).hours
-
-  /**
-   * Converts this duration to the number of whole weeks.
-   */
-  public val inWeeks: IntWeeks
-    get() = (`value` / DAYS_PER_WEEK).weeks
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.days"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.days"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.days"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntDays): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return when (`value`) {
-       0 -> "P0D"
-       Int.MIN_VALUE -> "-P2147483648D"
-       else -> buildString {
-         if (`value` < 0) { append('-') }
-         append("P")
-         append(`value`.absoluteValue)
-         append('D')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntDays = IntDays(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntDays = IntDays(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): IntDays = IntDays(`value` timesExact scalar)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongDays = this.toLongDays() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntDays {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntDays(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongDays = this.toLongDays() / scalar
-
-  public operator fun rem(scalar: Int): IntDays = IntDays(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongDays = this.toLongDays() % scalar
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongDays().inNanoseconds + nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongDays().inNanoseconds - nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds -
-      microseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.toLongDays().inMicroseconds + microseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.toLongDays().inMicroseconds - microseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds -
-      milliseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.toLongDays().inMilliseconds + milliseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.toLongDays().inMilliseconds - milliseconds
-
-  public operator fun plus(seconds: IntSeconds): IntSeconds = this.inSeconds + seconds
-
-  public operator fun minus(seconds: IntSeconds): IntSeconds = this.inSeconds - seconds
-
-  public operator fun plus(seconds: LongSeconds): LongSeconds = this.toLongDays().inSeconds +
-      seconds
-
-  public operator fun minus(seconds: LongSeconds): LongSeconds = this.toLongDays().inSeconds -
-      seconds
-
-  public operator fun plus(minutes: IntMinutes): IntMinutes = this.inMinutes + minutes
-
-  public operator fun minus(minutes: IntMinutes): IntMinutes = this.inMinutes - minutes
-
-  public operator fun plus(minutes: LongMinutes): LongMinutes = this.toLongDays().inMinutes +
-      minutes
-
-  public operator fun minus(minutes: LongMinutes): LongMinutes = this.toLongDays().inMinutes -
-      minutes
-
-  public operator fun plus(hours: IntHours): IntHours = this.inHours + hours
-
-  public operator fun minus(hours: IntHours): IntHours = this.inHours - hours
-
-  public operator fun plus(hours: LongHours): LongHours = this.toLongDays().inHours + hours
-
-  public operator fun minus(hours: LongHours): LongHours = this.toLongDays().inHours - hours
-
-  public operator fun plus(days: IntDays): IntDays = IntDays(`value` plusExact days.value)
-
-  public operator fun minus(days: IntDays): IntDays = IntDays(`value` minusExact days.value)
-
-  public operator fun plus(days: LongDays): LongDays = LongDays(`value`.toLong() plusExact
-      days.value)
-
-  public operator fun minus(days: LongDays): LongDays = LongDays(`value`.toLong() minusExact
-      days.value)
-
-  public operator fun plus(weeks: IntWeeks): IntDays = this + weeks.inDays
-
-  public operator fun minus(weeks: IntWeeks): IntDays = this - weeks.inDays
-
-  public operator fun plus(weeks: LongWeeks): LongDays = this.toLongDays() + weeks.inDays
-
-  public operator fun minus(weeks: LongWeeks): LongDays = this.toLongDays() - weeks.inDays
-
-  public inline fun <T> toComponents(action: (weeks: IntWeeks, days: IntDays) -> T): T {
-    val weeks = (`value` / DAYS_PER_WEEK).weeks
-    val days = (`value` % DAYS_PER_WEEK).days
-    return action(weeks, days)
-  }
-
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.days(`value`)
-
-  /**
-   * Converts this duration to [LongDays].
-   */
-  public fun toLongDays(): LongDays = LongDays(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntDays = IntDays(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntDays = IntDays(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of days.
- */
-public val Int.days: IntDays
-  get() = IntDays(this)
-
-/**
- * Multiplies this value by a duration of days.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(days: IntDays): IntDays = days * this
-
-/**
- * Multiplies this value by a duration of days.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(days: IntDays): LongDays = days * this
-
-/**
- * A number of days.
- */
-@JvmInline
-public value class LongDays(
+public value class Days(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongDays> {
+) : Comparable<Days> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongDays
-    get() = LongDays(absExact(`value`))
+  public val absoluteValue: Days
+    get() = Days(absExact(value))
 
   /**
-   * Converts this duration to nanoseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to nanoseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value` timesExact NANOSECONDS_PER_DAY).nanoseconds
+  public val inNanoseconds: Nanoseconds
+    get() = Nanoseconds(value timesExact NANOSECONDS_PER_DAY)
 
   /**
    * Converts this duration to nanoseconds without checking for overflow.
    */
-  internal val inNanosecondsUnchecked: LongNanoseconds
-    get() = (`value` * NANOSECONDS_PER_DAY).nanoseconds
+  internal val inNanosecondsUnchecked: Nanoseconds
+    get() = Nanoseconds(value * NANOSECONDS_PER_DAY)
 
   /**
-   * Converts this duration to microseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to microseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value` timesExact MICROSECONDS_PER_DAY).microseconds
+  public val inMicroseconds: Microseconds
+    get() = Microseconds(value timesExact MICROSECONDS_PER_DAY)
 
   /**
    * Converts this duration to microseconds without checking for overflow.
    */
-  internal val inMicrosecondsUnchecked: LongMicroseconds
-    get() = (`value` * MICROSECONDS_PER_DAY).microseconds
+  internal val inMicrosecondsUnchecked: Microseconds
+    get() = Microseconds(value * MICROSECONDS_PER_DAY)
 
   /**
-   * Converts this duration to milliseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to milliseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inMilliseconds: LongMilliseconds
-    get() = (`value` timesExact MILLISECONDS_PER_DAY).milliseconds
+  public val inMilliseconds: Milliseconds
+    get() = Milliseconds(value timesExact MILLISECONDS_PER_DAY)
 
   /**
    * Converts this duration to milliseconds without checking for overflow.
    */
-  internal val inMillisecondsUnchecked: LongMilliseconds
-    get() = (`value` * MILLISECONDS_PER_DAY).milliseconds
+  internal val inMillisecondsUnchecked: Milliseconds
+    get() = Milliseconds(value * MILLISECONDS_PER_DAY)
 
   /**
-   * Converts this duration to seconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to seconds. @throws ArithmeticException if overflow occurs
    */
-  public val inSeconds: LongSeconds
-    get() = (`value` timesExact SECONDS_PER_DAY).seconds
+  public val inSeconds: Seconds
+    get() = Seconds(value timesExact SECONDS_PER_DAY)
 
   /**
    * Converts this duration to seconds without checking for overflow.
    */
-  internal val inSecondsUnchecked: LongSeconds
-    get() = (`value` * SECONDS_PER_DAY).seconds
+  internal val inSecondsUnchecked: Seconds
+    get() = Seconds(value * SECONDS_PER_DAY)
 
   /**
-   * Converts this duration to minutes.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to minutes. @throws ArithmeticException if overflow occurs
    */
-  public val inMinutes: LongMinutes
-    get() = (`value` timesExact MINUTES_PER_DAY).minutes
+  public val inMinutes: Minutes
+    get() = Minutes(value timesExact MINUTES_PER_DAY)
 
   /**
    * Converts this duration to minutes without checking for overflow.
    */
-  internal val inMinutesUnchecked: LongMinutes
-    get() = (`value` * MINUTES_PER_DAY).minutes
+  internal val inMinutesUnchecked: Minutes
+    get() = Minutes(value * MINUTES_PER_DAY)
 
   /**
-   * Converts this duration to hours.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to hours. @throws ArithmeticException if overflow occurs
    */
-  public val inHours: LongHours
-    get() = (`value` timesExact HOURS_PER_DAY).hours
+  public val inHours: Hours
+    get() = Hours(value timesExact HOURS_PER_DAY)
 
   /**
    * Converts this duration to hours without checking for overflow.
    */
-  internal val inHoursUnchecked: LongHours
-    get() = (`value` * HOURS_PER_DAY).hours
+  internal val inHoursUnchecked: Hours
+    get() = Hours(value * HOURS_PER_DAY)
 
   /**
    * Converts this duration to the number of whole weeks.
    */
-  public val inWeeks: LongWeeks
-    get() = (`value` / DAYS_PER_WEEK).weeks
+  public val inWholeWeeks: Weeks
+    get() = Weeks(value / DAYS_PER_WEEK)
+
+  @Deprecated(
+    message = "Use inWholeWeeks instead.",
+    replaceWith = ReplaceWith("this.inWholeWeeks"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inWeeks: Weeks
+    get() = deprecatedToError()
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -465,7 +159,7 @@ public value class LongDays(
     replaceWith = ReplaceWith("this == 0L.days"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -475,7 +169,7 @@ public value class LongDays(
     replaceWith = ReplaceWith("this < 0L.days"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -485,226 +179,213 @@ public value class LongDays(
     replaceWith = ReplaceWith("this > 0L.days"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongDays): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Days): Int = value.compareTo(other.value)
+
+  /**
+   * Converts this duration to a [kotlin.time.Duration].
+   */
+  @ExperimentalTime
+  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.days(value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return when (`value`) {
+     return when (value) {
        0L -> "P0D"
        Long.MIN_VALUE -> "-P9223372036854775808D"
        else -> buildString {
-         if (`value` < 0) { append('-') }
+         if (value < 0) { append('-') }
          append("P")
-         append(`value`.absoluteValue)
+         append(value.absoluteValue)
          append('D')
        }
      }
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongDays = LongDays(`value`.negateExact())
+  public operator fun unaryMinus(): Days = Days(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongDays = LongDays(-`value`)
+  internal fun negateUnchecked(): Days = Days(-value)
+
+  public operator fun plus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds + nanoseconds
+
+  public operator fun minus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds -
+      nanoseconds
+
+  public operator fun plus(microseconds: Microseconds): Microseconds = this.inMicroseconds +
+      microseconds
+
+  public operator fun minus(microseconds: Microseconds): Microseconds = this.inMicroseconds -
+      microseconds
+
+  public operator fun plus(milliseconds: Milliseconds): Milliseconds = this.inMilliseconds +
+      milliseconds
+
+  public operator fun minus(milliseconds: Milliseconds): Milliseconds = this.inMilliseconds -
+      milliseconds
+
+  public operator fun plus(seconds: Seconds): Seconds = this.inSeconds + seconds
+
+  public operator fun minus(seconds: Seconds): Seconds = this.inSeconds - seconds
+
+  public operator fun plus(minutes: Minutes): Minutes = this.inMinutes + minutes
+
+  public operator fun minus(minutes: Minutes): Minutes = this.inMinutes - minutes
+
+  public operator fun plus(hours: Hours): Hours = this.inHours + hours
+
+  public operator fun minus(hours: Hours): Hours = this.inHours - hours
+
+  public operator fun plus(days: Days): Days = Days(value plusExact days.value)
+
+  public operator fun minus(days: Days): Days = Days(value minusExact days.value)
+
+  public operator fun plus(weeks: Weeks): Days = this + weeks.inDays
+
+  public operator fun minus(weeks: Weeks): Days = this - weeks.inDays
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongDays = LongDays(`value` timesExact scalar)
+  public operator fun times(scalar: Int): Days = Days(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongDays = LongDays(`value` timesExact scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongDays {
+  public operator fun div(scalar: Int): Days {
      return if (scalar == -1) {
        -this
      } else {
-       LongDays(`value` / scalar)
+       Days(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongDays {
+  public operator fun rem(scalar: Int): Days = Days(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Days = Days(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Days {
      return if (scalar == -1L) {
        -this
      } else {
-       LongDays(`value` / scalar)
+       Days(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongDays = LongDays(`value` % scalar)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Days = Days(value % scalar)
 
-  public operator fun rem(scalar: Long): LongDays = LongDays(`value` % scalar)
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds -
-      microseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.inMicroseconds - microseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds -
-      milliseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.inMilliseconds - milliseconds
-
-  public operator fun plus(seconds: IntSeconds): LongSeconds = this.inSeconds + seconds
-
-  public operator fun minus(seconds: IntSeconds): LongSeconds = this.inSeconds - seconds
-
-  public operator fun plus(seconds: LongSeconds): LongSeconds = this.inSeconds + seconds
-
-  public operator fun minus(seconds: LongSeconds): LongSeconds = this.inSeconds - seconds
-
-  public operator fun plus(minutes: IntMinutes): LongMinutes = this.inMinutes + minutes
-
-  public operator fun minus(minutes: IntMinutes): LongMinutes = this.inMinutes - minutes
-
-  public operator fun plus(minutes: LongMinutes): LongMinutes = this.inMinutes + minutes
-
-  public operator fun minus(minutes: LongMinutes): LongMinutes = this.inMinutes - minutes
-
-  public operator fun plus(hours: IntHours): LongHours = this.inHours + hours
-
-  public operator fun minus(hours: IntHours): LongHours = this.inHours - hours
-
-  public operator fun plus(hours: LongHours): LongHours = this.inHours + hours
-
-  public operator fun minus(hours: LongHours): LongHours = this.inHours - hours
-
-  public operator fun plus(days: IntDays): LongDays = LongDays(`value` plusExact days.value)
-
-  public operator fun minus(days: IntDays): LongDays = LongDays(`value` minusExact days.value)
-
-  public operator fun plus(days: LongDays): LongDays = LongDays(`value` plusExact days.value)
-
-  public operator fun minus(days: LongDays): LongDays = LongDays(`value` minusExact days.value)
-
-  public operator fun plus(weeks: IntWeeks): LongDays = this + weeks.inDays
-
-  public operator fun minus(weeks: IntWeeks): LongDays = this - weeks.inDays
-
-  public operator fun plus(weeks: LongWeeks): LongDays = this + weeks.inDays
-
-  public operator fun minus(weeks: LongWeeks): LongDays = this - weeks.inDays
-
-  public inline fun <T> toComponents(action: (weeks: LongWeeks, days: IntDays) -> T): T {
-    val weeks = (`value` / DAYS_PER_WEEK).weeks
-    val days = (`value` % DAYS_PER_WEEK).toInt().days
+  public inline fun <T> toComponentValues(action: (weeks: Long, days: Int) -> T): T {
+    val weeks = (value / DAYS_PER_WEEK)
+    val days = (value % DAYS_PER_WEEK).toInt()
     return action(weeks, days)
   }
 
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.days(`value`)
+  public inline fun <T> toComponents(action: (weeks: Weeks, days: Days) -> T): T {
+     return toComponentValues { weeks, days ->
+         action(Weeks(weeks), Days(days))
+     }
+  }
 
   /**
-   * Converts this duration to [IntDays].
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  public fun toIntDays(): IntDays = IntDays(`value`.toIntExact())
-
-  /**
-   * Converts this duration to [IntDays] without checking for overflow.
-   */
-  @PublishedApi
-  internal fun toIntDaysUnchecked(): IntDays = IntDays(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntDays]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntDays(): Days = this
+
+  /**
+   * Converts this duration to [IntDays] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntDaysUnchecked(): Days = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongDays = LongDays(Long.MIN_VALUE)
+    public val MIN: Days = Days(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongDays = LongDays(Long.MAX_VALUE)
+    public val MAX: Days = Days(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of days.
  */
-public val Long.days: LongDays
-  get() = LongDays(this)
+public val Int.days: Days
+  get() = Days(this)
 
 /**
- * Multiplies this value by a duration of days.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of days. @throws ArithmeticException if overflow occurs
  */
-public operator fun Int.times(days: LongDays): LongDays = days * this
+public operator fun Int.times(days: Days): Days = days * this
 
 /**
- * Multiplies this value by a duration of days.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of days.
  */
-public operator fun Long.times(days: LongDays): LongDays = days * this
+public val Long.days: Days
+  get() = Days(this)
 
 /**
- * Converts this duration to Island Time [LongDays].
+ * Multiplies this value by a duration of days. @throws ArithmeticException if overflow occurs
+ */
+public operator fun Long.times(days: Days): Days = days * this
+
+/**
+ * Converts this duration to Island Time [Days].
  */
 @ExperimentalTime
-public fun KotlinDuration.toIslandDays(): LongDays = LongDays(this.toLong(KotlinDurationUnit.DAYS))
+public fun KotlinDuration.toIslandDays(): Days = Days(this.toLong(KotlinDurationUnit.DAYS))

--- a/core/src/commonMain/generated/io/islandtime/measures/_Decades.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Decades.kt
@@ -15,9 +15,11 @@ import dev.erikchristensen.javamath2kmp.toIntExact
 import io.islandtime.`internal`.DECADES_PER_CENTURY
 import io.islandtime.`internal`.MONTHS_PER_DECADE
 import io.islandtime.`internal`.YEARS_PER_DECADE
+import io.islandtime.`internal`.deprecatedToError
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -27,282 +29,72 @@ import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 import kotlin.math.absoluteValue
 
-/**
- * A number of decades.
- */
+@Deprecated(
+  message = "Replace with Decades.",
+  replaceWith = ReplaceWith("Decades"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntDecades = Decades
+
+@Deprecated(
+  message = "Replace with Decades.",
+  replaceWith = ReplaceWith("Decades"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongDecades = Decades
+
 @JvmInline
-public value class IntDecades(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntDecades> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntDecades
-    get() = IntDecades(absExact(`value`))
-
-  /**
-   * Converts this duration to months.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inMonths: IntMonths
-    get() = (`value` timesExact MONTHS_PER_DECADE).months
-
-  /**
-   * Converts this duration to months without checking for overflow.
-   */
-  internal val inMonthsUnchecked: IntMonths
-    get() = (`value` * MONTHS_PER_DECADE).months
-
-  /**
-   * Converts this duration to years.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inYears: IntYears
-    get() = (`value` timesExact YEARS_PER_DECADE).years
-
-  /**
-   * Converts this duration to years without checking for overflow.
-   */
-  internal val inYearsUnchecked: IntYears
-    get() = (`value` * YEARS_PER_DECADE).years
-
-  /**
-   * Converts this duration to the number of whole centuries.
-   */
-  public val inCenturies: IntCenturies
-    get() = (`value` / DECADES_PER_CENTURY).centuries
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.decades"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.decades"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.decades"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntDecades): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return when (`value`) {
-       0 -> "P0Y"
-       Int.MIN_VALUE -> "-P2147483648Y"
-       else -> buildString {
-         if (`value` < 0) { append('-') }
-         append("P")
-         append(`value`.absoluteValue timesExact 10)
-         append('Y')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntDecades = IntDecades(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntDecades = IntDecades(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): IntDecades = IntDecades(`value` timesExact scalar)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongDecades = this.toLongDecades() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntDecades {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntDecades(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongDecades = this.toLongDecades() / scalar
-
-  public operator fun rem(scalar: Int): IntDecades = IntDecades(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongDecades = this.toLongDecades() % scalar
-
-  public operator fun plus(months: IntMonths): IntMonths = this.inMonths + months
-
-  public operator fun minus(months: IntMonths): IntMonths = this.inMonths - months
-
-  public operator fun plus(months: LongMonths): LongMonths = this.toLongDecades().inMonths + months
-
-  public operator fun minus(months: LongMonths): LongMonths = this.toLongDecades().inMonths - months
-
-  public operator fun plus(years: IntYears): IntYears = this.inYears + years
-
-  public operator fun minus(years: IntYears): IntYears = this.inYears - years
-
-  public operator fun plus(years: LongYears): LongYears = this.toLongDecades().inYears + years
-
-  public operator fun minus(years: LongYears): LongYears = this.toLongDecades().inYears - years
-
-  public operator fun plus(decades: IntDecades): IntDecades = IntDecades(`value` plusExact
-      decades.value)
-
-  public operator fun minus(decades: IntDecades): IntDecades = IntDecades(`value` minusExact
-      decades.value)
-
-  public operator fun plus(decades: LongDecades): LongDecades =
-      LongDecades(`value`.toLong() plusExact decades.value)
-
-  public operator fun minus(decades: LongDecades): LongDecades =
-      LongDecades(`value`.toLong() minusExact decades.value)
-
-  public operator fun plus(centuries: IntCenturies): IntDecades = this + centuries.inDecades
-
-  public operator fun minus(centuries: IntCenturies): IntDecades = this - centuries.inDecades
-
-  public operator fun plus(centuries: LongCenturies): LongDecades = this.toLongDecades() +
-      centuries.inDecades
-
-  public operator fun minus(centuries: LongCenturies): LongDecades = this.toLongDecades() -
-      centuries.inDecades
-
-  public inline fun <T> toComponents(action: (centuries: IntCenturies, decades: IntDecades) -> T):
-      T {
-    val centuries = (`value` / DECADES_PER_CENTURY).centuries
-    val decades = (`value` % DECADES_PER_CENTURY).decades
-    return action(centuries, decades)
-  }
-
-  /**
-   * Converts this duration to [LongDecades].
-   */
-  public fun toLongDecades(): LongDecades = LongDecades(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntDecades = IntDecades(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntDecades = IntDecades(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of decades.
- */
-public val Int.decades: IntDecades
-  get() = IntDecades(this)
-
-/**
- * Multiplies this value by a duration of decades.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(decades: IntDecades): IntDecades = decades * this
-
-/**
- * Multiplies this value by a duration of decades.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(decades: IntDecades): LongDecades = decades * this
-
-/**
- * A number of decades.
- */
-@JvmInline
-public value class LongDecades(
+public value class Decades(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongDecades> {
+) : Comparable<Decades> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongDecades
-    get() = LongDecades(absExact(`value`))
+  public val absoluteValue: Decades
+    get() = Decades(absExact(value))
 
   /**
-   * Converts this duration to months.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to months. @throws ArithmeticException if overflow occurs
    */
-  public val inMonths: LongMonths
-    get() = (`value` timesExact MONTHS_PER_DECADE).months
+  public val inMonths: Months
+    get() = Months(value timesExact MONTHS_PER_DECADE)
 
   /**
    * Converts this duration to months without checking for overflow.
    */
-  internal val inMonthsUnchecked: LongMonths
-    get() = (`value` * MONTHS_PER_DECADE).months
+  internal val inMonthsUnchecked: Months
+    get() = Months(value * MONTHS_PER_DECADE)
 
   /**
-   * Converts this duration to years.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to years. @throws ArithmeticException if overflow occurs
    */
-  public val inYears: LongYears
-    get() = (`value` timesExact YEARS_PER_DECADE).years
+  public val inYears: Years
+    get() = Years(value timesExact YEARS_PER_DECADE)
 
   /**
    * Converts this duration to years without checking for overflow.
    */
-  internal val inYearsUnchecked: LongYears
-    get() = (`value` * YEARS_PER_DECADE).years
+  internal val inYearsUnchecked: Years
+    get() = Years(value * YEARS_PER_DECADE)
 
   /**
    * Converts this duration to the number of whole centuries.
    */
-  public val inCenturies: LongCenturies
-    get() = (`value` / DECADES_PER_CENTURY).centuries
+  public val inWholeCenturies: Centuries
+    get() = Centuries(value / DECADES_PER_CENTURY)
+
+  @Deprecated(
+    message = "Use inWholeCenturies instead.",
+    replaceWith = ReplaceWith("this.inWholeCenturies"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inCenturies: Centuries
+    get() = deprecatedToError()
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -312,7 +104,7 @@ public value class LongDecades(
     replaceWith = ReplaceWith("this == 0L.decades"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -322,7 +114,7 @@ public value class LongDecades(
     replaceWith = ReplaceWith("this < 0L.decades"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -332,175 +124,180 @@ public value class LongDecades(
     replaceWith = ReplaceWith("this > 0L.decades"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongDecades): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Decades): Int = value.compareTo(other.value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return when (`value`) {
+     return when (value) {
        0L -> "P0Y"
        Long.MIN_VALUE -> "-P9223372036854775808Y"
        else -> buildString {
-         if (`value` < 0) { append('-') }
+         if (value < 0) { append('-') }
          append("P")
-         append(`value`.absoluteValue timesExact 10)
+         append(value.absoluteValue timesExact 10)
          append('Y')
        }
      }
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongDecades = LongDecades(`value`.negateExact())
+  public operator fun unaryMinus(): Decades = Decades(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongDecades = LongDecades(-`value`)
+  internal fun negateUnchecked(): Decades = Decades(-value)
+
+  public operator fun plus(months: Months): Months = this.inMonths + months
+
+  public operator fun minus(months: Months): Months = this.inMonths - months
+
+  public operator fun plus(years: Years): Years = this.inYears + years
+
+  public operator fun minus(years: Years): Years = this.inYears - years
+
+  public operator fun plus(decades: Decades): Decades = Decades(value plusExact decades.value)
+
+  public operator fun minus(decades: Decades): Decades = Decades(value minusExact decades.value)
+
+  public operator fun plus(centuries: Centuries): Decades = this + centuries.inDecades
+
+  public operator fun minus(centuries: Centuries): Decades = this - centuries.inDecades
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongDecades = LongDecades(`value` timesExact scalar)
+  public operator fun times(scalar: Int): Decades = Decades(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongDecades = LongDecades(`value` timesExact scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongDecades {
+  public operator fun div(scalar: Int): Decades {
      return if (scalar == -1) {
        -this
      } else {
-       LongDecades(`value` / scalar)
+       Decades(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongDecades {
+  public operator fun rem(scalar: Int): Decades = Decades(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Decades = Decades(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Decades {
      return if (scalar == -1L) {
        -this
      } else {
-       LongDecades(`value` / scalar)
+       Decades(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongDecades = LongDecades(`value` % scalar)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Decades = Decades(value % scalar)
 
-  public operator fun rem(scalar: Long): LongDecades = LongDecades(`value` % scalar)
-
-  public operator fun plus(months: IntMonths): LongMonths = this.inMonths + months
-
-  public operator fun minus(months: IntMonths): LongMonths = this.inMonths - months
-
-  public operator fun plus(months: LongMonths): LongMonths = this.inMonths + months
-
-  public operator fun minus(months: LongMonths): LongMonths = this.inMonths - months
-
-  public operator fun plus(years: IntYears): LongYears = this.inYears + years
-
-  public operator fun minus(years: IntYears): LongYears = this.inYears - years
-
-  public operator fun plus(years: LongYears): LongYears = this.inYears + years
-
-  public operator fun minus(years: LongYears): LongYears = this.inYears - years
-
-  public operator fun plus(decades: IntDecades): LongDecades = LongDecades(`value` plusExact
-      decades.value)
-
-  public operator fun minus(decades: IntDecades): LongDecades = LongDecades(`value` minusExact
-      decades.value)
-
-  public operator fun plus(decades: LongDecades): LongDecades = LongDecades(`value` plusExact
-      decades.value)
-
-  public operator fun minus(decades: LongDecades): LongDecades = LongDecades(`value` minusExact
-      decades.value)
-
-  public operator fun plus(centuries: IntCenturies): LongDecades = this + centuries.inDecades
-
-  public operator fun minus(centuries: IntCenturies): LongDecades = this - centuries.inDecades
-
-  public operator fun plus(centuries: LongCenturies): LongDecades = this + centuries.inDecades
-
-  public operator fun minus(centuries: LongCenturies): LongDecades = this - centuries.inDecades
-
-  public inline fun <T> toComponents(action: (centuries: LongCenturies, decades: IntDecades) -> T):
-      T {
-    val centuries = (`value` / DECADES_PER_CENTURY).centuries
-    val decades = (`value` % DECADES_PER_CENTURY).toInt().decades
+  public inline fun <T> toComponentValues(action: (centuries: Long, decades: Int) -> T): T {
+    val centuries = (value / DECADES_PER_CENTURY)
+    val decades = (value % DECADES_PER_CENTURY).toInt()
     return action(centuries, decades)
   }
 
-  /**
-   * Converts this duration to [IntDecades].
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toIntDecades(): IntDecades = IntDecades(`value`.toIntExact())
+  public inline fun <T> toComponents(action: (centuries: Centuries, decades: Decades) -> T): T {
+     return toComponentValues { centuries, decades ->
+         action(Centuries(centuries), Decades(decades))
+     }
+  }
 
   /**
-   * Converts this duration to [IntDecades] without checking for overflow.
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  @PublishedApi
-  internal fun toIntDecadesUnchecked(): IntDecades = IntDecades(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntDecades]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntDecades(): Decades = this
+
+  /**
+   * Converts this duration to [IntDecades] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntDecadesUnchecked(): Decades = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongDecades = LongDecades(Long.MIN_VALUE)
+    public val MIN: Decades = Decades(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongDecades = LongDecades(Long.MAX_VALUE)
+    public val MAX: Decades = Decades(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of decades.
  */
-public val Long.decades: LongDecades
-  get() = LongDecades(this)
+public val Int.decades: Decades
+  get() = Decades(this)
 
 /**
- * Multiplies this value by a duration of decades.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of decades. @throws ArithmeticException if overflow occurs
  */
-public operator fun Int.times(decades: LongDecades): LongDecades = decades * this
+public operator fun Int.times(decades: Decades): Decades = decades * this
 
 /**
- * Multiplies this value by a duration of decades.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of decades.
  */
-public operator fun Long.times(decades: LongDecades): LongDecades = decades * this
+public val Long.decades: Decades
+  get() = Decades(this)
+
+/**
+ * Multiplies this value by a duration of decades. @throws ArithmeticException if overflow occurs
+ */
+public operator fun Long.times(decades: Decades): Decades = decades * this

--- a/core/src/commonMain/generated/io/islandtime/measures/_Decades.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Decades.kt
@@ -17,6 +17,7 @@ import io.islandtime.`internal`.MONTHS_PER_DECADE
 import io.islandtime.`internal`.YEARS_PER_DECADE
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -78,16 +79,31 @@ public value class IntDecades(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.decades"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.decades"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.decades"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntDecades): Int = `value`.compareTo(other.`value`)
@@ -291,16 +307,31 @@ public value class LongDecades(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.decades"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.decades"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.decades"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongDecades): Int = `value`.compareTo(other.`value`)
@@ -437,6 +468,11 @@ public value class LongDecades(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Hours.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Hours.kt
@@ -20,6 +20,7 @@ import io.islandtime.`internal`.NANOSECONDS_PER_HOUR
 import io.islandtime.`internal`.SECONDS_PER_HOUR
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -109,16 +110,31 @@ public value class IntHours(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.hours"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.hours"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.hours"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntHours): Int = `value`.compareTo(other.`value`)
@@ -402,16 +418,31 @@ public value class LongHours(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.hours"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.hours"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.hours"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongHours): Int = `value`.compareTo(other.`value`)
@@ -585,6 +616,11 @@ public value class LongHours(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Hours.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Hours.kt
@@ -18,9 +18,11 @@ import io.islandtime.`internal`.MILLISECONDS_PER_HOUR
 import io.islandtime.`internal`.MINUTES_PER_HOUR
 import io.islandtime.`internal`.NANOSECONDS_PER_HOUR
 import io.islandtime.`internal`.SECONDS_PER_HOUR
+import io.islandtime.`internal`.deprecatedToError
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -33,387 +35,108 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Duration as KotlinDuration
 import kotlin.time.DurationUnit as KotlinDurationUnit
 
-/**
- * A number of hours.
- */
+@Deprecated(
+  message = "Replace with Hours.",
+  replaceWith = ReplaceWith("Hours"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntHours = Hours
+
+@Deprecated(
+  message = "Replace with Hours.",
+  replaceWith = ReplaceWith("Hours"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongHours = Hours
+
 @JvmInline
-public value class IntHours(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntHours> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntHours
-    get() = IntHours(absExact(`value`))
-
-  /**
-   * Converts this duration to nanoseconds.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value`.toLong() timesExact NANOSECONDS_PER_HOUR).nanoseconds
-
-  /**
-   * Converts this duration to nanoseconds without checking for overflow.
-   */
-  internal val inNanosecondsUnchecked: LongNanoseconds
-    get() = (`value`.toLong() * NANOSECONDS_PER_HOUR).nanoseconds
-
-  /**
-   * Converts this duration to microseconds.
-   */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value`.toLong() * MICROSECONDS_PER_HOUR).microseconds
-
-  /**
-   * Converts this duration to milliseconds.
-   */
-  public val inMilliseconds: LongMilliseconds
-    get() = (`value`.toLong() * MILLISECONDS_PER_HOUR).milliseconds
-
-  /**
-   * Converts this duration to seconds.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inSeconds: IntSeconds
-    get() = (`value` timesExact SECONDS_PER_HOUR).seconds
-
-  /**
-   * Converts this duration to seconds without checking for overflow.
-   */
-  internal val inSecondsUnchecked: IntSeconds
-    get() = (`value` * SECONDS_PER_HOUR).seconds
-
-  /**
-   * Converts this duration to minutes.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inMinutes: IntMinutes
-    get() = (`value` timesExact MINUTES_PER_HOUR).minutes
-
-  /**
-   * Converts this duration to minutes without checking for overflow.
-   */
-  internal val inMinutesUnchecked: IntMinutes
-    get() = (`value` * MINUTES_PER_HOUR).minutes
-
-  /**
-   * Converts this duration to the number of whole days.
-   */
-  public val inDays: IntDays
-    get() = (`value` / HOURS_PER_DAY).days
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.hours"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.hours"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.hours"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntHours): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return when (`value`) {
-       0 -> "PT0H"
-       Int.MIN_VALUE -> "-PT2147483648H"
-       else -> buildString {
-         if (`value` < 0) { append('-') }
-         append("PT")
-         append(`value`.absoluteValue)
-         append('H')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntHours = IntHours(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntHours = IntHours(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): IntHours = IntHours(`value` timesExact scalar)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongHours = this.toLongHours() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntHours {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntHours(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongHours = this.toLongHours() / scalar
-
-  public operator fun rem(scalar: Int): IntHours = IntHours(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongHours = this.toLongHours() % scalar
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongHours().inNanoseconds + nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongHours().inNanoseconds - nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds -
-      microseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.toLongHours().inMicroseconds + microseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.toLongHours().inMicroseconds - microseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds -
-      milliseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.toLongHours().inMilliseconds + milliseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.toLongHours().inMilliseconds - milliseconds
-
-  public operator fun plus(seconds: IntSeconds): IntSeconds = this.inSeconds + seconds
-
-  public operator fun minus(seconds: IntSeconds): IntSeconds = this.inSeconds - seconds
-
-  public operator fun plus(seconds: LongSeconds): LongSeconds = this.toLongHours().inSeconds +
-      seconds
-
-  public operator fun minus(seconds: LongSeconds): LongSeconds = this.toLongHours().inSeconds -
-      seconds
-
-  public operator fun plus(minutes: IntMinutes): IntMinutes = this.inMinutes + minutes
-
-  public operator fun minus(minutes: IntMinutes): IntMinutes = this.inMinutes - minutes
-
-  public operator fun plus(minutes: LongMinutes): LongMinutes = this.toLongHours().inMinutes +
-      minutes
-
-  public operator fun minus(minutes: LongMinutes): LongMinutes = this.toLongHours().inMinutes -
-      minutes
-
-  public operator fun plus(hours: IntHours): IntHours = IntHours(`value` plusExact hours.value)
-
-  public operator fun minus(hours: IntHours): IntHours = IntHours(`value` minusExact hours.value)
-
-  public operator fun plus(hours: LongHours): LongHours = LongHours(`value`.toLong() plusExact
-      hours.value)
-
-  public operator fun minus(hours: LongHours): LongHours = LongHours(`value`.toLong() minusExact
-      hours.value)
-
-  public operator fun plus(days: IntDays): IntHours = this + days.inHours
-
-  public operator fun minus(days: IntDays): IntHours = this - days.inHours
-
-  public operator fun plus(days: LongDays): LongHours = this.toLongHours() + days.inHours
-
-  public operator fun minus(days: LongDays): LongHours = this.toLongHours() - days.inHours
-
-  public inline fun <T> toComponents(action: (days: IntDays, hours: IntHours) -> T): T {
-    val days = (`value` / HOURS_PER_DAY).days
-    val hours = (`value` % HOURS_PER_DAY).hours
-    return action(days, hours)
-  }
-
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.hours(`value`)
-
-  /**
-   * Converts this duration to [LongHours].
-   */
-  public fun toLongHours(): LongHours = LongHours(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntHours = IntHours(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntHours = IntHours(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of hours.
- */
-public val Int.hours: IntHours
-  get() = IntHours(this)
-
-/**
- * Multiplies this value by a duration of hours.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(hours: IntHours): IntHours = hours * this
-
-/**
- * Multiplies this value by a duration of hours.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(hours: IntHours): LongHours = hours * this
-
-/**
- * A number of hours.
- */
-@JvmInline
-public value class LongHours(
+public value class Hours(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongHours> {
+) : Comparable<Hours> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongHours
-    get() = LongHours(absExact(`value`))
+  public val absoluteValue: Hours
+    get() = Hours(absExact(value))
 
   /**
-   * Converts this duration to nanoseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to nanoseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value` timesExact NANOSECONDS_PER_HOUR).nanoseconds
+  public val inNanoseconds: Nanoseconds
+    get() = Nanoseconds(value timesExact NANOSECONDS_PER_HOUR)
 
   /**
    * Converts this duration to nanoseconds without checking for overflow.
    */
-  internal val inNanosecondsUnchecked: LongNanoseconds
-    get() = (`value` * NANOSECONDS_PER_HOUR).nanoseconds
+  internal val inNanosecondsUnchecked: Nanoseconds
+    get() = Nanoseconds(value * NANOSECONDS_PER_HOUR)
 
   /**
-   * Converts this duration to microseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to microseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value` timesExact MICROSECONDS_PER_HOUR).microseconds
+  public val inMicroseconds: Microseconds
+    get() = Microseconds(value timesExact MICROSECONDS_PER_HOUR)
 
   /**
    * Converts this duration to microseconds without checking for overflow.
    */
-  internal val inMicrosecondsUnchecked: LongMicroseconds
-    get() = (`value` * MICROSECONDS_PER_HOUR).microseconds
+  internal val inMicrosecondsUnchecked: Microseconds
+    get() = Microseconds(value * MICROSECONDS_PER_HOUR)
 
   /**
-   * Converts this duration to milliseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to milliseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inMilliseconds: LongMilliseconds
-    get() = (`value` timesExact MILLISECONDS_PER_HOUR).milliseconds
+  public val inMilliseconds: Milliseconds
+    get() = Milliseconds(value timesExact MILLISECONDS_PER_HOUR)
 
   /**
    * Converts this duration to milliseconds without checking for overflow.
    */
-  internal val inMillisecondsUnchecked: LongMilliseconds
-    get() = (`value` * MILLISECONDS_PER_HOUR).milliseconds
+  internal val inMillisecondsUnchecked: Milliseconds
+    get() = Milliseconds(value * MILLISECONDS_PER_HOUR)
 
   /**
-   * Converts this duration to seconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to seconds. @throws ArithmeticException if overflow occurs
    */
-  public val inSeconds: LongSeconds
-    get() = (`value` timesExact SECONDS_PER_HOUR).seconds
+  public val inSeconds: Seconds
+    get() = Seconds(value timesExact SECONDS_PER_HOUR)
 
   /**
    * Converts this duration to seconds without checking for overflow.
    */
-  internal val inSecondsUnchecked: LongSeconds
-    get() = (`value` * SECONDS_PER_HOUR).seconds
+  internal val inSecondsUnchecked: Seconds
+    get() = Seconds(value * SECONDS_PER_HOUR)
 
   /**
-   * Converts this duration to minutes.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to minutes. @throws ArithmeticException if overflow occurs
    */
-  public val inMinutes: LongMinutes
-    get() = (`value` timesExact MINUTES_PER_HOUR).minutes
+  public val inMinutes: Minutes
+    get() = Minutes(value timesExact MINUTES_PER_HOUR)
 
   /**
    * Converts this duration to minutes without checking for overflow.
    */
-  internal val inMinutesUnchecked: LongMinutes
-    get() = (`value` * MINUTES_PER_HOUR).minutes
+  internal val inMinutesUnchecked: Minutes
+    get() = Minutes(value * MINUTES_PER_HOUR)
 
   /**
    * Converts this duration to the number of whole days.
    */
-  public val inDays: LongDays
-    get() = (`value` / HOURS_PER_DAY).days
+  public val inWholeDays: Days
+    get() = Days(value / HOURS_PER_DAY)
+
+  @Deprecated(
+    message = "Use inWholeDays instead.",
+    replaceWith = ReplaceWith("this.inWholeDays"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inDays: Days
+    get() = deprecatedToError()
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -423,7 +146,7 @@ public value class LongHours(
     replaceWith = ReplaceWith("this == 0L.hours"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -433,7 +156,7 @@ public value class LongHours(
     replaceWith = ReplaceWith("this < 0L.hours"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -443,219 +166,209 @@ public value class LongHours(
     replaceWith = ReplaceWith("this > 0L.hours"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongHours): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Hours): Int = value.compareTo(other.value)
+
+  /**
+   * Converts this duration to a [kotlin.time.Duration].
+   */
+  @ExperimentalTime
+  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.hours(value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return when (`value`) {
+     return when (value) {
        0L -> "PT0H"
        Long.MIN_VALUE -> "-PT9223372036854775808H"
        else -> buildString {
-         if (`value` < 0) { append('-') }
+         if (value < 0) { append('-') }
          append("PT")
-         append(`value`.absoluteValue)
+         append(value.absoluteValue)
          append('H')
        }
      }
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongHours = LongHours(`value`.negateExact())
+  public operator fun unaryMinus(): Hours = Hours(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongHours = LongHours(-`value`)
+  internal fun negateUnchecked(): Hours = Hours(-value)
+
+  public operator fun plus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds + nanoseconds
+
+  public operator fun minus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds -
+      nanoseconds
+
+  public operator fun plus(microseconds: Microseconds): Microseconds = this.inMicroseconds +
+      microseconds
+
+  public operator fun minus(microseconds: Microseconds): Microseconds = this.inMicroseconds -
+      microseconds
+
+  public operator fun plus(milliseconds: Milliseconds): Milliseconds = this.inMilliseconds +
+      milliseconds
+
+  public operator fun minus(milliseconds: Milliseconds): Milliseconds = this.inMilliseconds -
+      milliseconds
+
+  public operator fun plus(seconds: Seconds): Seconds = this.inSeconds + seconds
+
+  public operator fun minus(seconds: Seconds): Seconds = this.inSeconds - seconds
+
+  public operator fun plus(minutes: Minutes): Minutes = this.inMinutes + minutes
+
+  public operator fun minus(minutes: Minutes): Minutes = this.inMinutes - minutes
+
+  public operator fun plus(hours: Hours): Hours = Hours(value plusExact hours.value)
+
+  public operator fun minus(hours: Hours): Hours = Hours(value minusExact hours.value)
+
+  public operator fun plus(days: Days): Hours = this + days.inHours
+
+  public operator fun minus(days: Days): Hours = this - days.inHours
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongHours = LongHours(`value` timesExact scalar)
+  public operator fun times(scalar: Int): Hours = Hours(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongHours = LongHours(`value` timesExact scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongHours {
+  public operator fun div(scalar: Int): Hours {
      return if (scalar == -1) {
        -this
      } else {
-       LongHours(`value` / scalar)
+       Hours(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongHours {
+  public operator fun rem(scalar: Int): Hours = Hours(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Hours = Hours(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Hours {
      return if (scalar == -1L) {
        -this
      } else {
-       LongHours(`value` / scalar)
+       Hours(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongHours = LongHours(`value` % scalar)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Hours = Hours(value % scalar)
 
-  public operator fun rem(scalar: Long): LongHours = LongHours(`value` % scalar)
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds -
-      microseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.inMicroseconds - microseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds -
-      milliseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.inMilliseconds - milliseconds
-
-  public operator fun plus(seconds: IntSeconds): LongSeconds = this.inSeconds + seconds
-
-  public operator fun minus(seconds: IntSeconds): LongSeconds = this.inSeconds - seconds
-
-  public operator fun plus(seconds: LongSeconds): LongSeconds = this.inSeconds + seconds
-
-  public operator fun minus(seconds: LongSeconds): LongSeconds = this.inSeconds - seconds
-
-  public operator fun plus(minutes: IntMinutes): LongMinutes = this.inMinutes + minutes
-
-  public operator fun minus(minutes: IntMinutes): LongMinutes = this.inMinutes - minutes
-
-  public operator fun plus(minutes: LongMinutes): LongMinutes = this.inMinutes + minutes
-
-  public operator fun minus(minutes: LongMinutes): LongMinutes = this.inMinutes - minutes
-
-  public operator fun plus(hours: IntHours): LongHours = LongHours(`value` plusExact hours.value)
-
-  public operator fun minus(hours: IntHours): LongHours = LongHours(`value` minusExact hours.value)
-
-  public operator fun plus(hours: LongHours): LongHours = LongHours(`value` plusExact hours.value)
-
-  public operator fun minus(hours: LongHours): LongHours = LongHours(`value` minusExact hours.value)
-
-  public operator fun plus(days: IntDays): LongHours = this + days.inHours
-
-  public operator fun minus(days: IntDays): LongHours = this - days.inHours
-
-  public operator fun plus(days: LongDays): LongHours = this + days.inHours
-
-  public operator fun minus(days: LongDays): LongHours = this - days.inHours
-
-  public inline fun <T> toComponents(action: (days: LongDays, hours: IntHours) -> T): T {
-    val days = (`value` / HOURS_PER_DAY).days
-    val hours = (`value` % HOURS_PER_DAY).toInt().hours
+  public inline fun <T> toComponentValues(action: (days: Long, hours: Int) -> T): T {
+    val days = (value / HOURS_PER_DAY)
+    val hours = (value % HOURS_PER_DAY).toInt()
     return action(days, hours)
   }
 
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.hours(`value`)
+  public inline fun <T> toComponents(action: (days: Days, hours: Hours) -> T): T {
+     return toComponentValues { days, hours ->
+         action(Days(days), Hours(hours))
+     }
+  }
 
   /**
-   * Converts this duration to [IntHours].
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  public fun toIntHours(): IntHours = IntHours(`value`.toIntExact())
-
-  /**
-   * Converts this duration to [IntHours] without checking for overflow.
-   */
-  @PublishedApi
-  internal fun toIntHoursUnchecked(): IntHours = IntHours(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntHours]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntHours(): Hours = this
+
+  /**
+   * Converts this duration to [IntHours] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntHoursUnchecked(): Hours = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongHours = LongHours(Long.MIN_VALUE)
+    public val MIN: Hours = Hours(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongHours = LongHours(Long.MAX_VALUE)
+    public val MAX: Hours = Hours(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of hours.
  */
-public val Long.hours: LongHours
-  get() = LongHours(this)
+public val Int.hours: Hours
+  get() = Hours(this)
 
 /**
- * Multiplies this value by a duration of hours.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of hours. @throws ArithmeticException if overflow occurs
  */
-public operator fun Int.times(hours: LongHours): LongHours = hours * this
+public operator fun Int.times(hours: Hours): Hours = hours * this
 
 /**
- * Multiplies this value by a duration of hours.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of hours.
  */
-public operator fun Long.times(hours: LongHours): LongHours = hours * this
+public val Long.hours: Hours
+  get() = Hours(this)
 
 /**
- * Converts this duration to Island Time [LongHours].
+ * Multiplies this value by a duration of hours. @throws ArithmeticException if overflow occurs
+ */
+public operator fun Long.times(hours: Hours): Hours = hours * this
+
+/**
+ * Converts this duration to Island Time [Hours].
  */
 @ExperimentalTime
-public fun KotlinDuration.toIslandHours(): LongHours =
-    LongHours(this.toLong(KotlinDurationUnit.HOURS))
+public fun KotlinDuration.toIslandHours(): Hours = Hours(this.toLong(KotlinDurationUnit.HOURS))

--- a/core/src/commonMain/generated/io/islandtime/measures/_Microseconds.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Microseconds.kt
@@ -21,6 +21,7 @@ import io.islandtime.`internal`.NANOSECONDS_PER_MICROSECOND
 import io.islandtime.`internal`.toZeroPaddedString
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -89,16 +90,31 @@ public value class IntMicroseconds(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.microseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.microseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.microseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntMicroseconds): Int = `value`.compareTo(other.`value`)
@@ -432,16 +448,31 @@ public value class LongMicroseconds(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.microseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.microseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.microseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongMicroseconds): Int = `value`.compareTo(other.`value`)
@@ -684,6 +715,11 @@ public value class LongMicroseconds(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Microseconds.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Microseconds.kt
@@ -18,10 +18,12 @@ import io.islandtime.`internal`.MICROSECONDS_PER_MILLISECOND
 import io.islandtime.`internal`.MICROSECONDS_PER_MINUTE
 import io.islandtime.`internal`.MICROSECONDS_PER_SECOND
 import io.islandtime.`internal`.NANOSECONDS_PER_MICROSECOND
+import io.islandtime.`internal`.deprecatedToError
 import io.islandtime.`internal`.toZeroPaddedString
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -34,416 +36,116 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Duration as KotlinDuration
 import kotlin.time.DurationUnit as KotlinDurationUnit
 
-/**
- * A number of microseconds.
- */
+@Deprecated(
+  message = "Replace with Microseconds.",
+  replaceWith = ReplaceWith("Microseconds"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntMicroseconds = Microseconds
+
+@Deprecated(
+  message = "Replace with Microseconds.",
+  replaceWith = ReplaceWith("Microseconds"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongMicroseconds = Microseconds
+
 @JvmInline
-public value class IntMicroseconds(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntMicroseconds> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntMicroseconds
-    get() = IntMicroseconds(absExact(`value`))
-
-  /**
-   * Converts this duration to nanoseconds.
-   */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value`.toLong() * NANOSECONDS_PER_MICROSECOND).nanoseconds
-
-  /**
-   * Converts this duration to the number of whole milliseconds.
-   */
-  public val inMilliseconds: IntMilliseconds
-    get() = (`value` / MICROSECONDS_PER_MILLISECOND).milliseconds
-
-  /**
-   * Converts this duration to the number of whole seconds.
-   */
-  public val inSeconds: IntSeconds
-    get() = (`value` / MICROSECONDS_PER_SECOND).seconds
-
-  /**
-   * Converts this duration to the number of whole minutes.
-   */
-  public val inMinutes: IntMinutes
-    get() = (`value` / MICROSECONDS_PER_MINUTE).minutes
-
-  /**
-   * Converts this duration to the number of whole hours.
-   */
-  public val inHours: IntHours
-    get() = (`value` / MICROSECONDS_PER_HOUR).toInt().hours
-
-  /**
-   * Converts this duration to the number of whole days.
-   */
-  public val inDays: IntDays
-    get() = (`value` / MICROSECONDS_PER_DAY).toInt().days
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.microseconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.microseconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.microseconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntMicroseconds): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return if (`value` == 0) {
-       "PT0S"
-     } else {
-       buildString {
-         val wholePart = (`value` / 1000000).absoluteValue
-         val fractionalPart = (`value` % 1000000).absoluteValue
-         if (`value` < 0) { append('-') }
-         append("PT")
-         append(wholePart)
-         if (fractionalPart > 0) {
-           append('.')
-           append(fractionalPart.toZeroPaddedString(6).dropLastWhile { it == '0' })
-         }
-         append('S')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntMicroseconds = IntMicroseconds(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntMicroseconds = IntMicroseconds(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): LongMicroseconds = this.toLongMicroseconds() * scalar
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongMicroseconds = this.toLongMicroseconds() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntMicroseconds {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntMicroseconds(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongMicroseconds = this.toLongMicroseconds() / scalar
-
-  public operator fun rem(scalar: Int): IntMicroseconds = IntMicroseconds(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongMicroseconds = this.toLongMicroseconds() % scalar
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds =
-      this.toLongMicroseconds().inNanoseconds + nanoseconds.toLongNanoseconds()
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds =
-      this.toLongMicroseconds().inNanoseconds - nanoseconds.toLongNanoseconds()
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongMicroseconds().inNanoseconds + nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongMicroseconds().inNanoseconds - nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds =
-      LongMicroseconds(`value`.toLong() plusExact microseconds.value)
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds =
-      LongMicroseconds(`value`.toLong() minusExact microseconds.value)
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds =
-      LongMicroseconds(`value`.toLong() plusExact microseconds.value)
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      LongMicroseconds(`value`.toLong() minusExact microseconds.value)
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMicroseconds =
-      this.toLongMicroseconds() + milliseconds.inMicroseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMicroseconds =
-      this.toLongMicroseconds() - milliseconds.inMicroseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMicroseconds =
-      this.toLongMicroseconds() + milliseconds.inMicroseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMicroseconds =
-      this.toLongMicroseconds() - milliseconds.inMicroseconds
-
-  public operator fun plus(seconds: IntSeconds): LongMicroseconds = this.toLongMicroseconds() +
-      seconds.inMicroseconds
-
-  public operator fun minus(seconds: IntSeconds): LongMicroseconds = this.toLongMicroseconds() -
-      seconds.inMicroseconds
-
-  public operator fun plus(seconds: LongSeconds): LongMicroseconds = this.toLongMicroseconds() +
-      seconds.inMicroseconds
-
-  public operator fun minus(seconds: LongSeconds): LongMicroseconds = this.toLongMicroseconds() -
-      seconds.inMicroseconds
-
-  public operator fun plus(minutes: IntMinutes): LongMicroseconds = this.toLongMicroseconds() +
-      minutes.inMicroseconds
-
-  public operator fun minus(minutes: IntMinutes): LongMicroseconds = this.toLongMicroseconds() -
-      minutes.inMicroseconds
-
-  public operator fun plus(minutes: LongMinutes): LongMicroseconds = this.toLongMicroseconds() +
-      minutes.inMicroseconds
-
-  public operator fun minus(minutes: LongMinutes): LongMicroseconds = this.toLongMicroseconds() -
-      minutes.inMicroseconds
-
-  public operator fun plus(hours: IntHours): LongMicroseconds = this.toLongMicroseconds() +
-      hours.inMicroseconds
-
-  public operator fun minus(hours: IntHours): LongMicroseconds = this.toLongMicroseconds() -
-      hours.inMicroseconds
-
-  public operator fun plus(hours: LongHours): LongMicroseconds = this.toLongMicroseconds() +
-      hours.inMicroseconds
-
-  public operator fun minus(hours: LongHours): LongMicroseconds = this.toLongMicroseconds() -
-      hours.inMicroseconds
-
-  public operator fun plus(days: IntDays): LongMicroseconds = this.toLongMicroseconds() +
-      days.inMicroseconds
-
-  public operator fun minus(days: IntDays): LongMicroseconds = this.toLongMicroseconds() -
-      days.inMicroseconds
-
-  public operator fun plus(days: LongDays): LongMicroseconds = this.toLongMicroseconds() +
-      days.inMicroseconds
-
-  public operator fun minus(days: LongDays): LongMicroseconds = this.toLongMicroseconds() -
-      days.inMicroseconds
-
-  public inline fun <T> toComponents(action: (milliseconds: IntMilliseconds,
-      microseconds: IntMicroseconds) -> T): T {
-    val milliseconds = (`value` / MICROSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = (`value` % MICROSECONDS_PER_MILLISECOND).microseconds
-    return action(milliseconds, microseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds
-  ) -> T): T {
-    val seconds = (`value` / MICROSECONDS_PER_SECOND).seconds
-    val milliseconds = ((`value` % MICROSECONDS_PER_SECOND) /
-        MICROSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = (`value` % MICROSECONDS_PER_MILLISECOND).microseconds
-    return action(seconds, milliseconds, microseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds
-  ) -> T): T {
-    val minutes = (`value` / MICROSECONDS_PER_MINUTE).minutes
-    val seconds = ((`value` % MICROSECONDS_PER_MINUTE) / MICROSECONDS_PER_SECOND).seconds
-    val milliseconds = ((`value` % MICROSECONDS_PER_SECOND) /
-        MICROSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = (`value` % MICROSECONDS_PER_MILLISECOND).microseconds
-    return action(minutes, seconds, milliseconds, microseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds
-  ) -> T): T {
-    val hours = (`value` / MICROSECONDS_PER_HOUR).toInt().hours
-    val minutes = ((`value` % MICROSECONDS_PER_HOUR) / MICROSECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % MICROSECONDS_PER_MINUTE) / MICROSECONDS_PER_SECOND).seconds
-    val milliseconds = ((`value` % MICROSECONDS_PER_SECOND) /
-        MICROSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = (`value` % MICROSECONDS_PER_MILLISECOND).microseconds
-    return action(hours, minutes, seconds, milliseconds, microseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    days: IntDays,
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds
-  ) -> T): T {
-    val days = (`value` / MICROSECONDS_PER_DAY).toInt().days
-    val hours = ((`value` % MICROSECONDS_PER_DAY) / MICROSECONDS_PER_HOUR).toInt().hours
-    val minutes = ((`value` % MICROSECONDS_PER_HOUR) / MICROSECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % MICROSECONDS_PER_MINUTE) / MICROSECONDS_PER_SECOND).seconds
-    val milliseconds = ((`value` % MICROSECONDS_PER_SECOND) /
-        MICROSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = (`value` % MICROSECONDS_PER_MILLISECOND).microseconds
-    return action(days, hours, minutes, seconds, milliseconds, microseconds)
-  }
-
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.microseconds(`value`)
-
-  /**
-   * Converts this duration to [LongMicroseconds].
-   */
-  public fun toLongMicroseconds(): LongMicroseconds = LongMicroseconds(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntMicroseconds = IntMicroseconds(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntMicroseconds = IntMicroseconds(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of microseconds.
- */
-public val Int.microseconds: IntMicroseconds
-  get() = IntMicroseconds(this)
-
-/**
- * Multiplies this value by a duration of microseconds.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(microseconds: IntMicroseconds): LongMicroseconds = microseconds * this
-
-/**
- * Multiplies this value by a duration of microseconds.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(microseconds: IntMicroseconds): LongMicroseconds = microseconds *
-    this
-
-/**
- * A number of microseconds.
- */
-@JvmInline
-public value class LongMicroseconds(
+public value class Microseconds(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongMicroseconds> {
+) : Comparable<Microseconds> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongMicroseconds
-    get() = LongMicroseconds(absExact(`value`))
+  public val absoluteValue: Microseconds
+    get() = Microseconds(absExact(value))
 
   /**
-   * Converts this duration to nanoseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to nanoseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value` timesExact NANOSECONDS_PER_MICROSECOND).nanoseconds
+  public val inNanoseconds: Nanoseconds
+    get() = Nanoseconds(value timesExact NANOSECONDS_PER_MICROSECOND)
 
   /**
    * Converts this duration to nanoseconds without checking for overflow.
    */
-  internal val inNanosecondsUnchecked: LongNanoseconds
-    get() = (`value` * NANOSECONDS_PER_MICROSECOND).nanoseconds
+  internal val inNanosecondsUnchecked: Nanoseconds
+    get() = Nanoseconds(value * NANOSECONDS_PER_MICROSECOND)
 
   /**
    * Converts this duration to the number of whole milliseconds.
    */
-  public val inMilliseconds: LongMilliseconds
-    get() = (`value` / MICROSECONDS_PER_MILLISECOND).milliseconds
+  public val inWholeMilliseconds: Milliseconds
+    get() = Milliseconds(value / MICROSECONDS_PER_MILLISECOND)
+
+  @Deprecated(
+    message = "Use inWholeMilliseconds instead.",
+    replaceWith = ReplaceWith("this.inWholeMilliseconds"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inMilliseconds: Milliseconds
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole seconds.
    */
-  public val inSeconds: LongSeconds
-    get() = (`value` / MICROSECONDS_PER_SECOND).seconds
+  public val inWholeSeconds: Seconds
+    get() = Seconds(value / MICROSECONDS_PER_SECOND)
+
+  @Deprecated(
+    message = "Use inWholeSeconds instead.",
+    replaceWith = ReplaceWith("this.inWholeSeconds"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inSeconds: Seconds
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole minutes.
    */
-  public val inMinutes: LongMinutes
-    get() = (`value` / MICROSECONDS_PER_MINUTE).minutes
+  public val inWholeMinutes: Minutes
+    get() = Minutes(value / MICROSECONDS_PER_MINUTE)
+
+  @Deprecated(
+    message = "Use inWholeMinutes instead.",
+    replaceWith = ReplaceWith("this.inWholeMinutes"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inMinutes: Minutes
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole hours.
    */
-  public val inHours: LongHours
-    get() = (`value` / MICROSECONDS_PER_HOUR).hours
+  public val inWholeHours: Hours
+    get() = Hours(value / MICROSECONDS_PER_HOUR)
+
+  @Deprecated(
+    message = "Use inWholeHours instead.",
+    replaceWith = ReplaceWith("this.inWholeHours"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inHours: Hours
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole days.
    */
-  public val inDays: LongDays
-    get() = (`value` / MICROSECONDS_PER_DAY).days
+  public val inWholeDays: Days
+    get() = Days(value / MICROSECONDS_PER_DAY)
+
+  @Deprecated(
+    message = "Use inWholeDays instead.",
+    replaceWith = ReplaceWith("this.inWholeDays"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inDays: Days
+    get() = deprecatedToError()
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -453,7 +155,7 @@ public value class LongMicroseconds(
     replaceWith = ReplaceWith("this == 0L.microseconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -463,7 +165,7 @@ public value class LongMicroseconds(
     replaceWith = ReplaceWith("this < 0L.microseconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -473,21 +175,27 @@ public value class LongMicroseconds(
     replaceWith = ReplaceWith("this > 0L.microseconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongMicroseconds): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Microseconds): Int = value.compareTo(other.value)
+
+  /**
+   * Converts this duration to a [kotlin.time.Duration].
+   */
+  @ExperimentalTime
+  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.microseconds(value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return if (`value` == 0L) {
+     return if (value == 0L) {
        "PT0S"
      } else {
        buildString {
-         val wholePart = (`value` / 1000000).absoluteValue
-         val fractionalPart = ((`value` % 1000000).toInt()).absoluteValue
-         if (`value` < 0) { append('-') }
+         val wholePart = (value / 1000000).absoluteValue
+         val fractionalPart = (value % 1000000).toInt().absoluteValue
+         if (value < 0) { append('-') }
          append("PT")
          append(wholePart)
          if (fractionalPart > 0) {
@@ -500,263 +208,291 @@ public value class LongMicroseconds(
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongMicroseconds = LongMicroseconds(`value`.negateExact())
+  public operator fun unaryMinus(): Microseconds = Microseconds(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongMicroseconds = LongMicroseconds(-`value`)
+  internal fun negateUnchecked(): Microseconds = Microseconds(-value)
+
+  public operator fun plus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds + nanoseconds
+
+  public operator fun minus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds -
+      nanoseconds
+
+  public operator fun plus(microseconds: Microseconds): Microseconds = Microseconds(value plusExact
+      microseconds.value)
+
+  public operator fun minus(microseconds: Microseconds): Microseconds =
+      Microseconds(value minusExact microseconds.value)
+
+  public operator fun plus(milliseconds: Milliseconds): Microseconds = this +
+      milliseconds.inMicroseconds
+
+  public operator fun minus(milliseconds: Milliseconds): Microseconds = this -
+      milliseconds.inMicroseconds
+
+  public operator fun plus(seconds: Seconds): Microseconds = this + seconds.inMicroseconds
+
+  public operator fun minus(seconds: Seconds): Microseconds = this - seconds.inMicroseconds
+
+  public operator fun plus(minutes: Minutes): Microseconds = this + minutes.inMicroseconds
+
+  public operator fun minus(minutes: Minutes): Microseconds = this - minutes.inMicroseconds
+
+  public operator fun plus(hours: Hours): Microseconds = this + hours.inMicroseconds
+
+  public operator fun minus(hours: Hours): Microseconds = this - hours.inMicroseconds
+
+  public operator fun plus(days: Days): Microseconds = this + days.inMicroseconds
+
+  public operator fun minus(days: Days): Microseconds = this - days.inMicroseconds
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongMicroseconds = LongMicroseconds(`value` timesExact
-      scalar)
+  public operator fun times(scalar: Int): Microseconds = Microseconds(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongMicroseconds = LongMicroseconds(`value` timesExact
-      scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongMicroseconds {
+  public operator fun div(scalar: Int): Microseconds {
      return if (scalar == -1) {
        -this
      } else {
-       LongMicroseconds(`value` / scalar)
+       Microseconds(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongMicroseconds {
+  public operator fun rem(scalar: Int): Microseconds = Microseconds(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Microseconds = Microseconds(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Microseconds {
      return if (scalar == -1L) {
        -this
      } else {
-       LongMicroseconds(`value` / scalar)
+       Microseconds(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongMicroseconds = LongMicroseconds(`value` % scalar)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Microseconds = Microseconds(value % scalar)
 
-  public operator fun rem(scalar: Long): LongMicroseconds = LongMicroseconds(`value` % scalar)
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds =
-      LongMicroseconds(`value` plusExact microseconds.value)
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds =
-      LongMicroseconds(`value` minusExact microseconds.value)
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds =
-      LongMicroseconds(`value` plusExact microseconds.value)
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      LongMicroseconds(`value` minusExact microseconds.value)
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMicroseconds = this +
-      milliseconds.inMicroseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMicroseconds = this -
-      milliseconds.inMicroseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMicroseconds = this +
-      milliseconds.inMicroseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMicroseconds = this -
-      milliseconds.inMicroseconds
-
-  public operator fun plus(seconds: IntSeconds): LongMicroseconds = this + seconds.inMicroseconds
-
-  public operator fun minus(seconds: IntSeconds): LongMicroseconds = this - seconds.inMicroseconds
-
-  public operator fun plus(seconds: LongSeconds): LongMicroseconds = this + seconds.inMicroseconds
-
-  public operator fun minus(seconds: LongSeconds): LongMicroseconds = this - seconds.inMicroseconds
-
-  public operator fun plus(minutes: IntMinutes): LongMicroseconds = this + minutes.inMicroseconds
-
-  public operator fun minus(minutes: IntMinutes): LongMicroseconds = this - minutes.inMicroseconds
-
-  public operator fun plus(minutes: LongMinutes): LongMicroseconds = this + minutes.inMicroseconds
-
-  public operator fun minus(minutes: LongMinutes): LongMicroseconds = this - minutes.inMicroseconds
-
-  public operator fun plus(hours: IntHours): LongMicroseconds = this + hours.inMicroseconds
-
-  public operator fun minus(hours: IntHours): LongMicroseconds = this - hours.inMicroseconds
-
-  public operator fun plus(hours: LongHours): LongMicroseconds = this + hours.inMicroseconds
-
-  public operator fun minus(hours: LongHours): LongMicroseconds = this - hours.inMicroseconds
-
-  public operator fun plus(days: IntDays): LongMicroseconds = this + days.inMicroseconds
-
-  public operator fun minus(days: IntDays): LongMicroseconds = this - days.inMicroseconds
-
-  public operator fun plus(days: LongDays): LongMicroseconds = this + days.inMicroseconds
-
-  public operator fun minus(days: LongDays): LongMicroseconds = this - days.inMicroseconds
-
-  public inline fun <T> toComponents(action: (milliseconds: LongMilliseconds,
-      microseconds: IntMicroseconds) -> T): T {
-    val milliseconds = (`value` / MICROSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = (`value` % MICROSECONDS_PER_MILLISECOND).toInt().microseconds
+  public inline fun <T> toComponentValues(action: (milliseconds: Long, microseconds: Int) -> T): T {
+    val milliseconds = (value / MICROSECONDS_PER_MILLISECOND)
+    val microseconds = (value % MICROSECONDS_PER_MILLISECOND).toInt()
     return action(milliseconds, microseconds)
   }
 
-  public inline fun <T> toComponents(action: (
-    seconds: LongSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds
+  public inline fun <T> toComponents(action: (milliseconds: Milliseconds,
+      microseconds: Microseconds) -> T): T {
+     return toComponentValues { milliseconds, microseconds ->
+         action(Milliseconds(milliseconds), Microseconds(microseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    seconds: Long,
+    milliseconds: Int,
+    microseconds: Int
   ) -> T): T {
-    val seconds = (`value` / MICROSECONDS_PER_SECOND).seconds
-    val milliseconds = ((`value` % MICROSECONDS_PER_SECOND) /
-        MICROSECONDS_PER_MILLISECOND).toInt().milliseconds
-    val microseconds = (`value` % MICROSECONDS_PER_MILLISECOND).toInt().microseconds
+    val seconds = (value / MICROSECONDS_PER_SECOND)
+    val milliseconds = ((value % MICROSECONDS_PER_SECOND) / MICROSECONDS_PER_MILLISECOND).toInt()
+    val microseconds = (value % MICROSECONDS_PER_MILLISECOND).toInt()
     return action(seconds, milliseconds, microseconds)
   }
 
   public inline fun <T> toComponents(action: (
-    minutes: LongMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds
+    seconds: Seconds,
+    milliseconds: Milliseconds,
+    microseconds: Microseconds
   ) -> T): T {
-    val minutes = (`value` / MICROSECONDS_PER_MINUTE).minutes
-    val seconds = ((`value` % MICROSECONDS_PER_MINUTE) / MICROSECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = ((`value` % MICROSECONDS_PER_SECOND) /
-        MICROSECONDS_PER_MILLISECOND).toInt().milliseconds
-    val microseconds = (`value` % MICROSECONDS_PER_MILLISECOND).toInt().microseconds
+     return toComponentValues { seconds, milliseconds, microseconds ->
+         action(Seconds(seconds), Milliseconds(milliseconds), Microseconds(microseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    minutes: Long,
+    seconds: Int,
+    milliseconds: Int,
+    microseconds: Int
+  ) -> T): T {
+    val minutes = (value / MICROSECONDS_PER_MINUTE)
+    val seconds = ((value % MICROSECONDS_PER_MINUTE) / MICROSECONDS_PER_SECOND).toInt()
+    val milliseconds = ((value % MICROSECONDS_PER_SECOND) / MICROSECONDS_PER_MILLISECOND).toInt()
+    val microseconds = (value % MICROSECONDS_PER_MILLISECOND).toInt()
     return action(minutes, seconds, milliseconds, microseconds)
   }
 
   public inline fun <T> toComponents(action: (
-    hours: LongHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds
+    minutes: Minutes,
+    seconds: Seconds,
+    milliseconds: Milliseconds,
+    microseconds: Microseconds
   ) -> T): T {
-    val hours = (`value` / MICROSECONDS_PER_HOUR).hours
-    val minutes = ((`value` % MICROSECONDS_PER_HOUR) / MICROSECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % MICROSECONDS_PER_MINUTE) / MICROSECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = ((`value` % MICROSECONDS_PER_SECOND) /
-        MICROSECONDS_PER_MILLISECOND).toInt().milliseconds
-    val microseconds = (`value` % MICROSECONDS_PER_MILLISECOND).toInt().microseconds
+     return toComponentValues { minutes, seconds, milliseconds, microseconds ->
+         action(Minutes(minutes), Seconds(seconds), Milliseconds(milliseconds),
+        Microseconds(microseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    hours: Long,
+    minutes: Int,
+    seconds: Int,
+    milliseconds: Int,
+    microseconds: Int
+  ) -> T): T {
+    val hours = (value / MICROSECONDS_PER_HOUR)
+    val minutes = ((value % MICROSECONDS_PER_HOUR) / MICROSECONDS_PER_MINUTE).toInt()
+    val seconds = ((value % MICROSECONDS_PER_MINUTE) / MICROSECONDS_PER_SECOND).toInt()
+    val milliseconds = ((value % MICROSECONDS_PER_SECOND) / MICROSECONDS_PER_MILLISECOND).toInt()
+    val microseconds = (value % MICROSECONDS_PER_MILLISECOND).toInt()
     return action(hours, minutes, seconds, milliseconds, microseconds)
   }
 
   public inline fun <T> toComponents(action: (
-    days: LongDays,
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds
+    hours: Hours,
+    minutes: Minutes,
+    seconds: Seconds,
+    milliseconds: Milliseconds,
+    microseconds: Microseconds
   ) -> T): T {
-    val days = (`value` / MICROSECONDS_PER_DAY).days
-    val hours = ((`value` % MICROSECONDS_PER_DAY) / MICROSECONDS_PER_HOUR).toInt().hours
-    val minutes = ((`value` % MICROSECONDS_PER_HOUR) / MICROSECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % MICROSECONDS_PER_MINUTE) / MICROSECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = ((`value` % MICROSECONDS_PER_SECOND) /
-        MICROSECONDS_PER_MILLISECOND).toInt().milliseconds
-    val microseconds = (`value` % MICROSECONDS_PER_MILLISECOND).toInt().microseconds
+     return toComponentValues { hours, minutes, seconds, milliseconds, microseconds ->
+         action(Hours(hours), Minutes(minutes), Seconds(seconds), Milliseconds(milliseconds),
+        Microseconds(microseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    days: Long,
+    hours: Int,
+    minutes: Int,
+    seconds: Int,
+    milliseconds: Int,
+    microseconds: Int
+  ) -> T): T {
+    val days = (value / MICROSECONDS_PER_DAY)
+    val hours = ((value % MICROSECONDS_PER_DAY) / MICROSECONDS_PER_HOUR).toInt()
+    val minutes = ((value % MICROSECONDS_PER_HOUR) / MICROSECONDS_PER_MINUTE).toInt()
+    val seconds = ((value % MICROSECONDS_PER_MINUTE) / MICROSECONDS_PER_SECOND).toInt()
+    val milliseconds = ((value % MICROSECONDS_PER_SECOND) / MICROSECONDS_PER_MILLISECOND).toInt()
+    val microseconds = (value % MICROSECONDS_PER_MILLISECOND).toInt()
     return action(days, hours, minutes, seconds, milliseconds, microseconds)
   }
 
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.microseconds(`value`)
+  public inline fun <T> toComponents(action: (
+    days: Days,
+    hours: Hours,
+    minutes: Minutes,
+    seconds: Seconds,
+    milliseconds: Milliseconds,
+    microseconds: Microseconds
+  ) -> T): T {
+     return toComponentValues { days, hours, minutes, seconds, milliseconds, microseconds ->
+         action(Days(days), Hours(hours), Minutes(minutes), Seconds(seconds),
+        Milliseconds(milliseconds), Microseconds(microseconds))
+     }
+  }
 
   /**
-   * Converts this duration to [IntMicroseconds].
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  public fun toIntMicroseconds(): IntMicroseconds = IntMicroseconds(`value`.toIntExact())
-
-  /**
-   * Converts this duration to [IntMicroseconds] without checking for overflow.
-   */
-  @PublishedApi
-  internal fun toIntMicrosecondsUnchecked(): IntMicroseconds = IntMicroseconds(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntMicroseconds]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntMicroseconds(): Microseconds = this
+
+  /**
+   * Converts this duration to [IntMicroseconds] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntMicrosecondsUnchecked(): Microseconds = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongMicroseconds = LongMicroseconds(Long.MIN_VALUE)
+    public val MIN: Microseconds = Microseconds(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongMicroseconds = LongMicroseconds(Long.MAX_VALUE)
+    public val MAX: Microseconds = Microseconds(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of microseconds.
  */
-public val Long.microseconds: LongMicroseconds
-  get() = LongMicroseconds(this)
+public val Int.microseconds: Microseconds
+  get() = Microseconds(this)
 
 /**
- * Multiplies this value by a duration of microseconds.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of microseconds. @throws ArithmeticException if overflow
+ * occurs
  */
-public operator fun Int.times(microseconds: LongMicroseconds): LongMicroseconds = microseconds *
-    this
+public operator fun Int.times(microseconds: Microseconds): Microseconds = microseconds * this
 
 /**
- * Multiplies this value by a duration of microseconds.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of microseconds.
  */
-public operator fun Long.times(microseconds: LongMicroseconds): LongMicroseconds = microseconds *
-    this
+public val Long.microseconds: Microseconds
+  get() = Microseconds(this)
 
 /**
- * Converts this duration to Island Time [LongMicroseconds].
+ * Multiplies this value by a duration of microseconds. @throws ArithmeticException if overflow
+ * occurs
+ */
+public operator fun Long.times(microseconds: Microseconds): Microseconds = microseconds * this
+
+/**
+ * Converts this duration to Island Time [Microseconds].
  */
 @ExperimentalTime
-public fun KotlinDuration.toIslandMicroseconds(): LongMicroseconds =
-    LongMicroseconds(this.toLong(KotlinDurationUnit.MICROSECONDS))
+public fun KotlinDuration.toIslandMicroseconds(): Microseconds =
+    Microseconds(this.toLong(KotlinDurationUnit.MICROSECONDS))

--- a/core/src/commonMain/generated/io/islandtime/measures/_Milliseconds.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Milliseconds.kt
@@ -21,6 +21,7 @@ import io.islandtime.`internal`.NANOSECONDS_PER_MILLISECOND
 import io.islandtime.`internal`.toZeroPaddedString
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -89,16 +90,31 @@ public value class IntMilliseconds(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.milliseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.milliseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.milliseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntMilliseconds): Int = `value`.compareTo(other.`value`)
@@ -418,16 +434,31 @@ public value class LongMilliseconds(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.milliseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.milliseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.milliseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongMilliseconds): Int = `value`.compareTo(other.`value`)
@@ -649,6 +680,11 @@ public value class LongMilliseconds(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Milliseconds.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Milliseconds.kt
@@ -18,10 +18,12 @@ import io.islandtime.`internal`.MILLISECONDS_PER_HOUR
 import io.islandtime.`internal`.MILLISECONDS_PER_MINUTE
 import io.islandtime.`internal`.MILLISECONDS_PER_SECOND
 import io.islandtime.`internal`.NANOSECONDS_PER_MILLISECOND
+import io.islandtime.`internal`.deprecatedToError
 import io.islandtime.`internal`.toZeroPaddedString
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -34,402 +36,114 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Duration as KotlinDuration
 import kotlin.time.DurationUnit as KotlinDurationUnit
 
-/**
- * A number of milliseconds.
- */
+@Deprecated(
+  message = "Replace with Milliseconds.",
+  replaceWith = ReplaceWith("Milliseconds"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntMilliseconds = Milliseconds
+
+@Deprecated(
+  message = "Replace with Milliseconds.",
+  replaceWith = ReplaceWith("Milliseconds"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongMilliseconds = Milliseconds
+
 @JvmInline
-public value class IntMilliseconds(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntMilliseconds> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntMilliseconds
-    get() = IntMilliseconds(absExact(`value`))
-
-  /**
-   * Converts this duration to nanoseconds.
-   */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value`.toLong() * NANOSECONDS_PER_MILLISECOND).nanoseconds
-
-  /**
-   * Converts this duration to microseconds.
-   */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value`.toLong() * MICROSECONDS_PER_MILLISECOND).microseconds
-
-  /**
-   * Converts this duration to the number of whole seconds.
-   */
-  public val inSeconds: IntSeconds
-    get() = (`value` / MILLISECONDS_PER_SECOND).seconds
-
-  /**
-   * Converts this duration to the number of whole minutes.
-   */
-  public val inMinutes: IntMinutes
-    get() = (`value` / MILLISECONDS_PER_MINUTE).minutes
-
-  /**
-   * Converts this duration to the number of whole hours.
-   */
-  public val inHours: IntHours
-    get() = (`value` / MILLISECONDS_PER_HOUR).hours
-
-  /**
-   * Converts this duration to the number of whole days.
-   */
-  public val inDays: IntDays
-    get() = (`value` / MILLISECONDS_PER_DAY).days
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.milliseconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.milliseconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.milliseconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntMilliseconds): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return if (`value` == 0) {
-       "PT0S"
-     } else {
-       buildString {
-         val wholePart = (`value` / 1000).absoluteValue
-         val fractionalPart = (`value` % 1000).absoluteValue
-         if (`value` < 0) { append('-') }
-         append("PT")
-         append(wholePart)
-         if (fractionalPart > 0) {
-           append('.')
-           append(fractionalPart.toZeroPaddedString(3).dropLastWhile { it == '0' })
-         }
-         append('S')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntMilliseconds = IntMilliseconds(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntMilliseconds = IntMilliseconds(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): LongMilliseconds = this.toLongMilliseconds() * scalar
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongMilliseconds = this.toLongMilliseconds() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntMilliseconds {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntMilliseconds(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongMilliseconds = this.toLongMilliseconds() / scalar
-
-  public operator fun rem(scalar: Int): IntMilliseconds = IntMilliseconds(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongMilliseconds = this.toLongMilliseconds() % scalar
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds =
-      this.toLongMilliseconds().inNanoseconds + nanoseconds.toLongNanoseconds()
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds =
-      this.toLongMilliseconds().inNanoseconds - nanoseconds.toLongNanoseconds()
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongMilliseconds().inNanoseconds + nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongMilliseconds().inNanoseconds - nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds =
-      this.toLongMilliseconds().inMicroseconds + microseconds.toLongMicroseconds()
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds =
-      this.toLongMilliseconds().inMicroseconds - microseconds.toLongMicroseconds()
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.toLongMilliseconds().inMicroseconds + microseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.toLongMilliseconds().inMicroseconds - microseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMilliseconds =
-      LongMilliseconds(`value`.toLong() plusExact milliseconds.value)
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMilliseconds =
-      LongMilliseconds(`value`.toLong() minusExact milliseconds.value)
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMilliseconds =
-      LongMilliseconds(`value`.toLong() plusExact milliseconds.value)
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMilliseconds =
-      LongMilliseconds(`value`.toLong() minusExact milliseconds.value)
-
-  public operator fun plus(seconds: IntSeconds): LongMilliseconds = this.toLongMilliseconds() +
-      seconds.inMilliseconds
-
-  public operator fun minus(seconds: IntSeconds): LongMilliseconds = this.toLongMilliseconds() -
-      seconds.inMilliseconds
-
-  public operator fun plus(seconds: LongSeconds): LongMilliseconds = this.toLongMilliseconds() +
-      seconds.inMilliseconds
-
-  public operator fun minus(seconds: LongSeconds): LongMilliseconds = this.toLongMilliseconds() -
-      seconds.inMilliseconds
-
-  public operator fun plus(minutes: IntMinutes): LongMilliseconds = this.toLongMilliseconds() +
-      minutes.inMilliseconds
-
-  public operator fun minus(minutes: IntMinutes): LongMilliseconds = this.toLongMilliseconds() -
-      minutes.inMilliseconds
-
-  public operator fun plus(minutes: LongMinutes): LongMilliseconds = this.toLongMilliseconds() +
-      minutes.inMilliseconds
-
-  public operator fun minus(minutes: LongMinutes): LongMilliseconds = this.toLongMilliseconds() -
-      minutes.inMilliseconds
-
-  public operator fun plus(hours: IntHours): LongMilliseconds = this.toLongMilliseconds() +
-      hours.inMilliseconds
-
-  public operator fun minus(hours: IntHours): LongMilliseconds = this.toLongMilliseconds() -
-      hours.inMilliseconds
-
-  public operator fun plus(hours: LongHours): LongMilliseconds = this.toLongMilliseconds() +
-      hours.inMilliseconds
-
-  public operator fun minus(hours: LongHours): LongMilliseconds = this.toLongMilliseconds() -
-      hours.inMilliseconds
-
-  public operator fun plus(days: IntDays): LongMilliseconds = this.toLongMilliseconds() +
-      days.inMilliseconds
-
-  public operator fun minus(days: IntDays): LongMilliseconds = this.toLongMilliseconds() -
-      days.inMilliseconds
-
-  public operator fun plus(days: LongDays): LongMilliseconds = this.toLongMilliseconds() +
-      days.inMilliseconds
-
-  public operator fun minus(days: LongDays): LongMilliseconds = this.toLongMilliseconds() -
-      days.inMilliseconds
-
-  public inline fun <T> toComponents(action: (seconds: IntSeconds, milliseconds: IntMilliseconds) ->
-      T): T {
-    val seconds = (`value` / MILLISECONDS_PER_SECOND).seconds
-    val milliseconds = (`value` % MILLISECONDS_PER_SECOND).milliseconds
-    return action(seconds, milliseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds
-  ) -> T): T {
-    val minutes = (`value` / MILLISECONDS_PER_MINUTE).minutes
-    val seconds = ((`value` % MILLISECONDS_PER_MINUTE) / MILLISECONDS_PER_SECOND).seconds
-    val milliseconds = (`value` % MILLISECONDS_PER_SECOND).milliseconds
-    return action(minutes, seconds, milliseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds
-  ) -> T): T {
-    val hours = (`value` / MILLISECONDS_PER_HOUR).hours
-    val minutes = ((`value` % MILLISECONDS_PER_HOUR) / MILLISECONDS_PER_MINUTE).minutes
-    val seconds = ((`value` % MILLISECONDS_PER_MINUTE) / MILLISECONDS_PER_SECOND).seconds
-    val milliseconds = (`value` % MILLISECONDS_PER_SECOND).milliseconds
-    return action(hours, minutes, seconds, milliseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    days: IntDays,
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds
-  ) -> T): T {
-    val days = (`value` / MILLISECONDS_PER_DAY).days
-    val hours = ((`value` % MILLISECONDS_PER_DAY) / MILLISECONDS_PER_HOUR).hours
-    val minutes = ((`value` % MILLISECONDS_PER_HOUR) / MILLISECONDS_PER_MINUTE).minutes
-    val seconds = ((`value` % MILLISECONDS_PER_MINUTE) / MILLISECONDS_PER_SECOND).seconds
-    val milliseconds = (`value` % MILLISECONDS_PER_SECOND).milliseconds
-    return action(days, hours, minutes, seconds, milliseconds)
-  }
-
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.milliseconds(`value`)
-
-  /**
-   * Converts this duration to [LongMilliseconds].
-   */
-  public fun toLongMilliseconds(): LongMilliseconds = LongMilliseconds(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntMilliseconds = IntMilliseconds(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntMilliseconds = IntMilliseconds(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of milliseconds.
- */
-public val Int.milliseconds: IntMilliseconds
-  get() = IntMilliseconds(this)
-
-/**
- * Multiplies this value by a duration of milliseconds.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(milliseconds: IntMilliseconds): LongMilliseconds = milliseconds * this
-
-/**
- * Multiplies this value by a duration of milliseconds.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(milliseconds: IntMilliseconds): LongMilliseconds = milliseconds *
-    this
-
-/**
- * A number of milliseconds.
- */
-@JvmInline
-public value class LongMilliseconds(
+public value class Milliseconds(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongMilliseconds> {
+) : Comparable<Milliseconds> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongMilliseconds
-    get() = LongMilliseconds(absExact(`value`))
+  public val absoluteValue: Milliseconds
+    get() = Milliseconds(absExact(value))
 
   /**
-   * Converts this duration to nanoseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to nanoseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value` timesExact NANOSECONDS_PER_MILLISECOND).nanoseconds
+  public val inNanoseconds: Nanoseconds
+    get() = Nanoseconds(value timesExact NANOSECONDS_PER_MILLISECOND)
 
   /**
    * Converts this duration to nanoseconds without checking for overflow.
    */
-  internal val inNanosecondsUnchecked: LongNanoseconds
-    get() = (`value` * NANOSECONDS_PER_MILLISECOND).nanoseconds
+  internal val inNanosecondsUnchecked: Nanoseconds
+    get() = Nanoseconds(value * NANOSECONDS_PER_MILLISECOND)
 
   /**
-   * Converts this duration to microseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to microseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value` timesExact MICROSECONDS_PER_MILLISECOND).microseconds
+  public val inMicroseconds: Microseconds
+    get() = Microseconds(value timesExact MICROSECONDS_PER_MILLISECOND)
 
   /**
    * Converts this duration to microseconds without checking for overflow.
    */
-  internal val inMicrosecondsUnchecked: LongMicroseconds
-    get() = (`value` * MICROSECONDS_PER_MILLISECOND).microseconds
+  internal val inMicrosecondsUnchecked: Microseconds
+    get() = Microseconds(value * MICROSECONDS_PER_MILLISECOND)
 
   /**
    * Converts this duration to the number of whole seconds.
    */
-  public val inSeconds: LongSeconds
-    get() = (`value` / MILLISECONDS_PER_SECOND).seconds
+  public val inWholeSeconds: Seconds
+    get() = Seconds(value / MILLISECONDS_PER_SECOND)
+
+  @Deprecated(
+    message = "Use inWholeSeconds instead.",
+    replaceWith = ReplaceWith("this.inWholeSeconds"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inSeconds: Seconds
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole minutes.
    */
-  public val inMinutes: LongMinutes
-    get() = (`value` / MILLISECONDS_PER_MINUTE).minutes
+  public val inWholeMinutes: Minutes
+    get() = Minutes(value / MILLISECONDS_PER_MINUTE)
+
+  @Deprecated(
+    message = "Use inWholeMinutes instead.",
+    replaceWith = ReplaceWith("this.inWholeMinutes"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inMinutes: Minutes
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole hours.
    */
-  public val inHours: LongHours
-    get() = (`value` / MILLISECONDS_PER_HOUR).hours
+  public val inWholeHours: Hours
+    get() = Hours(value / MILLISECONDS_PER_HOUR)
+
+  @Deprecated(
+    message = "Use inWholeHours instead.",
+    replaceWith = ReplaceWith("this.inWholeHours"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inHours: Hours
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole days.
    */
-  public val inDays: LongDays
-    get() = (`value` / MILLISECONDS_PER_DAY).days
+  public val inWholeDays: Days
+    get() = Days(value / MILLISECONDS_PER_DAY)
+
+  @Deprecated(
+    message = "Use inWholeDays instead.",
+    replaceWith = ReplaceWith("this.inWholeDays"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inDays: Days
+    get() = deprecatedToError()
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -439,7 +153,7 @@ public value class LongMilliseconds(
     replaceWith = ReplaceWith("this == 0L.milliseconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -449,7 +163,7 @@ public value class LongMilliseconds(
     replaceWith = ReplaceWith("this < 0L.milliseconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -459,21 +173,27 @@ public value class LongMilliseconds(
     replaceWith = ReplaceWith("this > 0L.milliseconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongMilliseconds): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Milliseconds): Int = value.compareTo(other.value)
+
+  /**
+   * Converts this duration to a [kotlin.time.Duration].
+   */
+  @ExperimentalTime
+  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.milliseconds(value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return if (`value` == 0L) {
+     return if (value == 0L) {
        "PT0S"
      } else {
        buildString {
-         val wholePart = (`value` / 1000).absoluteValue
-         val fractionalPart = ((`value` % 1000).toInt()).absoluteValue
-         if (`value` < 0) { append('-') }
+         val wholePart = (value / 1000).absoluteValue
+         val fractionalPart = (value % 1000).toInt().absoluteValue
+         if (value < 0) { append('-') }
          append("PT")
          append(wholePart)
          if (fractionalPart > 0) {
@@ -486,242 +206,259 @@ public value class LongMilliseconds(
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongMilliseconds = LongMilliseconds(`value`.negateExact())
+  public operator fun unaryMinus(): Milliseconds = Milliseconds(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongMilliseconds = LongMilliseconds(-`value`)
+  internal fun negateUnchecked(): Milliseconds = Milliseconds(-value)
+
+  public operator fun plus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds + nanoseconds
+
+  public operator fun minus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds -
+      nanoseconds
+
+  public operator fun plus(microseconds: Microseconds): Microseconds = this.inMicroseconds +
+      microseconds
+
+  public operator fun minus(microseconds: Microseconds): Microseconds = this.inMicroseconds -
+      microseconds
+
+  public operator fun plus(milliseconds: Milliseconds): Milliseconds = Milliseconds(value plusExact
+      milliseconds.value)
+
+  public operator fun minus(milliseconds: Milliseconds): Milliseconds =
+      Milliseconds(value minusExact milliseconds.value)
+
+  public operator fun plus(seconds: Seconds): Milliseconds = this + seconds.inMilliseconds
+
+  public operator fun minus(seconds: Seconds): Milliseconds = this - seconds.inMilliseconds
+
+  public operator fun plus(minutes: Minutes): Milliseconds = this + minutes.inMilliseconds
+
+  public operator fun minus(minutes: Minutes): Milliseconds = this - minutes.inMilliseconds
+
+  public operator fun plus(hours: Hours): Milliseconds = this + hours.inMilliseconds
+
+  public operator fun minus(hours: Hours): Milliseconds = this - hours.inMilliseconds
+
+  public operator fun plus(days: Days): Milliseconds = this + days.inMilliseconds
+
+  public operator fun minus(days: Days): Milliseconds = this - days.inMilliseconds
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongMilliseconds = LongMilliseconds(`value` timesExact
-      scalar)
+  public operator fun times(scalar: Int): Milliseconds = Milliseconds(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongMilliseconds = LongMilliseconds(`value` timesExact
-      scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongMilliseconds {
+  public operator fun div(scalar: Int): Milliseconds {
      return if (scalar == -1) {
        -this
      } else {
-       LongMilliseconds(`value` / scalar)
+       Milliseconds(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongMilliseconds {
+  public operator fun rem(scalar: Int): Milliseconds = Milliseconds(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Milliseconds = Milliseconds(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Milliseconds {
      return if (scalar == -1L) {
        -this
      } else {
-       LongMilliseconds(`value` / scalar)
+       Milliseconds(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongMilliseconds = LongMilliseconds(`value` % scalar)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Milliseconds = Milliseconds(value % scalar)
 
-  public operator fun rem(scalar: Long): LongMilliseconds = LongMilliseconds(`value` % scalar)
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds -
-      microseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.inMicroseconds - microseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMilliseconds =
-      LongMilliseconds(`value` plusExact milliseconds.value)
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMilliseconds =
-      LongMilliseconds(`value` minusExact milliseconds.value)
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMilliseconds =
-      LongMilliseconds(`value` plusExact milliseconds.value)
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMilliseconds =
-      LongMilliseconds(`value` minusExact milliseconds.value)
-
-  public operator fun plus(seconds: IntSeconds): LongMilliseconds = this + seconds.inMilliseconds
-
-  public operator fun minus(seconds: IntSeconds): LongMilliseconds = this - seconds.inMilliseconds
-
-  public operator fun plus(seconds: LongSeconds): LongMilliseconds = this + seconds.inMilliseconds
-
-  public operator fun minus(seconds: LongSeconds): LongMilliseconds = this - seconds.inMilliseconds
-
-  public operator fun plus(minutes: IntMinutes): LongMilliseconds = this + minutes.inMilliseconds
-
-  public operator fun minus(minutes: IntMinutes): LongMilliseconds = this - minutes.inMilliseconds
-
-  public operator fun plus(minutes: LongMinutes): LongMilliseconds = this + minutes.inMilliseconds
-
-  public operator fun minus(minutes: LongMinutes): LongMilliseconds = this - minutes.inMilliseconds
-
-  public operator fun plus(hours: IntHours): LongMilliseconds = this + hours.inMilliseconds
-
-  public operator fun minus(hours: IntHours): LongMilliseconds = this - hours.inMilliseconds
-
-  public operator fun plus(hours: LongHours): LongMilliseconds = this + hours.inMilliseconds
-
-  public operator fun minus(hours: LongHours): LongMilliseconds = this - hours.inMilliseconds
-
-  public operator fun plus(days: IntDays): LongMilliseconds = this + days.inMilliseconds
-
-  public operator fun minus(days: IntDays): LongMilliseconds = this - days.inMilliseconds
-
-  public operator fun plus(days: LongDays): LongMilliseconds = this + days.inMilliseconds
-
-  public operator fun minus(days: LongDays): LongMilliseconds = this - days.inMilliseconds
-
-  public inline fun <T> toComponents(action: (seconds: LongSeconds,
-      milliseconds: IntMilliseconds) -> T): T {
-    val seconds = (`value` / MILLISECONDS_PER_SECOND).seconds
-    val milliseconds = (`value` % MILLISECONDS_PER_SECOND).toInt().milliseconds
+  public inline fun <T> toComponentValues(action: (seconds: Long, milliseconds: Int) -> T): T {
+    val seconds = (value / MILLISECONDS_PER_SECOND)
+    val milliseconds = (value % MILLISECONDS_PER_SECOND).toInt()
     return action(seconds, milliseconds)
   }
 
-  public inline fun <T> toComponents(action: (
-    minutes: LongMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds
+  public inline fun <T> toComponents(action: (seconds: Seconds, milliseconds: Milliseconds) -> T):
+      T {
+     return toComponentValues { seconds, milliseconds ->
+         action(Seconds(seconds), Milliseconds(milliseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    minutes: Long,
+    seconds: Int,
+    milliseconds: Int
   ) -> T): T {
-    val minutes = (`value` / MILLISECONDS_PER_MINUTE).minutes
-    val seconds = ((`value` % MILLISECONDS_PER_MINUTE) / MILLISECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = (`value` % MILLISECONDS_PER_SECOND).toInt().milliseconds
+    val minutes = (value / MILLISECONDS_PER_MINUTE)
+    val seconds = ((value % MILLISECONDS_PER_MINUTE) / MILLISECONDS_PER_SECOND).toInt()
+    val milliseconds = (value % MILLISECONDS_PER_SECOND).toInt()
     return action(minutes, seconds, milliseconds)
   }
 
   public inline fun <T> toComponents(action: (
-    hours: LongHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds
+    minutes: Minutes,
+    seconds: Seconds,
+    milliseconds: Milliseconds
   ) -> T): T {
-    val hours = (`value` / MILLISECONDS_PER_HOUR).hours
-    val minutes = ((`value` % MILLISECONDS_PER_HOUR) / MILLISECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % MILLISECONDS_PER_MINUTE) / MILLISECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = (`value` % MILLISECONDS_PER_SECOND).toInt().milliseconds
+     return toComponentValues { minutes, seconds, milliseconds ->
+         action(Minutes(minutes), Seconds(seconds), Milliseconds(milliseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    hours: Long,
+    minutes: Int,
+    seconds: Int,
+    milliseconds: Int
+  ) -> T): T {
+    val hours = (value / MILLISECONDS_PER_HOUR)
+    val minutes = ((value % MILLISECONDS_PER_HOUR) / MILLISECONDS_PER_MINUTE).toInt()
+    val seconds = ((value % MILLISECONDS_PER_MINUTE) / MILLISECONDS_PER_SECOND).toInt()
+    val milliseconds = (value % MILLISECONDS_PER_SECOND).toInt()
     return action(hours, minutes, seconds, milliseconds)
   }
 
   public inline fun <T> toComponents(action: (
-    days: LongDays,
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds
+    hours: Hours,
+    minutes: Minutes,
+    seconds: Seconds,
+    milliseconds: Milliseconds
   ) -> T): T {
-    val days = (`value` / MILLISECONDS_PER_DAY).days
-    val hours = ((`value` % MILLISECONDS_PER_DAY) / MILLISECONDS_PER_HOUR).toInt().hours
-    val minutes = ((`value` % MILLISECONDS_PER_HOUR) / MILLISECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % MILLISECONDS_PER_MINUTE) / MILLISECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = (`value` % MILLISECONDS_PER_SECOND).toInt().milliseconds
+     return toComponentValues { hours, minutes, seconds, milliseconds ->
+         action(Hours(hours), Minutes(minutes), Seconds(seconds), Milliseconds(milliseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    days: Long,
+    hours: Int,
+    minutes: Int,
+    seconds: Int,
+    milliseconds: Int
+  ) -> T): T {
+    val days = (value / MILLISECONDS_PER_DAY)
+    val hours = ((value % MILLISECONDS_PER_DAY) / MILLISECONDS_PER_HOUR).toInt()
+    val minutes = ((value % MILLISECONDS_PER_HOUR) / MILLISECONDS_PER_MINUTE).toInt()
+    val seconds = ((value % MILLISECONDS_PER_MINUTE) / MILLISECONDS_PER_SECOND).toInt()
+    val milliseconds = (value % MILLISECONDS_PER_SECOND).toInt()
     return action(days, hours, minutes, seconds, milliseconds)
   }
 
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.milliseconds(`value`)
+  public inline fun <T> toComponents(action: (
+    days: Days,
+    hours: Hours,
+    minutes: Minutes,
+    seconds: Seconds,
+    milliseconds: Milliseconds
+  ) -> T): T {
+     return toComponentValues { days, hours, minutes, seconds, milliseconds ->
+         action(Days(days), Hours(hours), Minutes(minutes), Seconds(seconds),
+        Milliseconds(milliseconds))
+     }
+  }
 
   /**
-   * Converts this duration to [IntMilliseconds].
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  public fun toIntMilliseconds(): IntMilliseconds = IntMilliseconds(`value`.toIntExact())
-
-  /**
-   * Converts this duration to [IntMilliseconds] without checking for overflow.
-   */
-  @PublishedApi
-  internal fun toIntMillisecondsUnchecked(): IntMilliseconds = IntMilliseconds(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntMilliseconds]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntMilliseconds(): Milliseconds = this
+
+  /**
+   * Converts this duration to [IntMilliseconds] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntMillisecondsUnchecked(): Milliseconds = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongMilliseconds = LongMilliseconds(Long.MIN_VALUE)
+    public val MIN: Milliseconds = Milliseconds(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongMilliseconds = LongMilliseconds(Long.MAX_VALUE)
+    public val MAX: Milliseconds = Milliseconds(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of milliseconds.
  */
-public val Long.milliseconds: LongMilliseconds
-  get() = LongMilliseconds(this)
+public val Int.milliseconds: Milliseconds
+  get() = Milliseconds(this)
 
 /**
- * Multiplies this value by a duration of milliseconds.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of milliseconds. @throws ArithmeticException if overflow
+ * occurs
  */
-public operator fun Int.times(milliseconds: LongMilliseconds): LongMilliseconds = milliseconds *
-    this
+public operator fun Int.times(milliseconds: Milliseconds): Milliseconds = milliseconds * this
 
 /**
- * Multiplies this value by a duration of milliseconds.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of milliseconds.
  */
-public operator fun Long.times(milliseconds: LongMilliseconds): LongMilliseconds = milliseconds *
-    this
+public val Long.milliseconds: Milliseconds
+  get() = Milliseconds(this)
 
 /**
- * Converts this duration to Island Time [LongMilliseconds].
+ * Multiplies this value by a duration of milliseconds. @throws ArithmeticException if overflow
+ * occurs
+ */
+public operator fun Long.times(milliseconds: Milliseconds): Milliseconds = milliseconds * this
+
+/**
+ * Converts this duration to Island Time [Milliseconds].
  */
 @ExperimentalTime
-public fun KotlinDuration.toIslandMilliseconds(): LongMilliseconds =
-    LongMilliseconds(this.toLong(KotlinDurationUnit.MILLISECONDS))
+public fun KotlinDuration.toIslandMilliseconds(): Milliseconds =
+    Milliseconds(this.toLong(KotlinDurationUnit.MILLISECONDS))

--- a/core/src/commonMain/generated/io/islandtime/measures/_Minutes.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Minutes.kt
@@ -18,9 +18,11 @@ import io.islandtime.`internal`.MINUTES_PER_DAY
 import io.islandtime.`internal`.MINUTES_PER_HOUR
 import io.islandtime.`internal`.NANOSECONDS_PER_MINUTE
 import io.islandtime.`internal`.SECONDS_PER_MINUTE
+import io.islandtime.`internal`.deprecatedToError
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -33,384 +35,110 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Duration as KotlinDuration
 import kotlin.time.DurationUnit as KotlinDurationUnit
 
-/**
- * A number of minutes.
- */
+@Deprecated(
+  message = "Replace with Minutes.",
+  replaceWith = ReplaceWith("Minutes"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntMinutes = Minutes
+
+@Deprecated(
+  message = "Replace with Minutes.",
+  replaceWith = ReplaceWith("Minutes"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongMinutes = Minutes
+
 @JvmInline
-public value class IntMinutes(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntMinutes> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntMinutes
-    get() = IntMinutes(absExact(`value`))
-
-  /**
-   * Converts this duration to nanoseconds.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value`.toLong() timesExact NANOSECONDS_PER_MINUTE).nanoseconds
-
-  /**
-   * Converts this duration to nanoseconds without checking for overflow.
-   */
-  internal val inNanosecondsUnchecked: LongNanoseconds
-    get() = (`value`.toLong() * NANOSECONDS_PER_MINUTE).nanoseconds
-
-  /**
-   * Converts this duration to microseconds.
-   */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value`.toLong() * MICROSECONDS_PER_MINUTE).microseconds
-
-  /**
-   * Converts this duration to milliseconds.
-   */
-  public val inMilliseconds: LongMilliseconds
-    get() = (`value`.toLong() * MILLISECONDS_PER_MINUTE).milliseconds
-
-  /**
-   * Converts this duration to seconds.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inSeconds: IntSeconds
-    get() = (`value` timesExact SECONDS_PER_MINUTE).seconds
-
-  /**
-   * Converts this duration to seconds without checking for overflow.
-   */
-  internal val inSecondsUnchecked: IntSeconds
-    get() = (`value` * SECONDS_PER_MINUTE).seconds
-
-  /**
-   * Converts this duration to the number of whole hours.
-   */
-  public val inHours: IntHours
-    get() = (`value` / MINUTES_PER_HOUR).hours
-
-  /**
-   * Converts this duration to the number of whole days.
-   */
-  public val inDays: IntDays
-    get() = (`value` / MINUTES_PER_DAY).days
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.minutes"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.minutes"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.minutes"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntMinutes): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return when (`value`) {
-       0 -> "PT0M"
-       Int.MIN_VALUE -> "-PT2147483648M"
-       else -> buildString {
-         if (`value` < 0) { append('-') }
-         append("PT")
-         append(`value`.absoluteValue)
-         append('M')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntMinutes = IntMinutes(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntMinutes = IntMinutes(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): IntMinutes = IntMinutes(`value` timesExact scalar)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongMinutes = this.toLongMinutes() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntMinutes {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntMinutes(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongMinutes = this.toLongMinutes() / scalar
-
-  public operator fun rem(scalar: Int): IntMinutes = IntMinutes(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongMinutes = this.toLongMinutes() % scalar
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongMinutes().inNanoseconds + nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongMinutes().inNanoseconds - nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds -
-      microseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.toLongMinutes().inMicroseconds + microseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.toLongMinutes().inMicroseconds - microseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds -
-      milliseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.toLongMinutes().inMilliseconds + milliseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.toLongMinutes().inMilliseconds - milliseconds
-
-  public operator fun plus(seconds: IntSeconds): IntSeconds = this.inSeconds + seconds
-
-  public operator fun minus(seconds: IntSeconds): IntSeconds = this.inSeconds - seconds
-
-  public operator fun plus(seconds: LongSeconds): LongSeconds = this.toLongMinutes().inSeconds +
-      seconds
-
-  public operator fun minus(seconds: LongSeconds): LongSeconds = this.toLongMinutes().inSeconds -
-      seconds
-
-  public operator fun plus(minutes: IntMinutes): IntMinutes = IntMinutes(`value` plusExact
-      minutes.value)
-
-  public operator fun minus(minutes: IntMinutes): IntMinutes = IntMinutes(`value` minusExact
-      minutes.value)
-
-  public operator fun plus(minutes: LongMinutes): LongMinutes =
-      LongMinutes(`value`.toLong() plusExact minutes.value)
-
-  public operator fun minus(minutes: LongMinutes): LongMinutes =
-      LongMinutes(`value`.toLong() minusExact minutes.value)
-
-  public operator fun plus(hours: IntHours): IntMinutes = this + hours.inMinutes
-
-  public operator fun minus(hours: IntHours): IntMinutes = this - hours.inMinutes
-
-  public operator fun plus(hours: LongHours): LongMinutes = this.toLongMinutes() + hours.inMinutes
-
-  public operator fun minus(hours: LongHours): LongMinutes = this.toLongMinutes() - hours.inMinutes
-
-  public operator fun plus(days: IntDays): IntMinutes = this + days.inMinutes
-
-  public operator fun minus(days: IntDays): IntMinutes = this - days.inMinutes
-
-  public operator fun plus(days: LongDays): LongMinutes = this.toLongMinutes() + days.inMinutes
-
-  public operator fun minus(days: LongDays): LongMinutes = this.toLongMinutes() - days.inMinutes
-
-  public inline fun <T> toComponents(action: (hours: IntHours, minutes: IntMinutes) -> T): T {
-    val hours = (`value` / MINUTES_PER_HOUR).hours
-    val minutes = (`value` % MINUTES_PER_HOUR).minutes
-    return action(hours, minutes)
-  }
-
-  public inline fun <T> toComponents(action: (
-    days: IntDays,
-    hours: IntHours,
-    minutes: IntMinutes
-  ) -> T): T {
-    val days = (`value` / MINUTES_PER_DAY).days
-    val hours = ((`value` % MINUTES_PER_DAY) / MINUTES_PER_HOUR).hours
-    val minutes = (`value` % MINUTES_PER_HOUR).minutes
-    return action(days, hours, minutes)
-  }
-
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.minutes(`value`)
-
-  /**
-   * Converts this duration to [LongMinutes].
-   */
-  public fun toLongMinutes(): LongMinutes = LongMinutes(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntMinutes = IntMinutes(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntMinutes = IntMinutes(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of minutes.
- */
-public val Int.minutes: IntMinutes
-  get() = IntMinutes(this)
-
-/**
- * Multiplies this value by a duration of minutes.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(minutes: IntMinutes): IntMinutes = minutes * this
-
-/**
- * Multiplies this value by a duration of minutes.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(minutes: IntMinutes): LongMinutes = minutes * this
-
-/**
- * A number of minutes.
- */
-@JvmInline
-public value class LongMinutes(
+public value class Minutes(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongMinutes> {
+) : Comparable<Minutes> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongMinutes
-    get() = LongMinutes(absExact(`value`))
+  public val absoluteValue: Minutes
+    get() = Minutes(absExact(value))
 
   /**
-   * Converts this duration to nanoseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to nanoseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value` timesExact NANOSECONDS_PER_MINUTE).nanoseconds
+  public val inNanoseconds: Nanoseconds
+    get() = Nanoseconds(value timesExact NANOSECONDS_PER_MINUTE)
 
   /**
    * Converts this duration to nanoseconds without checking for overflow.
    */
-  internal val inNanosecondsUnchecked: LongNanoseconds
-    get() = (`value` * NANOSECONDS_PER_MINUTE).nanoseconds
+  internal val inNanosecondsUnchecked: Nanoseconds
+    get() = Nanoseconds(value * NANOSECONDS_PER_MINUTE)
 
   /**
-   * Converts this duration to microseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to microseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value` timesExact MICROSECONDS_PER_MINUTE).microseconds
+  public val inMicroseconds: Microseconds
+    get() = Microseconds(value timesExact MICROSECONDS_PER_MINUTE)
 
   /**
    * Converts this duration to microseconds without checking for overflow.
    */
-  internal val inMicrosecondsUnchecked: LongMicroseconds
-    get() = (`value` * MICROSECONDS_PER_MINUTE).microseconds
+  internal val inMicrosecondsUnchecked: Microseconds
+    get() = Microseconds(value * MICROSECONDS_PER_MINUTE)
 
   /**
-   * Converts this duration to milliseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to milliseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inMilliseconds: LongMilliseconds
-    get() = (`value` timesExact MILLISECONDS_PER_MINUTE).milliseconds
+  public val inMilliseconds: Milliseconds
+    get() = Milliseconds(value timesExact MILLISECONDS_PER_MINUTE)
 
   /**
    * Converts this duration to milliseconds without checking for overflow.
    */
-  internal val inMillisecondsUnchecked: LongMilliseconds
-    get() = (`value` * MILLISECONDS_PER_MINUTE).milliseconds
+  internal val inMillisecondsUnchecked: Milliseconds
+    get() = Milliseconds(value * MILLISECONDS_PER_MINUTE)
 
   /**
-   * Converts this duration to seconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to seconds. @throws ArithmeticException if overflow occurs
    */
-  public val inSeconds: LongSeconds
-    get() = (`value` timesExact SECONDS_PER_MINUTE).seconds
+  public val inSeconds: Seconds
+    get() = Seconds(value timesExact SECONDS_PER_MINUTE)
 
   /**
    * Converts this duration to seconds without checking for overflow.
    */
-  internal val inSecondsUnchecked: LongSeconds
-    get() = (`value` * SECONDS_PER_MINUTE).seconds
+  internal val inSecondsUnchecked: Seconds
+    get() = Seconds(value * SECONDS_PER_MINUTE)
 
   /**
    * Converts this duration to the number of whole hours.
    */
-  public val inHours: LongHours
-    get() = (`value` / MINUTES_PER_HOUR).hours
+  public val inWholeHours: Hours
+    get() = Hours(value / MINUTES_PER_HOUR)
+
+  @Deprecated(
+    message = "Use inWholeHours instead.",
+    replaceWith = ReplaceWith("this.inWholeHours"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inHours: Hours
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole days.
    */
-  public val inDays: LongDays
-    get() = (`value` / MINUTES_PER_DAY).days
+  public val inWholeDays: Days
+    get() = Days(value / MINUTES_PER_DAY)
+
+  @Deprecated(
+    message = "Use inWholeDays instead.",
+    replaceWith = ReplaceWith("this.inWholeDays"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inDays: Days
+    get() = deprecatedToError()
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -420,7 +148,7 @@ public value class LongMinutes(
     replaceWith = ReplaceWith("this == 0L.minutes"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -430,7 +158,7 @@ public value class LongMinutes(
     replaceWith = ReplaceWith("this < 0L.minutes"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -440,234 +168,231 @@ public value class LongMinutes(
     replaceWith = ReplaceWith("this > 0L.minutes"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongMinutes): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Minutes): Int = value.compareTo(other.value)
+
+  /**
+   * Converts this duration to a [kotlin.time.Duration].
+   */
+  @ExperimentalTime
+  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.minutes(value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return when (`value`) {
+     return when (value) {
        0L -> "PT0M"
        Long.MIN_VALUE -> "-PT9223372036854775808M"
        else -> buildString {
-         if (`value` < 0) { append('-') }
+         if (value < 0) { append('-') }
          append("PT")
-         append(`value`.absoluteValue)
+         append(value.absoluteValue)
          append('M')
        }
      }
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongMinutes = LongMinutes(`value`.negateExact())
+  public operator fun unaryMinus(): Minutes = Minutes(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongMinutes = LongMinutes(-`value`)
+  internal fun negateUnchecked(): Minutes = Minutes(-value)
+
+  public operator fun plus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds + nanoseconds
+
+  public operator fun minus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds -
+      nanoseconds
+
+  public operator fun plus(microseconds: Microseconds): Microseconds = this.inMicroseconds +
+      microseconds
+
+  public operator fun minus(microseconds: Microseconds): Microseconds = this.inMicroseconds -
+      microseconds
+
+  public operator fun plus(milliseconds: Milliseconds): Milliseconds = this.inMilliseconds +
+      milliseconds
+
+  public operator fun minus(milliseconds: Milliseconds): Milliseconds = this.inMilliseconds -
+      milliseconds
+
+  public operator fun plus(seconds: Seconds): Seconds = this.inSeconds + seconds
+
+  public operator fun minus(seconds: Seconds): Seconds = this.inSeconds - seconds
+
+  public operator fun plus(minutes: Minutes): Minutes = Minutes(value plusExact minutes.value)
+
+  public operator fun minus(minutes: Minutes): Minutes = Minutes(value minusExact minutes.value)
+
+  public operator fun plus(hours: Hours): Minutes = this + hours.inMinutes
+
+  public operator fun minus(hours: Hours): Minutes = this - hours.inMinutes
+
+  public operator fun plus(days: Days): Minutes = this + days.inMinutes
+
+  public operator fun minus(days: Days): Minutes = this - days.inMinutes
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongMinutes = LongMinutes(`value` timesExact scalar)
+  public operator fun times(scalar: Int): Minutes = Minutes(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongMinutes = LongMinutes(`value` timesExact scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongMinutes {
+  public operator fun div(scalar: Int): Minutes {
      return if (scalar == -1) {
        -this
      } else {
-       LongMinutes(`value` / scalar)
+       Minutes(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongMinutes {
+  public operator fun rem(scalar: Int): Minutes = Minutes(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Minutes = Minutes(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Minutes {
      return if (scalar == -1L) {
        -this
      } else {
-       LongMinutes(`value` / scalar)
+       Minutes(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongMinutes = LongMinutes(`value` % scalar)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Minutes = Minutes(value % scalar)
 
-  public operator fun rem(scalar: Long): LongMinutes = LongMinutes(`value` % scalar)
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds -
-      microseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.inMicroseconds - microseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds -
-      milliseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.inMilliseconds - milliseconds
-
-  public operator fun plus(seconds: IntSeconds): LongSeconds = this.inSeconds + seconds
-
-  public operator fun minus(seconds: IntSeconds): LongSeconds = this.inSeconds - seconds
-
-  public operator fun plus(seconds: LongSeconds): LongSeconds = this.inSeconds + seconds
-
-  public operator fun minus(seconds: LongSeconds): LongSeconds = this.inSeconds - seconds
-
-  public operator fun plus(minutes: IntMinutes): LongMinutes = LongMinutes(`value` plusExact
-      minutes.value)
-
-  public operator fun minus(minutes: IntMinutes): LongMinutes = LongMinutes(`value` minusExact
-      minutes.value)
-
-  public operator fun plus(minutes: LongMinutes): LongMinutes = LongMinutes(`value` plusExact
-      minutes.value)
-
-  public operator fun minus(minutes: LongMinutes): LongMinutes = LongMinutes(`value` minusExact
-      minutes.value)
-
-  public operator fun plus(hours: IntHours): LongMinutes = this + hours.inMinutes
-
-  public operator fun minus(hours: IntHours): LongMinutes = this - hours.inMinutes
-
-  public operator fun plus(hours: LongHours): LongMinutes = this + hours.inMinutes
-
-  public operator fun minus(hours: LongHours): LongMinutes = this - hours.inMinutes
-
-  public operator fun plus(days: IntDays): LongMinutes = this + days.inMinutes
-
-  public operator fun minus(days: IntDays): LongMinutes = this - days.inMinutes
-
-  public operator fun plus(days: LongDays): LongMinutes = this + days.inMinutes
-
-  public operator fun minus(days: LongDays): LongMinutes = this - days.inMinutes
-
-  public inline fun <T> toComponents(action: (hours: LongHours, minutes: IntMinutes) -> T): T {
-    val hours = (`value` / MINUTES_PER_HOUR).hours
-    val minutes = (`value` % MINUTES_PER_HOUR).toInt().minutes
+  public inline fun <T> toComponentValues(action: (hours: Long, minutes: Int) -> T): T {
+    val hours = (value / MINUTES_PER_HOUR)
+    val minutes = (value % MINUTES_PER_HOUR).toInt()
     return action(hours, minutes)
   }
 
-  public inline fun <T> toComponents(action: (
-    days: LongDays,
-    hours: IntHours,
-    minutes: IntMinutes
+  public inline fun <T> toComponents(action: (hours: Hours, minutes: Minutes) -> T): T {
+     return toComponentValues { hours, minutes ->
+         action(Hours(hours), Minutes(minutes))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    days: Long,
+    hours: Int,
+    minutes: Int
   ) -> T): T {
-    val days = (`value` / MINUTES_PER_DAY).days
-    val hours = ((`value` % MINUTES_PER_DAY) / MINUTES_PER_HOUR).toInt().hours
-    val minutes = (`value` % MINUTES_PER_HOUR).toInt().minutes
+    val days = (value / MINUTES_PER_DAY)
+    val hours = ((value % MINUTES_PER_DAY) / MINUTES_PER_HOUR).toInt()
+    val minutes = (value % MINUTES_PER_HOUR).toInt()
     return action(days, hours, minutes)
   }
 
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.minutes(`value`)
+  public inline fun <T> toComponents(action: (
+    days: Days,
+    hours: Hours,
+    minutes: Minutes
+  ) -> T): T {
+     return toComponentValues { days, hours, minutes ->
+         action(Days(days), Hours(hours), Minutes(minutes))
+     }
+  }
 
   /**
-   * Converts this duration to [IntMinutes].
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  public fun toIntMinutes(): IntMinutes = IntMinutes(`value`.toIntExact())
-
-  /**
-   * Converts this duration to [IntMinutes] without checking for overflow.
-   */
-  @PublishedApi
-  internal fun toIntMinutesUnchecked(): IntMinutes = IntMinutes(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntMinutes]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntMinutes(): Minutes = this
+
+  /**
+   * Converts this duration to [IntMinutes] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntMinutesUnchecked(): Minutes = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongMinutes = LongMinutes(Long.MIN_VALUE)
+    public val MIN: Minutes = Minutes(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongMinutes = LongMinutes(Long.MAX_VALUE)
+    public val MAX: Minutes = Minutes(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of minutes.
  */
-public val Long.minutes: LongMinutes
-  get() = LongMinutes(this)
+public val Int.minutes: Minutes
+  get() = Minutes(this)
 
 /**
- * Multiplies this value by a duration of minutes.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of minutes. @throws ArithmeticException if overflow occurs
  */
-public operator fun Int.times(minutes: LongMinutes): LongMinutes = minutes * this
+public operator fun Int.times(minutes: Minutes): Minutes = minutes * this
 
 /**
- * Multiplies this value by a duration of minutes.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of minutes.
  */
-public operator fun Long.times(minutes: LongMinutes): LongMinutes = minutes * this
+public val Long.minutes: Minutes
+  get() = Minutes(this)
 
 /**
- * Converts this duration to Island Time [LongMinutes].
+ * Multiplies this value by a duration of minutes. @throws ArithmeticException if overflow occurs
+ */
+public operator fun Long.times(minutes: Minutes): Minutes = minutes * this
+
+/**
+ * Converts this duration to Island Time [Minutes].
  */
 @ExperimentalTime
-public fun KotlinDuration.toIslandMinutes(): LongMinutes =
-    LongMinutes(this.toLong(KotlinDurationUnit.MINUTES))
+public fun KotlinDuration.toIslandMinutes(): Minutes =
+    Minutes(this.toLong(KotlinDurationUnit.MINUTES))

--- a/core/src/commonMain/generated/io/islandtime/measures/_Minutes.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Minutes.kt
@@ -20,6 +20,7 @@ import io.islandtime.`internal`.NANOSECONDS_PER_MINUTE
 import io.islandtime.`internal`.SECONDS_PER_MINUTE
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -102,16 +103,31 @@ public value class IntMinutes(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.minutes"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.minutes"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.minutes"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntMinutes): Int = `value`.compareTo(other.`value`)
@@ -399,16 +415,31 @@ public value class LongMinutes(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.minutes"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.minutes"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.minutes"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongMinutes): Int = `value`.compareTo(other.`value`)
@@ -597,6 +628,11 @@ public value class LongMinutes(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Months.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Months.kt
@@ -17,6 +17,7 @@ import io.islandtime.`internal`.MONTHS_PER_DECADE
 import io.islandtime.`internal`.MONTHS_PER_YEAR
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -64,16 +65,31 @@ public value class IntMonths(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.months"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.months"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.months"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntMonths): Int = `value`.compareTo(other.`value`)
@@ -287,16 +303,31 @@ public value class LongMonths(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.months"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.months"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.months"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongMonths): Int = `value`.compareTo(other.`value`)
@@ -456,6 +487,11 @@ public value class LongMonths(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Months.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Months.kt
@@ -15,9 +15,11 @@ import dev.erikchristensen.javamath2kmp.toIntExact
 import io.islandtime.`internal`.MONTHS_PER_CENTURY
 import io.islandtime.`internal`.MONTHS_PER_DECADE
 import io.islandtime.`internal`.MONTHS_PER_YEAR
+import io.islandtime.`internal`.deprecatedToError
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -27,278 +29,76 @@ import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 import kotlin.math.absoluteValue
 
-/**
- * A number of months.
- */
+@Deprecated(
+  message = "Replace with Months.",
+  replaceWith = ReplaceWith("Months"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntMonths = Months
+
+@Deprecated(
+  message = "Replace with Months.",
+  replaceWith = ReplaceWith("Months"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongMonths = Months
+
 @JvmInline
-public value class IntMonths(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntMonths> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntMonths
-    get() = IntMonths(absExact(`value`))
-
-  /**
-   * Converts this duration to the number of whole years.
-   */
-  public val inYears: IntYears
-    get() = (`value` / MONTHS_PER_YEAR).years
-
-  /**
-   * Converts this duration to the number of whole decades.
-   */
-  public val inDecades: IntDecades
-    get() = (`value` / MONTHS_PER_DECADE).decades
-
-  /**
-   * Converts this duration to the number of whole centuries.
-   */
-  public val inCenturies: IntCenturies
-    get() = (`value` / MONTHS_PER_CENTURY).centuries
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.months"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.months"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.months"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntMonths): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return when (`value`) {
-       0 -> "P0M"
-       Int.MIN_VALUE -> "-P2147483648M"
-       else -> buildString {
-         if (`value` < 0) { append('-') }
-         append("P")
-         append(`value`.absoluteValue)
-         append('M')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntMonths = IntMonths(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntMonths = IntMonths(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): IntMonths = IntMonths(`value` timesExact scalar)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongMonths = this.toLongMonths() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntMonths {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntMonths(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongMonths = this.toLongMonths() / scalar
-
-  public operator fun rem(scalar: Int): IntMonths = IntMonths(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongMonths = this.toLongMonths() % scalar
-
-  public operator fun plus(months: IntMonths): IntMonths = IntMonths(`value` plusExact months.value)
-
-  public operator fun minus(months: IntMonths): IntMonths = IntMonths(`value` minusExact
-      months.value)
-
-  public operator fun plus(months: LongMonths): LongMonths = LongMonths(`value`.toLong() plusExact
-      months.value)
-
-  public operator fun minus(months: LongMonths): LongMonths = LongMonths(`value`.toLong() minusExact
-      months.value)
-
-  public operator fun plus(years: IntYears): IntMonths = this + years.inMonths
-
-  public operator fun minus(years: IntYears): IntMonths = this - years.inMonths
-
-  public operator fun plus(years: LongYears): LongMonths = this.toLongMonths() + years.inMonths
-
-  public operator fun minus(years: LongYears): LongMonths = this.toLongMonths() - years.inMonths
-
-  public operator fun plus(decades: IntDecades): IntMonths = this + decades.inMonths
-
-  public operator fun minus(decades: IntDecades): IntMonths = this - decades.inMonths
-
-  public operator fun plus(decades: LongDecades): LongMonths = this.toLongMonths() +
-      decades.inMonths
-
-  public operator fun minus(decades: LongDecades): LongMonths = this.toLongMonths() -
-      decades.inMonths
-
-  public operator fun plus(centuries: IntCenturies): IntMonths = this + centuries.inMonths
-
-  public operator fun minus(centuries: IntCenturies): IntMonths = this - centuries.inMonths
-
-  public operator fun plus(centuries: LongCenturies): LongMonths = this.toLongMonths() +
-      centuries.inMonths
-
-  public operator fun minus(centuries: LongCenturies): LongMonths = this.toLongMonths() -
-      centuries.inMonths
-
-  public inline fun <T> toComponents(action: (years: IntYears, months: IntMonths) -> T): T {
-    val years = (`value` / MONTHS_PER_YEAR).years
-    val months = (`value` % MONTHS_PER_YEAR).months
-    return action(years, months)
-  }
-
-  public inline fun <T> toComponents(action: (
-    decades: IntDecades,
-    years: IntYears,
-    months: IntMonths
-  ) -> T): T {
-    val decades = (`value` / MONTHS_PER_DECADE).decades
-    val years = ((`value` % MONTHS_PER_DECADE) / MONTHS_PER_YEAR).years
-    val months = (`value` % MONTHS_PER_YEAR).months
-    return action(decades, years, months)
-  }
-
-  public inline fun <T> toComponents(action: (
-    centuries: IntCenturies,
-    decades: IntDecades,
-    years: IntYears,
-    months: IntMonths
-  ) -> T): T {
-    val centuries = (`value` / MONTHS_PER_CENTURY).centuries
-    val decades = ((`value` % MONTHS_PER_CENTURY) / MONTHS_PER_DECADE).decades
-    val years = ((`value` % MONTHS_PER_DECADE) / MONTHS_PER_YEAR).years
-    val months = (`value` % MONTHS_PER_YEAR).months
-    return action(centuries, decades, years, months)
-  }
-
-  /**
-   * Converts this duration to [LongMonths].
-   */
-  public fun toLongMonths(): LongMonths = LongMonths(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntMonths = IntMonths(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntMonths = IntMonths(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of months.
- */
-public val Int.months: IntMonths
-  get() = IntMonths(this)
-
-/**
- * Multiplies this value by a duration of months.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(months: IntMonths): IntMonths = months * this
-
-/**
- * Multiplies this value by a duration of months.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(months: IntMonths): LongMonths = months * this
-
-/**
- * A number of months.
- */
-@JvmInline
-public value class LongMonths(
+public value class Months(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongMonths> {
+) : Comparable<Months> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongMonths
-    get() = LongMonths(absExact(`value`))
+  public val absoluteValue: Months
+    get() = Months(absExact(value))
 
   /**
    * Converts this duration to the number of whole years.
    */
-  public val inYears: LongYears
-    get() = (`value` / MONTHS_PER_YEAR).years
+  public val inWholeYears: Years
+    get() = Years(value / MONTHS_PER_YEAR)
+
+  @Deprecated(
+    message = "Use inWholeYears instead.",
+    replaceWith = ReplaceWith("this.inWholeYears"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inYears: Years
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole decades.
    */
-  public val inDecades: LongDecades
-    get() = (`value` / MONTHS_PER_DECADE).decades
+  public val inWholeDecades: Decades
+    get() = Decades(value / MONTHS_PER_DECADE)
+
+  @Deprecated(
+    message = "Use inWholeDecades instead.",
+    replaceWith = ReplaceWith("this.inWholeDecades"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inDecades: Decades
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole centuries.
    */
-  public val inCenturies: LongCenturies
-    get() = (`value` / MONTHS_PER_CENTURY).centuries
+  public val inWholeCenturies: Centuries
+    get() = Centuries(value / MONTHS_PER_CENTURY)
+
+  @Deprecated(
+    message = "Use inWholeCenturies instead.",
+    replaceWith = ReplaceWith("this.inWholeCenturies"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inCenturies: Centuries
+    get() = deprecatedToError()
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -308,7 +108,7 @@ public value class LongMonths(
     replaceWith = ReplaceWith("this == 0L.months"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -318,7 +118,7 @@ public value class LongMonths(
     replaceWith = ReplaceWith("this < 0L.months"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -328,198 +128,225 @@ public value class LongMonths(
     replaceWith = ReplaceWith("this > 0L.months"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongMonths): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Months): Int = value.compareTo(other.value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return when (`value`) {
+     return when (value) {
        0L -> "P0M"
        Long.MIN_VALUE -> "-P9223372036854775808M"
        else -> buildString {
-         if (`value` < 0) { append('-') }
+         if (value < 0) { append('-') }
          append("P")
-         append(`value`.absoluteValue)
+         append(value.absoluteValue)
          append('M')
        }
      }
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongMonths = LongMonths(`value`.negateExact())
+  public operator fun unaryMinus(): Months = Months(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongMonths = LongMonths(-`value`)
+  internal fun negateUnchecked(): Months = Months(-value)
+
+  public operator fun plus(months: Months): Months = Months(value plusExact months.value)
+
+  public operator fun minus(months: Months): Months = Months(value minusExact months.value)
+
+  public operator fun plus(years: Years): Months = this + years.inMonths
+
+  public operator fun minus(years: Years): Months = this - years.inMonths
+
+  public operator fun plus(decades: Decades): Months = this + decades.inMonths
+
+  public operator fun minus(decades: Decades): Months = this - decades.inMonths
+
+  public operator fun plus(centuries: Centuries): Months = this + centuries.inMonths
+
+  public operator fun minus(centuries: Centuries): Months = this - centuries.inMonths
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongMonths = LongMonths(`value` timesExact scalar)
+  public operator fun times(scalar: Int): Months = Months(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongMonths = LongMonths(`value` timesExact scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongMonths {
+  public operator fun div(scalar: Int): Months {
      return if (scalar == -1) {
        -this
      } else {
-       LongMonths(`value` / scalar)
+       Months(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongMonths {
+  public operator fun rem(scalar: Int): Months = Months(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Months = Months(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Months {
      return if (scalar == -1L) {
        -this
      } else {
-       LongMonths(`value` / scalar)
+       Months(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongMonths = LongMonths(`value` % scalar)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Months = Months(value % scalar)
 
-  public operator fun rem(scalar: Long): LongMonths = LongMonths(`value` % scalar)
-
-  public operator fun plus(months: IntMonths): LongMonths = LongMonths(`value` plusExact
-      months.value)
-
-  public operator fun minus(months: IntMonths): LongMonths = LongMonths(`value` minusExact
-      months.value)
-
-  public operator fun plus(months: LongMonths): LongMonths = LongMonths(`value` plusExact
-      months.value)
-
-  public operator fun minus(months: LongMonths): LongMonths = LongMonths(`value` minusExact
-      months.value)
-
-  public operator fun plus(years: IntYears): LongMonths = this + years.inMonths
-
-  public operator fun minus(years: IntYears): LongMonths = this - years.inMonths
-
-  public operator fun plus(years: LongYears): LongMonths = this + years.inMonths
-
-  public operator fun minus(years: LongYears): LongMonths = this - years.inMonths
-
-  public operator fun plus(decades: IntDecades): LongMonths = this + decades.inMonths
-
-  public operator fun minus(decades: IntDecades): LongMonths = this - decades.inMonths
-
-  public operator fun plus(decades: LongDecades): LongMonths = this + decades.inMonths
-
-  public operator fun minus(decades: LongDecades): LongMonths = this - decades.inMonths
-
-  public operator fun plus(centuries: IntCenturies): LongMonths = this + centuries.inMonths
-
-  public operator fun minus(centuries: IntCenturies): LongMonths = this - centuries.inMonths
-
-  public operator fun plus(centuries: LongCenturies): LongMonths = this + centuries.inMonths
-
-  public operator fun minus(centuries: LongCenturies): LongMonths = this - centuries.inMonths
-
-  public inline fun <T> toComponents(action: (years: LongYears, months: IntMonths) -> T): T {
-    val years = (`value` / MONTHS_PER_YEAR).years
-    val months = (`value` % MONTHS_PER_YEAR).toInt().months
+  public inline fun <T> toComponentValues(action: (years: Long, months: Int) -> T): T {
+    val years = (value / MONTHS_PER_YEAR)
+    val months = (value % MONTHS_PER_YEAR).toInt()
     return action(years, months)
   }
 
-  public inline fun <T> toComponents(action: (
-    decades: LongDecades,
-    years: IntYears,
-    months: IntMonths
+  public inline fun <T> toComponents(action: (years: Years, months: Months) -> T): T {
+     return toComponentValues { years, months ->
+         action(Years(years), Months(months))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    decades: Long,
+    years: Int,
+    months: Int
   ) -> T): T {
-    val decades = (`value` / MONTHS_PER_DECADE).decades
-    val years = ((`value` % MONTHS_PER_DECADE) / MONTHS_PER_YEAR).toInt().years
-    val months = (`value` % MONTHS_PER_YEAR).toInt().months
+    val decades = (value / MONTHS_PER_DECADE)
+    val years = ((value % MONTHS_PER_DECADE) / MONTHS_PER_YEAR).toInt()
+    val months = (value % MONTHS_PER_YEAR).toInt()
     return action(decades, years, months)
   }
 
   public inline fun <T> toComponents(action: (
-    centuries: LongCenturies,
-    decades: IntDecades,
-    years: IntYears,
-    months: IntMonths
+    decades: Decades,
+    years: Years,
+    months: Months
   ) -> T): T {
-    val centuries = (`value` / MONTHS_PER_CENTURY).centuries
-    val decades = ((`value` % MONTHS_PER_CENTURY) / MONTHS_PER_DECADE).toInt().decades
-    val years = ((`value` % MONTHS_PER_DECADE) / MONTHS_PER_YEAR).toInt().years
-    val months = (`value` % MONTHS_PER_YEAR).toInt().months
+     return toComponentValues { decades, years, months ->
+         action(Decades(decades), Years(years), Months(months))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    centuries: Long,
+    decades: Int,
+    years: Int,
+    months: Int
+  ) -> T): T {
+    val centuries = (value / MONTHS_PER_CENTURY)
+    val decades = ((value % MONTHS_PER_CENTURY) / MONTHS_PER_DECADE).toInt()
+    val years = ((value % MONTHS_PER_DECADE) / MONTHS_PER_YEAR).toInt()
+    val months = (value % MONTHS_PER_YEAR).toInt()
     return action(centuries, decades, years, months)
   }
 
-  /**
-   * Converts this duration to [IntMonths].
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toIntMonths(): IntMonths = IntMonths(`value`.toIntExact())
+  public inline fun <T> toComponents(action: (
+    centuries: Centuries,
+    decades: Decades,
+    years: Years,
+    months: Months
+  ) -> T): T {
+     return toComponentValues { centuries, decades, years, months ->
+         action(Centuries(centuries), Decades(decades), Years(years), Months(months))
+     }
+  }
 
   /**
-   * Converts this duration to [IntMonths] without checking for overflow.
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  @PublishedApi
-  internal fun toIntMonthsUnchecked(): IntMonths = IntMonths(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntMonths]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntMonths(): Months = this
+
+  /**
+   * Converts this duration to [IntMonths] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntMonthsUnchecked(): Months = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongMonths = LongMonths(Long.MIN_VALUE)
+    public val MIN: Months = Months(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongMonths = LongMonths(Long.MAX_VALUE)
+    public val MAX: Months = Months(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of months.
  */
-public val Long.months: LongMonths
-  get() = LongMonths(this)
+public val Int.months: Months
+  get() = Months(this)
 
 /**
- * Multiplies this value by a duration of months.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of months. @throws ArithmeticException if overflow occurs
  */
-public operator fun Int.times(months: LongMonths): LongMonths = months * this
+public operator fun Int.times(months: Months): Months = months * this
 
 /**
- * Multiplies this value by a duration of months.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of months.
  */
-public operator fun Long.times(months: LongMonths): LongMonths = months * this
+public val Long.months: Months
+  get() = Months(this)
+
+/**
+ * Multiplies this value by a duration of months. @throws ArithmeticException if overflow occurs
+ */
+public operator fun Long.times(months: Months): Months = months * this

--- a/core/src/commonMain/generated/io/islandtime/measures/_Nanoseconds.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Nanoseconds.kt
@@ -21,6 +21,7 @@ import io.islandtime.`internal`.NANOSECONDS_PER_SECOND
 import io.islandtime.`internal`.toZeroPaddedString
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -89,16 +90,31 @@ public value class IntNanoseconds(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.nanoseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.nanoseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.nanoseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntNanoseconds): Int = `value`.compareTo(other.`value`)
@@ -448,16 +464,31 @@ public value class LongNanoseconds(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.nanoseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.nanoseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.nanoseconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongNanoseconds): Int = `value`.compareTo(other.`value`)
@@ -724,6 +755,11 @@ public value class LongNanoseconds(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Nanoseconds.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Nanoseconds.kt
@@ -18,10 +18,12 @@ import io.islandtime.`internal`.NANOSECONDS_PER_MICROSECOND
 import io.islandtime.`internal`.NANOSECONDS_PER_MILLISECOND
 import io.islandtime.`internal`.NANOSECONDS_PER_MINUTE
 import io.islandtime.`internal`.NANOSECONDS_PER_SECOND
+import io.islandtime.`internal`.deprecatedToError
 import io.islandtime.`internal`.toZeroPaddedString
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -34,432 +36,118 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Duration as KotlinDuration
 import kotlin.time.DurationUnit as KotlinDurationUnit
 
-/**
- * A number of nanoseconds.
- */
+@Deprecated(
+  message = "Replace with Nanoseconds.",
+  replaceWith = ReplaceWith("Nanoseconds"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntNanoseconds = Nanoseconds
+
+@Deprecated(
+  message = "Replace with Nanoseconds.",
+  replaceWith = ReplaceWith("Nanoseconds"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongNanoseconds = Nanoseconds
+
 @JvmInline
-public value class IntNanoseconds(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntNanoseconds> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntNanoseconds
-    get() = IntNanoseconds(absExact(`value`))
-
-  /**
-   * Converts this duration to the number of whole microseconds.
-   */
-  public val inMicroseconds: IntMicroseconds
-    get() = (`value` / NANOSECONDS_PER_MICROSECOND).microseconds
-
-  /**
-   * Converts this duration to the number of whole milliseconds.
-   */
-  public val inMilliseconds: IntMilliseconds
-    get() = (`value` / NANOSECONDS_PER_MILLISECOND).milliseconds
-
-  /**
-   * Converts this duration to the number of whole seconds.
-   */
-  public val inSeconds: IntSeconds
-    get() = (`value` / NANOSECONDS_PER_SECOND).seconds
-
-  /**
-   * Converts this duration to the number of whole minutes.
-   */
-  public val inMinutes: IntMinutes
-    get() = (`value` / NANOSECONDS_PER_MINUTE).toInt().minutes
-
-  /**
-   * Converts this duration to the number of whole hours.
-   */
-  public val inHours: IntHours
-    get() = (`value` / NANOSECONDS_PER_HOUR).toInt().hours
-
-  /**
-   * Converts this duration to the number of whole days.
-   */
-  public val inDays: IntDays
-    get() = (`value` / NANOSECONDS_PER_DAY).toInt().days
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.nanoseconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.nanoseconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.nanoseconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntNanoseconds): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return if (`value` == 0) {
-       "PT0S"
-     } else {
-       buildString {
-         val wholePart = (`value` / 1000000000).absoluteValue
-         val fractionalPart = (`value` % 1000000000).absoluteValue
-         if (`value` < 0) { append('-') }
-         append("PT")
-         append(wholePart)
-         if (fractionalPart > 0) {
-           append('.')
-           append(fractionalPart.toZeroPaddedString(9).dropLastWhile { it == '0' })
-         }
-         append('S')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntNanoseconds = IntNanoseconds(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntNanoseconds = IntNanoseconds(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): LongNanoseconds = this.toLongNanoseconds() * scalar
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongNanoseconds = this.toLongNanoseconds() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntNanoseconds {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntNanoseconds(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongNanoseconds = this.toLongNanoseconds() / scalar
-
-  public operator fun rem(scalar: Int): IntNanoseconds = IntNanoseconds(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongNanoseconds = this.toLongNanoseconds() % scalar
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds =
-      LongNanoseconds(`value`.toLong() plusExact nanoseconds.value)
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds =
-      LongNanoseconds(`value`.toLong() minusExact nanoseconds.value)
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      LongNanoseconds(`value`.toLong() plusExact nanoseconds.value)
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      LongNanoseconds(`value`.toLong() minusExact nanoseconds.value)
-
-  public operator fun plus(microseconds: IntMicroseconds): LongNanoseconds =
-      this.toLongNanoseconds() + microseconds.inNanoseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongNanoseconds =
-      this.toLongNanoseconds() - microseconds.inNanoseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongNanoseconds =
-      this.toLongNanoseconds() + microseconds.inNanoseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongNanoseconds =
-      this.toLongNanoseconds() - microseconds.inNanoseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongNanoseconds =
-      this.toLongNanoseconds() + milliseconds.inNanoseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongNanoseconds =
-      this.toLongNanoseconds() - milliseconds.inNanoseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongNanoseconds =
-      this.toLongNanoseconds() + milliseconds.inNanoseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongNanoseconds =
-      this.toLongNanoseconds() - milliseconds.inNanoseconds
-
-  public operator fun plus(seconds: IntSeconds): LongNanoseconds = this.toLongNanoseconds() +
-      seconds.inNanoseconds
-
-  public operator fun minus(seconds: IntSeconds): LongNanoseconds = this.toLongNanoseconds() -
-      seconds.inNanoseconds
-
-  public operator fun plus(seconds: LongSeconds): LongNanoseconds = this.toLongNanoseconds() +
-      seconds.inNanoseconds
-
-  public operator fun minus(seconds: LongSeconds): LongNanoseconds = this.toLongNanoseconds() -
-      seconds.inNanoseconds
-
-  public operator fun plus(minutes: IntMinutes): LongNanoseconds = this.toLongNanoseconds() +
-      minutes.inNanoseconds
-
-  public operator fun minus(minutes: IntMinutes): LongNanoseconds = this.toLongNanoseconds() -
-      minutes.inNanoseconds
-
-  public operator fun plus(minutes: LongMinutes): LongNanoseconds = this.toLongNanoseconds() +
-      minutes.inNanoseconds
-
-  public operator fun minus(minutes: LongMinutes): LongNanoseconds = this.toLongNanoseconds() -
-      minutes.inNanoseconds
-
-  public operator fun plus(hours: IntHours): LongNanoseconds = this.toLongNanoseconds() +
-      hours.inNanoseconds
-
-  public operator fun minus(hours: IntHours): LongNanoseconds = this.toLongNanoseconds() -
-      hours.inNanoseconds
-
-  public operator fun plus(hours: LongHours): LongNanoseconds = this.toLongNanoseconds() +
-      hours.inNanoseconds
-
-  public operator fun minus(hours: LongHours): LongNanoseconds = this.toLongNanoseconds() -
-      hours.inNanoseconds
-
-  public operator fun plus(days: IntDays): LongNanoseconds = this.toLongNanoseconds() +
-      days.inNanoseconds
-
-  public operator fun minus(days: IntDays): LongNanoseconds = this.toLongNanoseconds() -
-      days.inNanoseconds
-
-  public operator fun plus(days: LongDays): LongNanoseconds = this.toLongNanoseconds() +
-      days.inNanoseconds
-
-  public operator fun minus(days: LongDays): LongNanoseconds = this.toLongNanoseconds() -
-      days.inNanoseconds
-
-  public inline fun <T> toComponents(action: (microseconds: IntMicroseconds,
-      nanoseconds: IntNanoseconds) -> T): T {
-    val microseconds = (`value` / NANOSECONDS_PER_MICROSECOND).microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).nanoseconds
-    return action(microseconds, nanoseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds,
-    nanoseconds: IntNanoseconds
-  ) -> T): T {
-    val milliseconds = (`value` / NANOSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = ((`value` % NANOSECONDS_PER_MILLISECOND) /
-        NANOSECONDS_PER_MICROSECOND).microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).nanoseconds
-    return action(milliseconds, microseconds, nanoseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds,
-    nanoseconds: IntNanoseconds
-  ) -> T): T {
-    val seconds = (`value` / NANOSECONDS_PER_SECOND).seconds
-    val milliseconds = ((`value` % NANOSECONDS_PER_SECOND) /
-        NANOSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = ((`value` % NANOSECONDS_PER_MILLISECOND) /
-        NANOSECONDS_PER_MICROSECOND).microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).nanoseconds
-    return action(seconds, milliseconds, microseconds, nanoseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds,
-    nanoseconds: IntNanoseconds
-  ) -> T): T {
-    val minutes = (`value` / NANOSECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % NANOSECONDS_PER_MINUTE) / NANOSECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = ((`value` % NANOSECONDS_PER_SECOND) /
-        NANOSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = ((`value` % NANOSECONDS_PER_MILLISECOND) /
-        NANOSECONDS_PER_MICROSECOND).microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).nanoseconds
-    return action(minutes, seconds, milliseconds, microseconds, nanoseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds,
-    nanoseconds: IntNanoseconds
-  ) -> T): T {
-    val hours = (`value` / NANOSECONDS_PER_HOUR).toInt().hours
-    val minutes = ((`value` % NANOSECONDS_PER_HOUR) / NANOSECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % NANOSECONDS_PER_MINUTE) / NANOSECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = ((`value` % NANOSECONDS_PER_SECOND) /
-        NANOSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = ((`value` % NANOSECONDS_PER_MILLISECOND) /
-        NANOSECONDS_PER_MICROSECOND).microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).nanoseconds
-    return action(hours, minutes, seconds, milliseconds, microseconds, nanoseconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    days: IntDays,
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds,
-    nanoseconds: IntNanoseconds
-  ) -> T): T {
-    val days = (`value` / NANOSECONDS_PER_DAY).toInt().days
-    val hours = ((`value` % NANOSECONDS_PER_DAY) / NANOSECONDS_PER_HOUR).toInt().hours
-    val minutes = ((`value` % NANOSECONDS_PER_HOUR) / NANOSECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % NANOSECONDS_PER_MINUTE) / NANOSECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = ((`value` % NANOSECONDS_PER_SECOND) /
-        NANOSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = ((`value` % NANOSECONDS_PER_MILLISECOND) /
-        NANOSECONDS_PER_MICROSECOND).microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).nanoseconds
-    return action(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds)
-  }
-
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.nanoseconds(`value`)
-
-  /**
-   * Converts this duration to [LongNanoseconds].
-   */
-  public fun toLongNanoseconds(): LongNanoseconds = LongNanoseconds(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntNanoseconds = IntNanoseconds(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntNanoseconds = IntNanoseconds(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of nanoseconds.
- */
-public val Int.nanoseconds: IntNanoseconds
-  get() = IntNanoseconds(this)
-
-/**
- * Multiplies this value by a duration of nanoseconds.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(nanoseconds: IntNanoseconds): LongNanoseconds = nanoseconds * this
-
-/**
- * Multiplies this value by a duration of nanoseconds.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(nanoseconds: IntNanoseconds): LongNanoseconds = nanoseconds * this
-
-/**
- * A number of nanoseconds.
- */
-@JvmInline
-public value class LongNanoseconds(
+public value class Nanoseconds(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongNanoseconds> {
+) : Comparable<Nanoseconds> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongNanoseconds
-    get() = LongNanoseconds(absExact(`value`))
+  public val absoluteValue: Nanoseconds
+    get() = Nanoseconds(absExact(value))
 
   /**
    * Converts this duration to the number of whole microseconds.
    */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value` / NANOSECONDS_PER_MICROSECOND).microseconds
+  public val inWholeMicroseconds: Microseconds
+    get() = Microseconds(value / NANOSECONDS_PER_MICROSECOND)
+
+  @Deprecated(
+    message = "Use inWholeMicroseconds instead.",
+    replaceWith = ReplaceWith("this.inWholeMicroseconds"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inMicroseconds: Microseconds
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole milliseconds.
    */
-  public val inMilliseconds: LongMilliseconds
-    get() = (`value` / NANOSECONDS_PER_MILLISECOND).milliseconds
+  public val inWholeMilliseconds: Milliseconds
+    get() = Milliseconds(value / NANOSECONDS_PER_MILLISECOND)
+
+  @Deprecated(
+    message = "Use inWholeMilliseconds instead.",
+    replaceWith = ReplaceWith("this.inWholeMilliseconds"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inMilliseconds: Milliseconds
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole seconds.
    */
-  public val inSeconds: LongSeconds
-    get() = (`value` / NANOSECONDS_PER_SECOND).seconds
+  public val inWholeSeconds: Seconds
+    get() = Seconds(value / NANOSECONDS_PER_SECOND)
+
+  @Deprecated(
+    message = "Use inWholeSeconds instead.",
+    replaceWith = ReplaceWith("this.inWholeSeconds"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inSeconds: Seconds
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole minutes.
    */
-  public val inMinutes: LongMinutes
-    get() = (`value` / NANOSECONDS_PER_MINUTE).minutes
+  public val inWholeMinutes: Minutes
+    get() = Minutes(value / NANOSECONDS_PER_MINUTE)
+
+  @Deprecated(
+    message = "Use inWholeMinutes instead.",
+    replaceWith = ReplaceWith("this.inWholeMinutes"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inMinutes: Minutes
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole hours.
    */
-  public val inHours: LongHours
-    get() = (`value` / NANOSECONDS_PER_HOUR).hours
+  public val inWholeHours: Hours
+    get() = Hours(value / NANOSECONDS_PER_HOUR)
+
+  @Deprecated(
+    message = "Use inWholeHours instead.",
+    replaceWith = ReplaceWith("this.inWholeHours"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inHours: Hours
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole days.
    */
-  public val inDays: LongDays
-    get() = (`value` / NANOSECONDS_PER_DAY).days
+  public val inWholeDays: Days
+    get() = Days(value / NANOSECONDS_PER_DAY)
+
+  @Deprecated(
+    message = "Use inWholeDays instead.",
+    replaceWith = ReplaceWith("this.inWholeDays"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inDays: Days
+    get() = deprecatedToError()
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -469,7 +157,7 @@ public value class LongNanoseconds(
     replaceWith = ReplaceWith("this == 0L.nanoseconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -479,7 +167,7 @@ public value class LongNanoseconds(
     replaceWith = ReplaceWith("this < 0L.nanoseconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -489,21 +177,27 @@ public value class LongNanoseconds(
     replaceWith = ReplaceWith("this > 0L.nanoseconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongNanoseconds): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Nanoseconds): Int = value.compareTo(other.value)
+
+  /**
+   * Converts this duration to a [kotlin.time.Duration].
+   */
+  @ExperimentalTime
+  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.nanoseconds(value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return if (`value` == 0L) {
+     return if (value == 0L) {
        "PT0S"
      } else {
        buildString {
-         val wholePart = (`value` / 1000000000).absoluteValue
-         val fractionalPart = ((`value` % 1000000000).toInt()).absoluteValue
-         if (`value` < 0) { append('-') }
+         val wholePart = (value / 1000000000).absoluteValue
+         val fractionalPart = (value % 1000000000).toInt().absoluteValue
+         if (value < 0) { append('-') }
          append("PT")
          append(wholePart)
          if (fractionalPart > 0) {
@@ -516,285 +210,327 @@ public value class LongNanoseconds(
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongNanoseconds = LongNanoseconds(`value`.negateExact())
+  public operator fun unaryMinus(): Nanoseconds = Nanoseconds(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongNanoseconds = LongNanoseconds(-`value`)
+  internal fun negateUnchecked(): Nanoseconds = Nanoseconds(-value)
+
+  public operator fun plus(nanoseconds: Nanoseconds): Nanoseconds = Nanoseconds(value plusExact
+      nanoseconds.value)
+
+  public operator fun minus(nanoseconds: Nanoseconds): Nanoseconds = Nanoseconds(value minusExact
+      nanoseconds.value)
+
+  public operator fun plus(microseconds: Microseconds): Nanoseconds = this +
+      microseconds.inNanoseconds
+
+  public operator fun minus(microseconds: Microseconds): Nanoseconds = this -
+      microseconds.inNanoseconds
+
+  public operator fun plus(milliseconds: Milliseconds): Nanoseconds = this +
+      milliseconds.inNanoseconds
+
+  public operator fun minus(milliseconds: Milliseconds): Nanoseconds = this -
+      milliseconds.inNanoseconds
+
+  public operator fun plus(seconds: Seconds): Nanoseconds = this + seconds.inNanoseconds
+
+  public operator fun minus(seconds: Seconds): Nanoseconds = this - seconds.inNanoseconds
+
+  public operator fun plus(minutes: Minutes): Nanoseconds = this + minutes.inNanoseconds
+
+  public operator fun minus(minutes: Minutes): Nanoseconds = this - minutes.inNanoseconds
+
+  public operator fun plus(hours: Hours): Nanoseconds = this + hours.inNanoseconds
+
+  public operator fun minus(hours: Hours): Nanoseconds = this - hours.inNanoseconds
+
+  public operator fun plus(days: Days): Nanoseconds = this + days.inNanoseconds
+
+  public operator fun minus(days: Days): Nanoseconds = this - days.inNanoseconds
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongNanoseconds = LongNanoseconds(`value` timesExact
-      scalar)
+  public operator fun times(scalar: Int): Nanoseconds = Nanoseconds(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongNanoseconds = LongNanoseconds(`value` timesExact
-      scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongNanoseconds {
+  public operator fun div(scalar: Int): Nanoseconds {
      return if (scalar == -1) {
        -this
      } else {
-       LongNanoseconds(`value` / scalar)
+       Nanoseconds(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongNanoseconds {
+  public operator fun rem(scalar: Int): Nanoseconds = Nanoseconds(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Nanoseconds = Nanoseconds(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Nanoseconds {
      return if (scalar == -1L) {
        -this
      } else {
-       LongNanoseconds(`value` / scalar)
+       Nanoseconds(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongNanoseconds = LongNanoseconds(`value` % scalar)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Nanoseconds = Nanoseconds(value % scalar)
 
-  public operator fun rem(scalar: Long): LongNanoseconds = LongNanoseconds(`value` % scalar)
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds =
-      LongNanoseconds(`value` plusExact nanoseconds.value)
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds =
-      LongNanoseconds(`value` minusExact nanoseconds.value)
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      LongNanoseconds(`value` plusExact nanoseconds.value)
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      LongNanoseconds(`value` minusExact nanoseconds.value)
-
-  public operator fun plus(microseconds: IntMicroseconds): LongNanoseconds = this +
-      microseconds.inNanoseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongNanoseconds = this -
-      microseconds.inNanoseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongNanoseconds = this +
-      microseconds.inNanoseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongNanoseconds = this -
-      microseconds.inNanoseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongNanoseconds = this +
-      milliseconds.inNanoseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongNanoseconds = this -
-      milliseconds.inNanoseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongNanoseconds = this +
-      milliseconds.inNanoseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongNanoseconds = this -
-      milliseconds.inNanoseconds
-
-  public operator fun plus(seconds: IntSeconds): LongNanoseconds = this + seconds.inNanoseconds
-
-  public operator fun minus(seconds: IntSeconds): LongNanoseconds = this - seconds.inNanoseconds
-
-  public operator fun plus(seconds: LongSeconds): LongNanoseconds = this + seconds.inNanoseconds
-
-  public operator fun minus(seconds: LongSeconds): LongNanoseconds = this - seconds.inNanoseconds
-
-  public operator fun plus(minutes: IntMinutes): LongNanoseconds = this + minutes.inNanoseconds
-
-  public operator fun minus(minutes: IntMinutes): LongNanoseconds = this - minutes.inNanoseconds
-
-  public operator fun plus(minutes: LongMinutes): LongNanoseconds = this + minutes.inNanoseconds
-
-  public operator fun minus(minutes: LongMinutes): LongNanoseconds = this - minutes.inNanoseconds
-
-  public operator fun plus(hours: IntHours): LongNanoseconds = this + hours.inNanoseconds
-
-  public operator fun minus(hours: IntHours): LongNanoseconds = this - hours.inNanoseconds
-
-  public operator fun plus(hours: LongHours): LongNanoseconds = this + hours.inNanoseconds
-
-  public operator fun minus(hours: LongHours): LongNanoseconds = this - hours.inNanoseconds
-
-  public operator fun plus(days: IntDays): LongNanoseconds = this + days.inNanoseconds
-
-  public operator fun minus(days: IntDays): LongNanoseconds = this - days.inNanoseconds
-
-  public operator fun plus(days: LongDays): LongNanoseconds = this + days.inNanoseconds
-
-  public operator fun minus(days: LongDays): LongNanoseconds = this - days.inNanoseconds
-
-  public inline fun <T> toComponents(action: (microseconds: LongMicroseconds,
-      nanoseconds: IntNanoseconds) -> T): T {
-    val microseconds = (`value` / NANOSECONDS_PER_MICROSECOND).microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).toInt().nanoseconds
+  public inline fun <T> toComponentValues(action: (microseconds: Long, nanoseconds: Int) -> T): T {
+    val microseconds = (value / NANOSECONDS_PER_MICROSECOND)
+    val nanoseconds = (value % NANOSECONDS_PER_MICROSECOND).toInt()
     return action(microseconds, nanoseconds)
   }
 
-  public inline fun <T> toComponents(action: (
-    milliseconds: LongMilliseconds,
-    microseconds: IntMicroseconds,
-    nanoseconds: IntNanoseconds
+  public inline fun <T> toComponents(action: (microseconds: Microseconds,
+      nanoseconds: Nanoseconds) -> T): T {
+     return toComponentValues { microseconds, nanoseconds ->
+         action(Microseconds(microseconds), Nanoseconds(nanoseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    milliseconds: Long,
+    microseconds: Int,
+    nanoseconds: Int
   ) -> T): T {
-    val milliseconds = (`value` / NANOSECONDS_PER_MILLISECOND).milliseconds
-    val microseconds = ((`value` % NANOSECONDS_PER_MILLISECOND) /
-        NANOSECONDS_PER_MICROSECOND).toInt().microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).toInt().nanoseconds
+    val milliseconds = (value / NANOSECONDS_PER_MILLISECOND)
+    val microseconds = ((value % NANOSECONDS_PER_MILLISECOND) / NANOSECONDS_PER_MICROSECOND).toInt()
+    val nanoseconds = (value % NANOSECONDS_PER_MICROSECOND).toInt()
     return action(milliseconds, microseconds, nanoseconds)
   }
 
   public inline fun <T> toComponents(action: (
-    seconds: LongSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds,
-    nanoseconds: IntNanoseconds
+    milliseconds: Milliseconds,
+    microseconds: Microseconds,
+    nanoseconds: Nanoseconds
   ) -> T): T {
-    val seconds = (`value` / NANOSECONDS_PER_SECOND).seconds
-    val milliseconds = ((`value` % NANOSECONDS_PER_SECOND) /
-        NANOSECONDS_PER_MILLISECOND).toInt().milliseconds
-    val microseconds = ((`value` % NANOSECONDS_PER_MILLISECOND) /
-        NANOSECONDS_PER_MICROSECOND).toInt().microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).toInt().nanoseconds
+     return toComponentValues { milliseconds, microseconds, nanoseconds ->
+         action(Milliseconds(milliseconds), Microseconds(microseconds), Nanoseconds(nanoseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    seconds: Long,
+    milliseconds: Int,
+    microseconds: Int,
+    nanoseconds: Int
+  ) -> T): T {
+    val seconds = (value / NANOSECONDS_PER_SECOND)
+    val milliseconds = ((value % NANOSECONDS_PER_SECOND) / NANOSECONDS_PER_MILLISECOND).toInt()
+    val microseconds = ((value % NANOSECONDS_PER_MILLISECOND) / NANOSECONDS_PER_MICROSECOND).toInt()
+    val nanoseconds = (value % NANOSECONDS_PER_MICROSECOND).toInt()
     return action(seconds, milliseconds, microseconds, nanoseconds)
   }
 
   public inline fun <T> toComponents(action: (
-    minutes: LongMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds,
-    nanoseconds: IntNanoseconds
+    seconds: Seconds,
+    milliseconds: Milliseconds,
+    microseconds: Microseconds,
+    nanoseconds: Nanoseconds
   ) -> T): T {
-    val minutes = (`value` / NANOSECONDS_PER_MINUTE).minutes
-    val seconds = ((`value` % NANOSECONDS_PER_MINUTE) / NANOSECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = ((`value` % NANOSECONDS_PER_SECOND) /
-        NANOSECONDS_PER_MILLISECOND).toInt().milliseconds
-    val microseconds = ((`value` % NANOSECONDS_PER_MILLISECOND) /
-        NANOSECONDS_PER_MICROSECOND).toInt().microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).toInt().nanoseconds
+     return toComponentValues { seconds, milliseconds, microseconds, nanoseconds ->
+         action(Seconds(seconds), Milliseconds(milliseconds), Microseconds(microseconds),
+        Nanoseconds(nanoseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    minutes: Long,
+    seconds: Int,
+    milliseconds: Int,
+    microseconds: Int,
+    nanoseconds: Int
+  ) -> T): T {
+    val minutes = (value / NANOSECONDS_PER_MINUTE)
+    val seconds = ((value % NANOSECONDS_PER_MINUTE) / NANOSECONDS_PER_SECOND).toInt()
+    val milliseconds = ((value % NANOSECONDS_PER_SECOND) / NANOSECONDS_PER_MILLISECOND).toInt()
+    val microseconds = ((value % NANOSECONDS_PER_MILLISECOND) / NANOSECONDS_PER_MICROSECOND).toInt()
+    val nanoseconds = (value % NANOSECONDS_PER_MICROSECOND).toInt()
     return action(minutes, seconds, milliseconds, microseconds, nanoseconds)
   }
 
   public inline fun <T> toComponents(action: (
-    hours: LongHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds,
-    nanoseconds: IntNanoseconds
+    minutes: Minutes,
+    seconds: Seconds,
+    milliseconds: Milliseconds,
+    microseconds: Microseconds,
+    nanoseconds: Nanoseconds
   ) -> T): T {
-    val hours = (`value` / NANOSECONDS_PER_HOUR).hours
-    val minutes = ((`value` % NANOSECONDS_PER_HOUR) / NANOSECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % NANOSECONDS_PER_MINUTE) / NANOSECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = ((`value` % NANOSECONDS_PER_SECOND) /
-        NANOSECONDS_PER_MILLISECOND).toInt().milliseconds
-    val microseconds = ((`value` % NANOSECONDS_PER_MILLISECOND) /
-        NANOSECONDS_PER_MICROSECOND).toInt().microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).toInt().nanoseconds
+     return toComponentValues { minutes, seconds, milliseconds, microseconds, nanoseconds ->
+         action(Minutes(minutes), Seconds(seconds), Milliseconds(milliseconds),
+        Microseconds(microseconds), Nanoseconds(nanoseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    hours: Long,
+    minutes: Int,
+    seconds: Int,
+    milliseconds: Int,
+    microseconds: Int,
+    nanoseconds: Int
+  ) -> T): T {
+    val hours = (value / NANOSECONDS_PER_HOUR)
+    val minutes = ((value % NANOSECONDS_PER_HOUR) / NANOSECONDS_PER_MINUTE).toInt()
+    val seconds = ((value % NANOSECONDS_PER_MINUTE) / NANOSECONDS_PER_SECOND).toInt()
+    val milliseconds = ((value % NANOSECONDS_PER_SECOND) / NANOSECONDS_PER_MILLISECOND).toInt()
+    val microseconds = ((value % NANOSECONDS_PER_MILLISECOND) / NANOSECONDS_PER_MICROSECOND).toInt()
+    val nanoseconds = (value % NANOSECONDS_PER_MICROSECOND).toInt()
     return action(hours, minutes, seconds, milliseconds, microseconds, nanoseconds)
   }
 
   public inline fun <T> toComponents(action: (
-    days: LongDays,
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds,
-    milliseconds: IntMilliseconds,
-    microseconds: IntMicroseconds,
-    nanoseconds: IntNanoseconds
+    hours: Hours,
+    minutes: Minutes,
+    seconds: Seconds,
+    milliseconds: Milliseconds,
+    microseconds: Microseconds,
+    nanoseconds: Nanoseconds
   ) -> T): T {
-    val days = (`value` / NANOSECONDS_PER_DAY).days
-    val hours = ((`value` % NANOSECONDS_PER_DAY) / NANOSECONDS_PER_HOUR).toInt().hours
-    val minutes = ((`value` % NANOSECONDS_PER_HOUR) / NANOSECONDS_PER_MINUTE).toInt().minutes
-    val seconds = ((`value` % NANOSECONDS_PER_MINUTE) / NANOSECONDS_PER_SECOND).toInt().seconds
-    val milliseconds = ((`value` % NANOSECONDS_PER_SECOND) /
-        NANOSECONDS_PER_MILLISECOND).toInt().milliseconds
-    val microseconds = ((`value` % NANOSECONDS_PER_MILLISECOND) /
-        NANOSECONDS_PER_MICROSECOND).toInt().microseconds
-    val nanoseconds = (`value` % NANOSECONDS_PER_MICROSECOND).toInt().nanoseconds
+     return toComponentValues { hours, minutes, seconds, milliseconds, microseconds, nanoseconds ->
+         action(Hours(hours), Minutes(minutes), Seconds(seconds), Milliseconds(milliseconds),
+        Microseconds(microseconds), Nanoseconds(nanoseconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    days: Long,
+    hours: Int,
+    minutes: Int,
+    seconds: Int,
+    milliseconds: Int,
+    microseconds: Int,
+    nanoseconds: Int
+  ) -> T): T {
+    val days = (value / NANOSECONDS_PER_DAY)
+    val hours = ((value % NANOSECONDS_PER_DAY) / NANOSECONDS_PER_HOUR).toInt()
+    val minutes = ((value % NANOSECONDS_PER_HOUR) / NANOSECONDS_PER_MINUTE).toInt()
+    val seconds = ((value % NANOSECONDS_PER_MINUTE) / NANOSECONDS_PER_SECOND).toInt()
+    val milliseconds = ((value % NANOSECONDS_PER_SECOND) / NANOSECONDS_PER_MILLISECOND).toInt()
+    val microseconds = ((value % NANOSECONDS_PER_MILLISECOND) / NANOSECONDS_PER_MICROSECOND).toInt()
+    val nanoseconds = (value % NANOSECONDS_PER_MICROSECOND).toInt()
     return action(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds)
   }
 
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.nanoseconds(`value`)
+  public inline fun <T> toComponents(action: (
+    days: Days,
+    hours: Hours,
+    minutes: Minutes,
+    seconds: Seconds,
+    milliseconds: Milliseconds,
+    microseconds: Microseconds,
+    nanoseconds: Nanoseconds
+  ) -> T): T {
+     return toComponentValues { days, hours, minutes, seconds, milliseconds, microseconds,
+        nanoseconds ->
+         action(Days(days), Hours(hours), Minutes(minutes), Seconds(seconds),
+        Milliseconds(milliseconds), Microseconds(microseconds), Nanoseconds(nanoseconds))
+     }
+  }
 
   /**
-   * Converts this duration to [IntNanoseconds].
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  public fun toIntNanoseconds(): IntNanoseconds = IntNanoseconds(`value`.toIntExact())
-
-  /**
-   * Converts this duration to [IntNanoseconds] without checking for overflow.
-   */
-  @PublishedApi
-  internal fun toIntNanosecondsUnchecked(): IntNanoseconds = IntNanoseconds(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntNanoseconds]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntNanoseconds(): Nanoseconds = this
+
+  /**
+   * Converts this duration to [IntNanoseconds] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntNanosecondsUnchecked(): Nanoseconds = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongNanoseconds = LongNanoseconds(Long.MIN_VALUE)
+    public val MIN: Nanoseconds = Nanoseconds(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongNanoseconds = LongNanoseconds(Long.MAX_VALUE)
+    public val MAX: Nanoseconds = Nanoseconds(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of nanoseconds.
  */
-public val Long.nanoseconds: LongNanoseconds
-  get() = LongNanoseconds(this)
+public val Int.nanoseconds: Nanoseconds
+  get() = Nanoseconds(this)
 
 /**
- * Multiplies this value by a duration of nanoseconds.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of nanoseconds. @throws ArithmeticException if overflow
+ * occurs
  */
-public operator fun Int.times(nanoseconds: LongNanoseconds): LongNanoseconds = nanoseconds * this
+public operator fun Int.times(nanoseconds: Nanoseconds): Nanoseconds = nanoseconds * this
 
 /**
- * Multiplies this value by a duration of nanoseconds.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of nanoseconds.
  */
-public operator fun Long.times(nanoseconds: LongNanoseconds): LongNanoseconds = nanoseconds * this
+public val Long.nanoseconds: Nanoseconds
+  get() = Nanoseconds(this)
 
 /**
- * Converts this duration to Island Time [LongNanoseconds].
+ * Multiplies this value by a duration of nanoseconds. @throws ArithmeticException if overflow
+ * occurs
+ */
+public operator fun Long.times(nanoseconds: Nanoseconds): Nanoseconds = nanoseconds * this
+
+/**
+ * Converts this duration to Island Time [Nanoseconds].
  */
 @ExperimentalTime
-public fun KotlinDuration.toIslandNanoseconds(): LongNanoseconds =
-    LongNanoseconds(this.toLong(KotlinDurationUnit.NANOSECONDS))
+public fun KotlinDuration.toIslandNanoseconds(): Nanoseconds =
+    Nanoseconds(this.toLong(KotlinDurationUnit.NANOSECONDS))

--- a/core/src/commonMain/generated/io/islandtime/measures/_Seconds.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Seconds.kt
@@ -20,6 +20,7 @@ import io.islandtime.`internal`.SECONDS_PER_HOUR
 import io.islandtime.`internal`.SECONDS_PER_MINUTE
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -88,16 +89,31 @@ public value class IntSeconds(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.seconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.seconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.seconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntSeconds): Int = `value`.compareTo(other.`value`)
@@ -391,16 +407,31 @@ public value class LongSeconds(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.seconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.seconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.seconds"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongSeconds): Int = `value`.compareTo(other.`value`)
@@ -602,6 +633,11 @@ public value class LongSeconds(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Seconds.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Seconds.kt
@@ -18,9 +18,11 @@ import io.islandtime.`internal`.NANOSECONDS_PER_SECOND
 import io.islandtime.`internal`.SECONDS_PER_DAY
 import io.islandtime.`internal`.SECONDS_PER_HOUR
 import io.islandtime.`internal`.SECONDS_PER_MINUTE
+import io.islandtime.`internal`.deprecatedToError
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -33,376 +35,112 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Duration as KotlinDuration
 import kotlin.time.DurationUnit as KotlinDurationUnit
 
-/**
- * A number of seconds.
- */
+@Deprecated(
+  message = "Replace with Seconds.",
+  replaceWith = ReplaceWith("Seconds"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntSeconds = Seconds
+
+@Deprecated(
+  message = "Replace with Seconds.",
+  replaceWith = ReplaceWith("Seconds"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongSeconds = Seconds
+
 @JvmInline
-public value class IntSeconds(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntSeconds> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntSeconds
-    get() = IntSeconds(absExact(`value`))
-
-  /**
-   * Converts this duration to nanoseconds.
-   */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value`.toLong() * NANOSECONDS_PER_SECOND).nanoseconds
-
-  /**
-   * Converts this duration to microseconds.
-   */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value`.toLong() * MICROSECONDS_PER_SECOND).microseconds
-
-  /**
-   * Converts this duration to milliseconds.
-   */
-  public val inMilliseconds: LongMilliseconds
-    get() = (`value`.toLong() * MILLISECONDS_PER_SECOND).milliseconds
-
-  /**
-   * Converts this duration to the number of whole minutes.
-   */
-  public val inMinutes: IntMinutes
-    get() = (`value` / SECONDS_PER_MINUTE).minutes
-
-  /**
-   * Converts this duration to the number of whole hours.
-   */
-  public val inHours: IntHours
-    get() = (`value` / SECONDS_PER_HOUR).hours
-
-  /**
-   * Converts this duration to the number of whole days.
-   */
-  public val inDays: IntDays
-    get() = (`value` / SECONDS_PER_DAY).days
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.seconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.seconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.seconds"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntSeconds): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return when (`value`) {
-       0 -> "PT0S"
-       Int.MIN_VALUE -> "-PT2147483648S"
-       else -> buildString {
-         if (`value` < 0) { append('-') }
-         append("PT")
-         append(`value`.absoluteValue)
-         append('S')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntSeconds = IntSeconds(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntSeconds = IntSeconds(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): IntSeconds = IntSeconds(`value` timesExact scalar)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongSeconds = this.toLongSeconds() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntSeconds {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntSeconds(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongSeconds = this.toLongSeconds() / scalar
-
-  public operator fun rem(scalar: Int): IntSeconds = IntSeconds(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongSeconds = this.toLongSeconds() % scalar
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongSeconds().inNanoseconds + nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds =
-      this.toLongSeconds().inNanoseconds - nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds -
-      microseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.toLongSeconds().inMicroseconds + microseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.toLongSeconds().inMicroseconds - microseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds -
-      milliseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.toLongSeconds().inMilliseconds + milliseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.toLongSeconds().inMilliseconds - milliseconds
-
-  public operator fun plus(seconds: IntSeconds): IntSeconds = IntSeconds(`value` plusExact
-      seconds.value)
-
-  public operator fun minus(seconds: IntSeconds): IntSeconds = IntSeconds(`value` minusExact
-      seconds.value)
-
-  public operator fun plus(seconds: LongSeconds): LongSeconds =
-      LongSeconds(`value`.toLong() plusExact seconds.value)
-
-  public operator fun minus(seconds: LongSeconds): LongSeconds =
-      LongSeconds(`value`.toLong() minusExact seconds.value)
-
-  public operator fun plus(minutes: IntMinutes): IntSeconds = this + minutes.inSeconds
-
-  public operator fun minus(minutes: IntMinutes): IntSeconds = this - minutes.inSeconds
-
-  public operator fun plus(minutes: LongMinutes): LongSeconds = this.toLongSeconds() +
-      minutes.inSeconds
-
-  public operator fun minus(minutes: LongMinutes): LongSeconds = this.toLongSeconds() -
-      minutes.inSeconds
-
-  public operator fun plus(hours: IntHours): IntSeconds = this + hours.inSeconds
-
-  public operator fun minus(hours: IntHours): IntSeconds = this - hours.inSeconds
-
-  public operator fun plus(hours: LongHours): LongSeconds = this.toLongSeconds() + hours.inSeconds
-
-  public operator fun minus(hours: LongHours): LongSeconds = this.toLongSeconds() - hours.inSeconds
-
-  public operator fun plus(days: IntDays): IntSeconds = this + days.inSeconds
-
-  public operator fun minus(days: IntDays): IntSeconds = this - days.inSeconds
-
-  public operator fun plus(days: LongDays): LongSeconds = this.toLongSeconds() + days.inSeconds
-
-  public operator fun minus(days: LongDays): LongSeconds = this.toLongSeconds() - days.inSeconds
-
-  public inline fun <T> toComponents(action: (minutes: IntMinutes, seconds: IntSeconds) -> T): T {
-    val minutes = (`value` / SECONDS_PER_MINUTE).minutes
-    val seconds = (`value` % SECONDS_PER_MINUTE).seconds
-    return action(minutes, seconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds
-  ) -> T): T {
-    val hours = (`value` / SECONDS_PER_HOUR).hours
-    val minutes = ((`value` % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE).minutes
-    val seconds = (`value` % SECONDS_PER_MINUTE).seconds
-    return action(hours, minutes, seconds)
-  }
-
-  public inline fun <T> toComponents(action: (
-    days: IntDays,
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds
-  ) -> T): T {
-    val days = (`value` / SECONDS_PER_DAY).days
-    val hours = ((`value` % SECONDS_PER_DAY) / SECONDS_PER_HOUR).hours
-    val minutes = ((`value` % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE).minutes
-    val seconds = (`value` % SECONDS_PER_MINUTE).seconds
-    return action(days, hours, minutes, seconds)
-  }
-
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.seconds(`value`)
-
-  /**
-   * Converts this duration to [LongSeconds].
-   */
-  public fun toLongSeconds(): LongSeconds = LongSeconds(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntSeconds = IntSeconds(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntSeconds = IntSeconds(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of seconds.
- */
-public val Int.seconds: IntSeconds
-  get() = IntSeconds(this)
-
-/**
- * Multiplies this value by a duration of seconds.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(seconds: IntSeconds): IntSeconds = seconds * this
-
-/**
- * Multiplies this value by a duration of seconds.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(seconds: IntSeconds): LongSeconds = seconds * this
-
-/**
- * A number of seconds.
- */
-@JvmInline
-public value class LongSeconds(
+public value class Seconds(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongSeconds> {
+) : Comparable<Seconds> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongSeconds
-    get() = LongSeconds(absExact(`value`))
+  public val absoluteValue: Seconds
+    get() = Seconds(absExact(value))
 
   /**
-   * Converts this duration to nanoseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to nanoseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inNanoseconds: LongNanoseconds
-    get() = (`value` timesExact NANOSECONDS_PER_SECOND).nanoseconds
+  public val inNanoseconds: Nanoseconds
+    get() = Nanoseconds(value timesExact NANOSECONDS_PER_SECOND)
 
   /**
    * Converts this duration to nanoseconds without checking for overflow.
    */
-  internal val inNanosecondsUnchecked: LongNanoseconds
-    get() = (`value` * NANOSECONDS_PER_SECOND).nanoseconds
+  internal val inNanosecondsUnchecked: Nanoseconds
+    get() = Nanoseconds(value * NANOSECONDS_PER_SECOND)
 
   /**
-   * Converts this duration to microseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to microseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inMicroseconds: LongMicroseconds
-    get() = (`value` timesExact MICROSECONDS_PER_SECOND).microseconds
+  public val inMicroseconds: Microseconds
+    get() = Microseconds(value timesExact MICROSECONDS_PER_SECOND)
 
   /**
    * Converts this duration to microseconds without checking for overflow.
    */
-  internal val inMicrosecondsUnchecked: LongMicroseconds
-    get() = (`value` * MICROSECONDS_PER_SECOND).microseconds
+  internal val inMicrosecondsUnchecked: Microseconds
+    get() = Microseconds(value * MICROSECONDS_PER_SECOND)
 
   /**
-   * Converts this duration to milliseconds.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to milliseconds. @throws ArithmeticException if overflow occurs
    */
-  public val inMilliseconds: LongMilliseconds
-    get() = (`value` timesExact MILLISECONDS_PER_SECOND).milliseconds
+  public val inMilliseconds: Milliseconds
+    get() = Milliseconds(value timesExact MILLISECONDS_PER_SECOND)
 
   /**
    * Converts this duration to milliseconds without checking for overflow.
    */
-  internal val inMillisecondsUnchecked: LongMilliseconds
-    get() = (`value` * MILLISECONDS_PER_SECOND).milliseconds
+  internal val inMillisecondsUnchecked: Milliseconds
+    get() = Milliseconds(value * MILLISECONDS_PER_SECOND)
 
   /**
    * Converts this duration to the number of whole minutes.
    */
-  public val inMinutes: LongMinutes
-    get() = (`value` / SECONDS_PER_MINUTE).minutes
+  public val inWholeMinutes: Minutes
+    get() = Minutes(value / SECONDS_PER_MINUTE)
+
+  @Deprecated(
+    message = "Use inWholeMinutes instead.",
+    replaceWith = ReplaceWith("this.inWholeMinutes"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inMinutes: Minutes
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole hours.
    */
-  public val inHours: LongHours
-    get() = (`value` / SECONDS_PER_HOUR).hours
+  public val inWholeHours: Hours
+    get() = Hours(value / SECONDS_PER_HOUR)
+
+  @Deprecated(
+    message = "Use inWholeHours instead.",
+    replaceWith = ReplaceWith("this.inWholeHours"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inHours: Hours
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole days.
    */
-  public val inDays: LongDays
-    get() = (`value` / SECONDS_PER_DAY).days
+  public val inWholeDays: Days
+    get() = Days(value / SECONDS_PER_DAY)
+
+  @Deprecated(
+    message = "Use inWholeDays instead.",
+    replaceWith = ReplaceWith("this.inWholeDays"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inDays: Days
+    get() = deprecatedToError()
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -412,7 +150,7 @@ public value class LongSeconds(
     replaceWith = ReplaceWith("this == 0L.seconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -422,7 +160,7 @@ public value class LongSeconds(
     replaceWith = ReplaceWith("this < 0L.seconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -432,247 +170,255 @@ public value class LongSeconds(
     replaceWith = ReplaceWith("this > 0L.seconds"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongSeconds): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Seconds): Int = value.compareTo(other.value)
+
+  /**
+   * Converts this duration to a [kotlin.time.Duration].
+   */
+  @ExperimentalTime
+  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.seconds(value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return when (`value`) {
+     return when (value) {
        0L -> "PT0S"
        Long.MIN_VALUE -> "-PT9223372036854775808S"
        else -> buildString {
-         if (`value` < 0) { append('-') }
+         if (value < 0) { append('-') }
          append("PT")
-         append(`value`.absoluteValue)
+         append(value.absoluteValue)
          append('S')
        }
      }
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongSeconds = LongSeconds(`value`.negateExact())
+  public operator fun unaryMinus(): Seconds = Seconds(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongSeconds = LongSeconds(-`value`)
+  internal fun negateUnchecked(): Seconds = Seconds(-value)
+
+  public operator fun plus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds + nanoseconds
+
+  public operator fun minus(nanoseconds: Nanoseconds): Nanoseconds = this.inNanoseconds -
+      nanoseconds
+
+  public operator fun plus(microseconds: Microseconds): Microseconds = this.inMicroseconds +
+      microseconds
+
+  public operator fun minus(microseconds: Microseconds): Microseconds = this.inMicroseconds -
+      microseconds
+
+  public operator fun plus(milliseconds: Milliseconds): Milliseconds = this.inMilliseconds +
+      milliseconds
+
+  public operator fun minus(milliseconds: Milliseconds): Milliseconds = this.inMilliseconds -
+      milliseconds
+
+  public operator fun plus(seconds: Seconds): Seconds = Seconds(value plusExact seconds.value)
+
+  public operator fun minus(seconds: Seconds): Seconds = Seconds(value minusExact seconds.value)
+
+  public operator fun plus(minutes: Minutes): Seconds = this + minutes.inSeconds
+
+  public operator fun minus(minutes: Minutes): Seconds = this - minutes.inSeconds
+
+  public operator fun plus(hours: Hours): Seconds = this + hours.inSeconds
+
+  public operator fun minus(hours: Hours): Seconds = this - hours.inSeconds
+
+  public operator fun plus(days: Days): Seconds = this + days.inSeconds
+
+  public operator fun minus(days: Days): Seconds = this - days.inSeconds
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongSeconds = LongSeconds(`value` timesExact scalar)
+  public operator fun times(scalar: Int): Seconds = Seconds(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongSeconds = LongSeconds(`value` timesExact scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongSeconds {
+  public operator fun div(scalar: Int): Seconds {
      return if (scalar == -1) {
        -this
      } else {
-       LongSeconds(`value` / scalar)
+       Seconds(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongSeconds {
+  public operator fun rem(scalar: Int): Seconds = Seconds(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Seconds = Seconds(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Seconds {
      return if (scalar == -1L) {
        -this
      } else {
-       LongSeconds(`value` / scalar)
+       Seconds(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongSeconds = LongSeconds(`value` % scalar)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Seconds = Seconds(value % scalar)
 
-  public operator fun rem(scalar: Long): LongSeconds = LongSeconds(`value` % scalar)
-
-  public operator fun plus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: IntNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds +
-      nanoseconds
-
-  public operator fun minus(nanoseconds: LongNanoseconds): LongNanoseconds = this.inNanoseconds -
-      nanoseconds
-
-  public operator fun plus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: IntMicroseconds): LongMicroseconds = this.inMicroseconds -
-      microseconds
-
-  public operator fun plus(microseconds: LongMicroseconds): LongMicroseconds = this.inMicroseconds +
-      microseconds
-
-  public operator fun minus(microseconds: LongMicroseconds): LongMicroseconds =
-      this.inMicroseconds - microseconds
-
-  public operator fun plus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: IntMilliseconds): LongMilliseconds = this.inMilliseconds -
-      milliseconds
-
-  public operator fun plus(milliseconds: LongMilliseconds): LongMilliseconds = this.inMilliseconds +
-      milliseconds
-
-  public operator fun minus(milliseconds: LongMilliseconds): LongMilliseconds =
-      this.inMilliseconds - milliseconds
-
-  public operator fun plus(seconds: IntSeconds): LongSeconds = LongSeconds(`value` plusExact
-      seconds.value)
-
-  public operator fun minus(seconds: IntSeconds): LongSeconds = LongSeconds(`value` minusExact
-      seconds.value)
-
-  public operator fun plus(seconds: LongSeconds): LongSeconds = LongSeconds(`value` plusExact
-      seconds.value)
-
-  public operator fun minus(seconds: LongSeconds): LongSeconds = LongSeconds(`value` minusExact
-      seconds.value)
-
-  public operator fun plus(minutes: IntMinutes): LongSeconds = this + minutes.inSeconds
-
-  public operator fun minus(minutes: IntMinutes): LongSeconds = this - minutes.inSeconds
-
-  public operator fun plus(minutes: LongMinutes): LongSeconds = this + minutes.inSeconds
-
-  public operator fun minus(minutes: LongMinutes): LongSeconds = this - minutes.inSeconds
-
-  public operator fun plus(hours: IntHours): LongSeconds = this + hours.inSeconds
-
-  public operator fun minus(hours: IntHours): LongSeconds = this - hours.inSeconds
-
-  public operator fun plus(hours: LongHours): LongSeconds = this + hours.inSeconds
-
-  public operator fun minus(hours: LongHours): LongSeconds = this - hours.inSeconds
-
-  public operator fun plus(days: IntDays): LongSeconds = this + days.inSeconds
-
-  public operator fun minus(days: IntDays): LongSeconds = this - days.inSeconds
-
-  public operator fun plus(days: LongDays): LongSeconds = this + days.inSeconds
-
-  public operator fun minus(days: LongDays): LongSeconds = this - days.inSeconds
-
-  public inline fun <T> toComponents(action: (minutes: LongMinutes, seconds: IntSeconds) -> T): T {
-    val minutes = (`value` / SECONDS_PER_MINUTE).minutes
-    val seconds = (`value` % SECONDS_PER_MINUTE).toInt().seconds
+  public inline fun <T> toComponentValues(action: (minutes: Long, seconds: Int) -> T): T {
+    val minutes = (value / SECONDS_PER_MINUTE)
+    val seconds = (value % SECONDS_PER_MINUTE).toInt()
     return action(minutes, seconds)
   }
 
-  public inline fun <T> toComponents(action: (
-    hours: LongHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds
+  public inline fun <T> toComponents(action: (minutes: Minutes, seconds: Seconds) -> T): T {
+     return toComponentValues { minutes, seconds ->
+         action(Minutes(minutes), Seconds(seconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    hours: Long,
+    minutes: Int,
+    seconds: Int
   ) -> T): T {
-    val hours = (`value` / SECONDS_PER_HOUR).hours
-    val minutes = ((`value` % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE).toInt().minutes
-    val seconds = (`value` % SECONDS_PER_MINUTE).toInt().seconds
+    val hours = (value / SECONDS_PER_HOUR)
+    val minutes = ((value % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE).toInt()
+    val seconds = (value % SECONDS_PER_MINUTE).toInt()
     return action(hours, minutes, seconds)
   }
 
   public inline fun <T> toComponents(action: (
-    days: LongDays,
-    hours: IntHours,
-    minutes: IntMinutes,
-    seconds: IntSeconds
+    hours: Hours,
+    minutes: Minutes,
+    seconds: Seconds
   ) -> T): T {
-    val days = (`value` / SECONDS_PER_DAY).days
-    val hours = ((`value` % SECONDS_PER_DAY) / SECONDS_PER_HOUR).toInt().hours
-    val minutes = ((`value` % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE).toInt().minutes
-    val seconds = (`value` % SECONDS_PER_MINUTE).toInt().seconds
+     return toComponentValues { hours, minutes, seconds ->
+         action(Hours(hours), Minutes(minutes), Seconds(seconds))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    days: Long,
+    hours: Int,
+    minutes: Int,
+    seconds: Int
+  ) -> T): T {
+    val days = (value / SECONDS_PER_DAY)
+    val hours = ((value % SECONDS_PER_DAY) / SECONDS_PER_HOUR).toInt()
+    val minutes = ((value % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE).toInt()
+    val seconds = (value % SECONDS_PER_MINUTE).toInt()
     return action(days, hours, minutes, seconds)
   }
 
-  /**
-   * Converts this duration to a [kotlin.time.Duration].
-   */
-  @ExperimentalTime
-  public fun toKotlinDuration(): KotlinDuration = KotlinDuration.seconds(`value`)
+  public inline fun <T> toComponents(action: (
+    days: Days,
+    hours: Hours,
+    minutes: Minutes,
+    seconds: Seconds
+  ) -> T): T {
+     return toComponentValues { days, hours, minutes, seconds ->
+         action(Days(days), Hours(hours), Minutes(minutes), Seconds(seconds))
+     }
+  }
 
   /**
-   * Converts this duration to [IntSeconds].
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  public fun toIntSeconds(): IntSeconds = IntSeconds(`value`.toIntExact())
-
-  /**
-   * Converts this duration to [IntSeconds] without checking for overflow.
-   */
-  @PublishedApi
-  internal fun toIntSecondsUnchecked(): IntSeconds = IntSeconds(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntSeconds]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntSeconds(): Seconds = this
+
+  /**
+   * Converts this duration to [IntSeconds] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntSecondsUnchecked(): Seconds = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongSeconds = LongSeconds(Long.MIN_VALUE)
+    public val MIN: Seconds = Seconds(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongSeconds = LongSeconds(Long.MAX_VALUE)
+    public val MAX: Seconds = Seconds(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of seconds.
  */
-public val Long.seconds: LongSeconds
-  get() = LongSeconds(this)
+public val Int.seconds: Seconds
+  get() = Seconds(this)
 
 /**
- * Multiplies this value by a duration of seconds.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of seconds. @throws ArithmeticException if overflow occurs
  */
-public operator fun Int.times(seconds: LongSeconds): LongSeconds = seconds * this
+public operator fun Int.times(seconds: Seconds): Seconds = seconds * this
 
 /**
- * Multiplies this value by a duration of seconds.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of seconds.
  */
-public operator fun Long.times(seconds: LongSeconds): LongSeconds = seconds * this
+public val Long.seconds: Seconds
+  get() = Seconds(this)
 
 /**
- * Converts this duration to Island Time [LongSeconds].
+ * Multiplies this value by a duration of seconds. @throws ArithmeticException if overflow occurs
+ */
+public operator fun Long.times(seconds: Seconds): Seconds = seconds * this
+
+/**
+ * Converts this duration to Island Time [Seconds].
  */
 @ExperimentalTime
-public fun KotlinDuration.toIslandSeconds(): LongSeconds =
-    LongSeconds(this.toLong(KotlinDurationUnit.SECONDS))
+public fun KotlinDuration.toIslandSeconds(): Seconds =
+    Seconds(this.toLong(KotlinDurationUnit.SECONDS))

--- a/core/src/commonMain/generated/io/islandtime/measures/_Weeks.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Weeks.kt
@@ -16,6 +16,7 @@ import io.islandtime.`internal`.DAYS_PER_WEEK
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -25,217 +26,46 @@ import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 import kotlin.math.absoluteValue
 
-/**
- * A number of weeks.
- */
+@Deprecated(
+  message = "Replace with Weeks.",
+  replaceWith = ReplaceWith("Weeks"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntWeeks = Weeks
+
+@Deprecated(
+  message = "Replace with Weeks.",
+  replaceWith = ReplaceWith("Weeks"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongWeeks = Weeks
+
 @JvmInline
-public value class IntWeeks(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntWeeks> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntWeeks
-    get() = IntWeeks(absExact(`value`))
-
-  /**
-   * Converts this duration to days.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inDays: IntDays
-    get() = (`value` timesExact DAYS_PER_WEEK).days
-
-  /**
-   * Converts this duration to days without checking for overflow.
-   */
-  internal val inDaysUnchecked: IntDays
-    get() = (`value` * DAYS_PER_WEEK).days
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.weeks"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.weeks"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.weeks"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntWeeks): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return when (`value`) {
-       0 -> "P0W"
-       Int.MIN_VALUE -> "-P2147483648W"
-       else -> buildString {
-         if (`value` < 0) { append('-') }
-         append("P")
-         append(`value`.absoluteValue)
-         append('W')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntWeeks = IntWeeks(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntWeeks = IntWeeks(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): IntWeeks = IntWeeks(`value` timesExact scalar)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongWeeks = this.toLongWeeks() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntWeeks {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntWeeks(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongWeeks = this.toLongWeeks() / scalar
-
-  public operator fun rem(scalar: Int): IntWeeks = IntWeeks(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongWeeks = this.toLongWeeks() % scalar
-
-  public operator fun plus(days: IntDays): IntDays = this.inDays + days
-
-  public operator fun minus(days: IntDays): IntDays = this.inDays - days
-
-  public operator fun plus(days: LongDays): LongDays = this.toLongWeeks().inDays + days
-
-  public operator fun minus(days: LongDays): LongDays = this.toLongWeeks().inDays - days
-
-  public operator fun plus(weeks: IntWeeks): IntWeeks = IntWeeks(`value` plusExact weeks.value)
-
-  public operator fun minus(weeks: IntWeeks): IntWeeks = IntWeeks(`value` minusExact weeks.value)
-
-  public operator fun plus(weeks: LongWeeks): LongWeeks = LongWeeks(`value`.toLong() plusExact
-      weeks.value)
-
-  public operator fun minus(weeks: LongWeeks): LongWeeks = LongWeeks(`value`.toLong() minusExact
-      weeks.value)
-
-  /**
-   * Converts this duration to [LongWeeks].
-   */
-  public fun toLongWeeks(): LongWeeks = LongWeeks(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntWeeks = IntWeeks(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntWeeks = IntWeeks(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of weeks.
- */
-public val Int.weeks: IntWeeks
-  get() = IntWeeks(this)
-
-/**
- * Multiplies this value by a duration of weeks.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(weeks: IntWeeks): IntWeeks = weeks * this
-
-/**
- * Multiplies this value by a duration of weeks.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(weeks: IntWeeks): LongWeeks = weeks * this
-
-/**
- * A number of weeks.
- */
-@JvmInline
-public value class LongWeeks(
+public value class Weeks(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongWeeks> {
+) : Comparable<Weeks> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongWeeks
-    get() = LongWeeks(absExact(`value`))
+  public val absoluteValue: Weeks
+    get() = Weeks(absExact(value))
 
   /**
-   * Converts this duration to days.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to days. @throws ArithmeticException if overflow occurs
    */
-  public val inDays: LongDays
-    get() = (`value` timesExact DAYS_PER_WEEK).days
+  public val inDays: Days
+    get() = Days(value timesExact DAYS_PER_WEEK)
 
   /**
    * Converts this duration to days without checking for overflow.
    */
-  internal val inDaysUnchecked: LongDays
-    get() = (`value` * DAYS_PER_WEEK).days
+  internal val inDaysUnchecked: Days
+    get() = Days(value * DAYS_PER_WEEK)
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -245,7 +75,7 @@ public value class LongWeeks(
     replaceWith = ReplaceWith("this == 0L.weeks"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -255,7 +85,7 @@ public value class LongWeeks(
     replaceWith = ReplaceWith("this < 0L.weeks"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -265,148 +95,160 @@ public value class LongWeeks(
     replaceWith = ReplaceWith("this > 0L.weeks"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongWeeks): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Weeks): Int = value.compareTo(other.value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return when (`value`) {
+     return when (value) {
        0L -> "P0W"
        Long.MIN_VALUE -> "-P9223372036854775808W"
        else -> buildString {
-         if (`value` < 0) { append('-') }
+         if (value < 0) { append('-') }
          append("P")
-         append(`value`.absoluteValue)
+         append(value.absoluteValue)
          append('W')
        }
      }
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongWeeks = LongWeeks(`value`.negateExact())
+  public operator fun unaryMinus(): Weeks = Weeks(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongWeeks = LongWeeks(-`value`)
+  internal fun negateUnchecked(): Weeks = Weeks(-value)
+
+  public operator fun plus(days: Days): Days = this.inDays + days
+
+  public operator fun minus(days: Days): Days = this.inDays - days
+
+  public operator fun plus(weeks: Weeks): Weeks = Weeks(value plusExact weeks.value)
+
+  public operator fun minus(weeks: Weeks): Weeks = Weeks(value minusExact weeks.value)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongWeeks = LongWeeks(`value` timesExact scalar)
+  public operator fun times(scalar: Int): Weeks = Weeks(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongWeeks = LongWeeks(`value` timesExact scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongWeeks {
+  public operator fun div(scalar: Int): Weeks {
      return if (scalar == -1) {
        -this
      } else {
-       LongWeeks(`value` / scalar)
+       Weeks(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongWeeks {
+  public operator fun rem(scalar: Int): Weeks = Weeks(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Weeks = Weeks(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Weeks {
      return if (scalar == -1L) {
        -this
      } else {
-       LongWeeks(`value` / scalar)
+       Weeks(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongWeeks = LongWeeks(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongWeeks = LongWeeks(`value` % scalar)
-
-  public operator fun plus(days: IntDays): LongDays = this.inDays + days
-
-  public operator fun minus(days: IntDays): LongDays = this.inDays - days
-
-  public operator fun plus(days: LongDays): LongDays = this.inDays + days
-
-  public operator fun minus(days: LongDays): LongDays = this.inDays - days
-
-  public operator fun plus(weeks: IntWeeks): LongWeeks = LongWeeks(`value` plusExact weeks.value)
-
-  public operator fun minus(weeks: IntWeeks): LongWeeks = LongWeeks(`value` minusExact weeks.value)
-
-  public operator fun plus(weeks: LongWeeks): LongWeeks = LongWeeks(`value` plusExact weeks.value)
-
-  public operator fun minus(weeks: LongWeeks): LongWeeks = LongWeeks(`value` minusExact weeks.value)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Weeks = Weeks(value % scalar)
 
   /**
-   * Converts this duration to [IntWeeks].
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  public fun toIntWeeks(): IntWeeks = IntWeeks(`value`.toIntExact())
-
-  /**
-   * Converts this duration to [IntWeeks] without checking for overflow.
-   */
-  @PublishedApi
-  internal fun toIntWeeksUnchecked(): IntWeeks = IntWeeks(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntWeeks]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntWeeks(): Weeks = this
+
+  /**
+   * Converts this duration to [IntWeeks] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntWeeksUnchecked(): Weeks = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongWeeks = LongWeeks(Long.MIN_VALUE)
+    public val MIN: Weeks = Weeks(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongWeeks = LongWeeks(Long.MAX_VALUE)
+    public val MAX: Weeks = Weeks(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of weeks.
  */
-public val Long.weeks: LongWeeks
-  get() = LongWeeks(this)
+public val Int.weeks: Weeks
+  get() = Weeks(this)
 
 /**
- * Multiplies this value by a duration of weeks.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of weeks. @throws ArithmeticException if overflow occurs
  */
-public operator fun Int.times(weeks: LongWeeks): LongWeeks = weeks * this
+public operator fun Int.times(weeks: Weeks): Weeks = weeks * this
 
 /**
- * Multiplies this value by a duration of weeks.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of weeks.
  */
-public operator fun Long.times(weeks: LongWeeks): LongWeeks = weeks * this
+public val Long.weeks: Weeks
+  get() = Weeks(this)
+
+/**
+ * Multiplies this value by a duration of weeks. @throws ArithmeticException if overflow occurs
+ */
+public operator fun Long.times(weeks: Weeks): Weeks = weeks * this

--- a/core/src/commonMain/generated/io/islandtime/measures/_Weeks.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Weeks.kt
@@ -15,6 +15,7 @@ import dev.erikchristensen.javamath2kmp.toIntExact
 import io.islandtime.`internal`.DAYS_PER_WEEK
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -57,16 +58,31 @@ public value class IntWeeks(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.weeks"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.weeks"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.weeks"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntWeeks): Int = `value`.compareTo(other.`value`)
@@ -224,16 +240,31 @@ public value class LongWeeks(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.weeks"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.weeks"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.weeks"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongWeeks): Int = `value`.compareTo(other.`value`)
@@ -343,6 +374,11 @@ public value class LongWeeks(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/generated/io/islandtime/measures/_Years.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Years.kt
@@ -15,9 +15,11 @@ import dev.erikchristensen.javamath2kmp.toIntExact
 import io.islandtime.`internal`.MONTHS_PER_YEAR
 import io.islandtime.`internal`.YEARS_PER_CENTURY
 import io.islandtime.`internal`.YEARS_PER_DECADE
+import io.islandtime.`internal`.deprecatedToError
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -27,276 +29,74 @@ import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 import kotlin.math.absoluteValue
 
-/**
- * A number of years.
- */
+@Deprecated(
+  message = "Replace with Years.",
+  replaceWith = ReplaceWith("Years"),
+  level = DeprecationLevel.ERROR
+)
+public typealias IntYears = Years
+
+@Deprecated(
+  message = "Replace with Years.",
+  replaceWith = ReplaceWith("Years"),
+  level = DeprecationLevel.ERROR
+)
+public typealias LongYears = Years
+
 @JvmInline
-public value class IntYears(
-  /**
-   * The underlying value.
-   */
-  public val `value`: Int
-) : Comparable<IntYears> {
-  /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val absoluteValue: IntYears
-    get() = IntYears(absExact(`value`))
-
-  /**
-   * Converts this duration to months.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public val inMonths: IntMonths
-    get() = (`value` timesExact MONTHS_PER_YEAR).months
-
-  /**
-   * Converts this duration to months without checking for overflow.
-   */
-  internal val inMonthsUnchecked: IntMonths
-    get() = (`value` * MONTHS_PER_YEAR).months
-
-  /**
-   * Converts this duration to the number of whole decades.
-   */
-  public val inDecades: IntDecades
-    get() = (`value` / YEARS_PER_DECADE).decades
-
-  /**
-   * Converts this duration to the number of whole centuries.
-   */
-  public val inCenturies: IntCenturies
-    get() = (`value` / YEARS_PER_CENTURY).centuries
-
-  /**
-   * Checks if this duration is zero.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this == 0.years"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isZero(): Boolean = `value` == 0
-
-  /**
-   * Checks if this duration is negative.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this < 0.years"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isNegative(): Boolean = `value` < 0
-
-  /**
-   * Checks if this duration is positive.
-   */
-  @Deprecated(
-    message = "Replace with direct comparison.",
-    replaceWith = ReplaceWith("this > 0.years"),
-    level = DeprecationLevel.ERROR
-  )
-  public fun isPositive(): Boolean = `value` > 0
-
-  public override fun compareTo(other: IntYears): Int = `value`.compareTo(other.`value`)
-
-  /**
-   * Converts this duration to an ISO-8601 time interval representation.
-   */
-  public override fun toString(): String {
-     return when (`value`) {
-       0 -> "P0Y"
-       Int.MIN_VALUE -> "-P2147483648Y"
-       else -> buildString {
-         if (`value` < 0) { append('-') }
-         append("P")
-         append(`value`.absoluteValue)
-         append('Y')
-       }
-     }
-  }
-
-  /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun unaryMinus(): IntYears = IntYears(`value`.negateExact())
-
-  /**
-   * Negates this duration without checking for overflow.
-   */
-  internal fun negateUnchecked(): IntYears = IntYears(-`value`)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Int): IntYears = IntYears(`value` timesExact scalar)
-
-  /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public operator fun times(scalar: Long): LongYears = this.toLongYears() * scalar
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): IntYears {
-     return if (scalar == -1) {
-       -this
-     } else {
-       IntYears(`value` / scalar)
-     }
-  }
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if the scalar is zero
-   */
-  public operator fun div(scalar: Long): LongYears = this.toLongYears() / scalar
-
-  public operator fun rem(scalar: Int): IntYears = IntYears(`value` % scalar)
-
-  public operator fun rem(scalar: Long): LongYears = this.toLongYears() % scalar
-
-  public operator fun plus(months: IntMonths): IntMonths = this.inMonths + months
-
-  public operator fun minus(months: IntMonths): IntMonths = this.inMonths - months
-
-  public operator fun plus(months: LongMonths): LongMonths = this.toLongYears().inMonths + months
-
-  public operator fun minus(months: LongMonths): LongMonths = this.toLongYears().inMonths - months
-
-  public operator fun plus(years: IntYears): IntYears = IntYears(`value` plusExact years.value)
-
-  public operator fun minus(years: IntYears): IntYears = IntYears(`value` minusExact years.value)
-
-  public operator fun plus(years: LongYears): LongYears = LongYears(`value`.toLong() plusExact
-      years.value)
-
-  public operator fun minus(years: LongYears): LongYears = LongYears(`value`.toLong() minusExact
-      years.value)
-
-  public operator fun plus(decades: IntDecades): IntYears = this + decades.inYears
-
-  public operator fun minus(decades: IntDecades): IntYears = this - decades.inYears
-
-  public operator fun plus(decades: LongDecades): LongYears = this.toLongYears() + decades.inYears
-
-  public operator fun minus(decades: LongDecades): LongYears = this.toLongYears() - decades.inYears
-
-  public operator fun plus(centuries: IntCenturies): IntYears = this + centuries.inYears
-
-  public operator fun minus(centuries: IntCenturies): IntYears = this - centuries.inYears
-
-  public operator fun plus(centuries: LongCenturies): LongYears = this.toLongYears() +
-      centuries.inYears
-
-  public operator fun minus(centuries: LongCenturies): LongYears = this.toLongYears() -
-      centuries.inYears
-
-  public inline fun <T> toComponents(action: (decades: IntDecades, years: IntYears) -> T): T {
-    val decades = (`value` / YEARS_PER_DECADE).decades
-    val years = (`value` % YEARS_PER_DECADE).years
-    return action(decades, years)
-  }
-
-  public inline fun <T> toComponents(action: (
-    centuries: IntCenturies,
-    decades: IntDecades,
-    years: IntYears
-  ) -> T): T {
-    val centuries = (`value` / YEARS_PER_CENTURY).centuries
-    val decades = ((`value` % YEARS_PER_CENTURY) / YEARS_PER_DECADE).decades
-    val years = (`value` % YEARS_PER_DECADE).years
-    return action(centuries, decades, years)
-  }
-
-  /**
-   * Converts this duration to [LongYears].
-   */
-  public fun toLongYears(): LongYears = LongYears(`value`.toLong())
-
-  /**
-   * Converts this duration to a `Long` value.
-   */
-  public fun toLong(): Long = `value`.toLong()
-
-  public companion object {
-    /**
-     * The smallest supported value.
-     */
-    public val MIN: IntYears = IntYears(Int.MIN_VALUE)
-
-    /**
-     * The largest supported value.
-     */
-    public val MAX: IntYears = IntYears(Int.MAX_VALUE)
-  }
-}
-
-/**
- * Converts this value to a duration of years.
- */
-public val Int.years: IntYears
-  get() = IntYears(this)
-
-/**
- * Multiplies this value by a duration of years.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Int.times(years: IntYears): IntYears = years * this
-
-/**
- * Multiplies this value by a duration of years.
- * @throws ArithmeticException if overflow occurs
- */
-public operator fun Long.times(years: IntYears): LongYears = years * this
-
-/**
- * A number of years.
- */
-@JvmInline
-public value class LongYears(
+public value class Years(
   /**
    * The underlying value.
    */
   public val `value`: Long
-) : Comparable<LongYears> {
+) : Comparable<Years> {
   /**
-   * The absolute value of this duration.
-   * @throws ArithmeticException if overflow occurs
+   * The absolute value of this duration. @throws ArithmeticException if overflow occurs
    */
-  public val absoluteValue: LongYears
-    get() = LongYears(absExact(`value`))
+  public val absoluteValue: Years
+    get() = Years(absExact(value))
 
   /**
-   * Converts this duration to months.
-   * @throws ArithmeticException if overflow occurs
+   * Converts this duration to months. @throws ArithmeticException if overflow occurs
    */
-  public val inMonths: LongMonths
-    get() = (`value` timesExact MONTHS_PER_YEAR).months
+  public val inMonths: Months
+    get() = Months(value timesExact MONTHS_PER_YEAR)
 
   /**
    * Converts this duration to months without checking for overflow.
    */
-  internal val inMonthsUnchecked: LongMonths
-    get() = (`value` * MONTHS_PER_YEAR).months
+  internal val inMonthsUnchecked: Months
+    get() = Months(value * MONTHS_PER_YEAR)
 
   /**
    * Converts this duration to the number of whole decades.
    */
-  public val inDecades: LongDecades
-    get() = (`value` / YEARS_PER_DECADE).decades
+  public val inWholeDecades: Decades
+    get() = Decades(value / YEARS_PER_DECADE)
+
+  @Deprecated(
+    message = "Use inWholeDecades instead.",
+    replaceWith = ReplaceWith("this.inWholeDecades"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inDecades: Decades
+    get() = deprecatedToError()
 
   /**
    * Converts this duration to the number of whole centuries.
    */
-  public val inCenturies: LongCenturies
-    get() = (`value` / YEARS_PER_CENTURY).centuries
+  public val inWholeCenturies: Centuries
+    get() = Centuries(value / YEARS_PER_CENTURY)
+
+  @Deprecated(
+    message = "Use inWholeCenturies instead.",
+    replaceWith = ReplaceWith("this.inWholeCenturies"),
+    level = DeprecationLevel.ERROR
+  )
+  public val inCenturies: Centuries
+    get() = deprecatedToError()
+
+  public constructor(`value`: Int) : this(value.toLong())
 
   /**
    * Checks if this duration is zero.
@@ -306,7 +106,7 @@ public value class LongYears(
     replaceWith = ReplaceWith("this == 0L.years"),
     level = DeprecationLevel.ERROR
   )
-  public fun isZero(): Boolean = `value` == 0L
+  public fun isZero(): Boolean = value == 0L
 
   /**
    * Checks if this duration is negative.
@@ -316,7 +116,7 @@ public value class LongYears(
     replaceWith = ReplaceWith("this < 0L.years"),
     level = DeprecationLevel.ERROR
   )
-  public fun isNegative(): Boolean = `value` < 0L
+  public fun isNegative(): Boolean = value < 0L
 
   /**
    * Checks if this duration is positive.
@@ -326,181 +126,201 @@ public value class LongYears(
     replaceWith = ReplaceWith("this > 0L.years"),
     level = DeprecationLevel.ERROR
   )
-  public fun isPositive(): Boolean = `value` > 0L
+  public fun isPositive(): Boolean = value > 0L
 
-  public override fun compareTo(other: LongYears): Int = `value`.compareTo(other.`value`)
+  public override fun compareTo(other: Years): Int = value.compareTo(other.value)
 
   /**
    * Converts this duration to an ISO-8601 time interval representation.
    */
   public override fun toString(): String {
-     return when (`value`) {
+     return when (value) {
        0L -> "P0Y"
        Long.MIN_VALUE -> "-P9223372036854775808Y"
        else -> buildString {
-         if (`value` < 0) { append('-') }
+         if (value < 0) { append('-') }
          append("P")
-         append(`value`.absoluteValue)
+         append(value.absoluteValue)
          append('Y')
        }
      }
   }
 
   /**
-   * Negates this duration.
-   * @throws ArithmeticException if overflow occurs
+   * Negates this duration. @throws ArithmeticException if overflow occurs
    */
-  public operator fun unaryMinus(): LongYears = LongYears(`value`.negateExact())
+  public operator fun unaryMinus(): Years = Years(value.negateExact())
 
   /**
    * Negates this duration without checking for overflow.
    */
-  internal fun negateUnchecked(): LongYears = LongYears(-`value`)
+  internal fun negateUnchecked(): Years = Years(-value)
+
+  public operator fun plus(months: Months): Months = this.inMonths + months
+
+  public operator fun minus(months: Months): Months = this.inMonths - months
+
+  public operator fun plus(years: Years): Years = Years(value plusExact years.value)
+
+  public operator fun minus(years: Years): Years = Years(value minusExact years.value)
+
+  public operator fun plus(decades: Decades): Years = this + decades.inYears
+
+  public operator fun minus(decades: Decades): Years = this - decades.inYears
+
+  public operator fun plus(centuries: Centuries): Years = this + centuries.inYears
+
+  public operator fun minus(centuries: Centuries): Years = this - centuries.inYears
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
    */
-  public operator fun times(scalar: Int): LongYears = LongYears(`value` timesExact scalar)
+  public operator fun times(scalar: Int): Years = Years(value timesExact scalar)
 
   /**
-   * Multiplies this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
    */
-  public operator fun times(scalar: Long): LongYears = LongYears(`value` timesExact scalar)
-
-  /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
-   */
-  public operator fun div(scalar: Int): LongYears {
+  public operator fun div(scalar: Int): Years {
      return if (scalar == -1) {
        -this
      } else {
-       LongYears(`value` / scalar)
+       Years(value / scalar)
      }
   }
 
   /**
-   * Divides this duration by a scalar value.
-   * @throws ArithmeticException if overflow occurs or the scalar is zero
+   * Returns the remainder of this duration divided by a scalar value.
    */
-  public operator fun div(scalar: Long): LongYears {
+  public operator fun rem(scalar: Int): Years = Years(value % scalar)
+
+  /**
+   * Multiplies this duration by a scalar value. @throws ArithmeticException if overflow occurs
+   */
+  public operator fun times(scalar: Long): Years = Years(value timesExact scalar)
+
+  /**
+   * Returns this duration divided by a scalar value. @throws ArithmeticException if overflow occurs
+   * or the scalar is zero
+   */
+  public operator fun div(scalar: Long): Years {
      return if (scalar == -1L) {
        -this
      } else {
-       LongYears(`value` / scalar)
+       Years(value / scalar)
      }
   }
 
-  public operator fun rem(scalar: Int): LongYears = LongYears(`value` % scalar)
+  /**
+   * Returns the remainder of this duration divided by a scalar value.
+   */
+  public operator fun rem(scalar: Long): Years = Years(value % scalar)
 
-  public operator fun rem(scalar: Long): LongYears = LongYears(`value` % scalar)
-
-  public operator fun plus(months: IntMonths): LongMonths = this.inMonths + months
-
-  public operator fun minus(months: IntMonths): LongMonths = this.inMonths - months
-
-  public operator fun plus(months: LongMonths): LongMonths = this.inMonths + months
-
-  public operator fun minus(months: LongMonths): LongMonths = this.inMonths - months
-
-  public operator fun plus(years: IntYears): LongYears = LongYears(`value` plusExact years.value)
-
-  public operator fun minus(years: IntYears): LongYears = LongYears(`value` minusExact years.value)
-
-  public operator fun plus(years: LongYears): LongYears = LongYears(`value` plusExact years.value)
-
-  public operator fun minus(years: LongYears): LongYears = LongYears(`value` minusExact years.value)
-
-  public operator fun plus(decades: IntDecades): LongYears = this + decades.inYears
-
-  public operator fun minus(decades: IntDecades): LongYears = this - decades.inYears
-
-  public operator fun plus(decades: LongDecades): LongYears = this + decades.inYears
-
-  public operator fun minus(decades: LongDecades): LongYears = this - decades.inYears
-
-  public operator fun plus(centuries: IntCenturies): LongYears = this + centuries.inYears
-
-  public operator fun minus(centuries: IntCenturies): LongYears = this - centuries.inYears
-
-  public operator fun plus(centuries: LongCenturies): LongYears = this + centuries.inYears
-
-  public operator fun minus(centuries: LongCenturies): LongYears = this - centuries.inYears
-
-  public inline fun <T> toComponents(action: (decades: LongDecades, years: IntYears) -> T): T {
-    val decades = (`value` / YEARS_PER_DECADE).decades
-    val years = (`value` % YEARS_PER_DECADE).toInt().years
+  public inline fun <T> toComponentValues(action: (decades: Long, years: Int) -> T): T {
+    val decades = (value / YEARS_PER_DECADE)
+    val years = (value % YEARS_PER_DECADE).toInt()
     return action(decades, years)
   }
 
-  public inline fun <T> toComponents(action: (
-    centuries: LongCenturies,
-    decades: IntDecades,
-    years: IntYears
+  public inline fun <T> toComponents(action: (decades: Decades, years: Years) -> T): T {
+     return toComponentValues { decades, years ->
+         action(Decades(decades), Years(years))
+     }
+  }
+
+  public inline fun <T> toComponentValues(action: (
+    centuries: Long,
+    decades: Int,
+    years: Int
   ) -> T): T {
-    val centuries = (`value` / YEARS_PER_CENTURY).centuries
-    val decades = ((`value` % YEARS_PER_CENTURY) / YEARS_PER_DECADE).toInt().decades
-    val years = (`value` % YEARS_PER_DECADE).toInt().years
+    val centuries = (value / YEARS_PER_CENTURY)
+    val decades = ((value % YEARS_PER_CENTURY) / YEARS_PER_DECADE).toInt()
+    val years = (value % YEARS_PER_DECADE).toInt()
     return action(centuries, decades, years)
   }
 
-  /**
-   * Converts this duration to [IntYears].
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toIntYears(): IntYears = IntYears(`value`.toIntExact())
+  public inline fun <T> toComponents(action: (
+    centuries: Centuries,
+    decades: Decades,
+    years: Years
+  ) -> T): T {
+     return toComponentValues { centuries, decades, years ->
+         action(Centuries(centuries), Decades(decades), Years(years))
+     }
+  }
 
   /**
-   * Converts this duration to [IntYears] without checking for overflow.
+   * Converts this duration to an `Int` value. @throws ArithmeticException if overflow occurs
    */
-  @PublishedApi
-  internal fun toIntYearsUnchecked(): IntYears = IntYears(`value`.toInt())
-
-  /**
-   * Converts this duration to an `Int` value.
-   * @throws ArithmeticException if overflow occurs
-   */
-  public fun toInt(): Int = `value`.toIntExact()
+  public fun toInt(): Int = value.toIntExact()
 
   /**
    * Converts this duration to an `Int` value without checking for overflow.
    */
-  internal fun toIntUnchecked(): Int = `value`.toInt()
+  internal fun toIntUnchecked(): Int = value.toInt()
+
+  /**
+   * Converts this duration to [IntYears]. @throws ArithmeticException if overflow occurs
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  public fun toIntYears(): Years = this
+
+  /**
+   * Converts this duration to [IntYears] without checking for overflow.
+   */
+  @Deprecated(
+    message = "The 'Int' class no longer exists.",
+    replaceWith = ReplaceWith("this"),
+    level = DeprecationLevel.ERROR
+  )
+  @PublishedApi
+  internal fun toIntYearsUnchecked(): Years = this
 
   /**
    * Converts this duration to a `Long` value.
    */
-  public fun toLong(): Long = `value`
+  public fun toLong(): Long = value
+
+  /**
+   * Converts this duration to a `Double` value.
+   */
+  public fun toDouble(): Double = value.toDouble()
 
   public companion object {
     /**
      * The smallest supported value.
      */
-    public val MIN: LongYears = LongYears(Long.MIN_VALUE)
+    public val MIN: Years = Years(Long.MIN_VALUE)
 
     /**
      * The largest supported value.
      */
-    public val MAX: LongYears = LongYears(Long.MAX_VALUE)
+    public val MAX: Years = Years(Long.MAX_VALUE)
   }
 }
 
 /**
  * Converts this value to a duration of years.
  */
-public val Long.years: LongYears
-  get() = LongYears(this)
+public val Int.years: Years
+  get() = Years(this)
 
 /**
- * Multiplies this value by a duration of years.
- * @throws ArithmeticException if overflow occurs
+ * Multiplies this value by a duration of years. @throws ArithmeticException if overflow occurs
  */
-public operator fun Int.times(years: LongYears): LongYears = years * this
+public operator fun Int.times(years: Years): Years = years * this
 
 /**
- * Multiplies this value by a duration of years.
- * @throws ArithmeticException if overflow occurs
+ * Converts this value to a duration of years.
  */
-public operator fun Long.times(years: LongYears): LongYears = years * this
+public val Long.years: Years
+  get() = Years(this)
+
+/**
+ * Multiplies this value by a duration of years. @throws ArithmeticException if overflow occurs
+ */
+public operator fun Long.times(years: Years): Years = years * this

--- a/core/src/commonMain/generated/io/islandtime/measures/_Years.kt
+++ b/core/src/commonMain/generated/io/islandtime/measures/_Years.kt
@@ -17,6 +17,7 @@ import io.islandtime.`internal`.YEARS_PER_CENTURY
 import io.islandtime.`internal`.YEARS_PER_DECADE
 import kotlin.Boolean
 import kotlin.Comparable
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.Long
 import kotlin.PublishedApi
@@ -71,16 +72,31 @@ public value class IntYears(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0.years"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0.years"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0.years"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0
 
   public override fun compareTo(other: IntYears): Int = `value`.compareTo(other.`value`)
@@ -285,16 +301,31 @@ public value class LongYears(
   /**
    * Checks if this duration is zero.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this == 0L.years"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isZero(): Boolean = `value` == 0L
 
   /**
    * Checks if this duration is negative.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this < 0L.years"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isNegative(): Boolean = `value` < 0L
 
   /**
    * Checks if this duration is positive.
    */
+  @Deprecated(
+    message = "Replace with direct comparison.",
+    replaceWith = ReplaceWith("this > 0L.years"),
+    level = DeprecationLevel.ERROR
+  )
   public fun isPositive(): Boolean = `value` > 0L
 
   public override fun compareTo(other: LongYears): Int = `value`.compareTo(other.`value`)
@@ -437,6 +468,11 @@ public value class LongYears(
    * Converts this duration to an `Int` value without checking for overflow.
    */
   internal fun toIntUnchecked(): Int = `value`.toInt()
+
+  /**
+   * Converts this duration to a `Long` value.
+   */
+  public fun toLong(): Long = `value`
 
   public companion object {
     /**

--- a/core/src/commonMain/kotlin/io/islandtime/Conversions.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/Conversions.kt
@@ -32,7 +32,7 @@ fun ZonedDateTime.toOffsetDateTime(): OffsetDateTime = OffsetDateTime(dateTime, 
  * Converts this instant to the corresponding [Date] at [offset].
  */
 fun Instant.toDateAt(offset: UtcOffset): Date {
-    val adjustedSeconds = secondOfUnixEpoch + offset.totalSeconds.value
+    val adjustedSeconds = secondOfUnixEpoch + offset.totalSecondsValue
     val dayOfUnixEpoch = adjustedSeconds floorDiv SECONDS_PER_DAY
     return Date.fromDayOfUnixEpoch(dayOfUnixEpoch)
 }

--- a/core/src/commonMain/kotlin/io/islandtime/Date.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/Date.kt
@@ -52,7 +52,7 @@ class Date(
     val dayOfWeek: DayOfWeek
         get() {
             val zeroIndexedDayOfWeek = (dayOfUnixEpoch + 3) floorMod 7
-            return DayOfWeek.values()[zeroIndexedDayOfWeek.toInt()]
+            return DayOfWeek.values()[zeroIndexedDayOfWeek]
         }
 
     /**
@@ -78,7 +78,7 @@ class Date(
     /**
      * The number of days away from the Unix epoch (`1970-01-01T00:00Z`) that this date falls.
      */
-    inline val daysSinceUnixEpoch: LongDays get() = dayOfUnixEpoch.days
+    inline val daysSinceUnixEpoch: Days get() = dayOfUnixEpoch.days
 
     @Deprecated(
         "Use toYearMonth() instead.",
@@ -93,8 +93,9 @@ class Date(
         ReplaceWith("this.dayOfUnixEpoch"),
         DeprecationLevel.ERROR
     )
+    @Suppress("unused")
     val unixEpochDay: Long
-        get() = dayOfUnixEpoch
+        get() = deprecatedToError()
 
     /**
      * Returns this date with [period] added to it.
@@ -110,9 +111,7 @@ class Date(
         }
     }
 
-    operator fun plus(years: IntYears): Date = plus(years.toLongYears())
-
-    operator fun plus(years: LongYears): Date {
+    operator fun plus(years: Years): Date {
         return if (years.value == 0L) {
             this
         } else {
@@ -121,26 +120,21 @@ class Date(
         }
     }
 
-    operator fun plus(months: IntMonths): Date = plus(months.toLongMonths())
-
-    operator fun plus(months: LongMonths): Date {
+    operator fun plus(months: Months): Date {
         return if (months.value == 0L) {
             this
         } else {
             val newMonthsSinceYear0 = monthsSinceYear0 + months.value
             val newYear = checkValidYear(newMonthsSinceYear0 floorDiv MONTHS_PER_YEAR)
-            val newMonth = Month.values()[(newMonthsSinceYear0 floorMod MONTHS_PER_YEAR).toInt()]
+            val newMonth = Month.values()[newMonthsSinceYear0 floorMod MONTHS_PER_YEAR]
 
             Date(newYear, newMonth, dayOfMonth.coerceAtMost(newMonth.lastDayIn(newYear)))
         }
     }
 
-    operator fun plus(weeks: IntWeeks): Date = plus(weeks.toLongWeeks().inDaysUnchecked)
-    operator fun plus(weeks: LongWeeks): Date = plus(weeks.inDays)
+    operator fun plus(weeks: Weeks): Date = plus(weeks.inDays)
 
-    operator fun plus(days: IntDays): Date = plus(days.toLongDays())
-
-    operator fun plus(days: LongDays): Date {
+    operator fun plus(days: Days): Date {
         return if (days.value == 0L) {
             this
         } else {
@@ -162,9 +156,7 @@ class Date(
         }
     }
 
-    operator fun minus(years: IntYears): Date = plus(years.toLongYears().negateUnchecked())
-
-    operator fun minus(years: LongYears): Date {
+    operator fun minus(years: Years): Date {
         return if (years.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.years + 1.years
         } else {
@@ -172,9 +164,7 @@ class Date(
         }
     }
 
-    operator fun minus(months: IntMonths): Date = plus(months.toLongMonths().negateUnchecked())
-
-    operator fun minus(months: LongMonths): Date {
+    operator fun minus(months: Months): Date {
         return if (months.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.months + 1.months
         } else {
@@ -182,9 +172,7 @@ class Date(
         }
     }
 
-    operator fun minus(weeks: IntWeeks): Date = plus(weeks.toLongWeeks().inDaysUnchecked.negateUnchecked())
-
-    operator fun minus(weeks: LongWeeks): Date {
+    operator fun minus(weeks: Weeks): Date {
         return if (weeks.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.days + 1.weeks
         } else {
@@ -192,9 +180,7 @@ class Date(
         }
     }
 
-    operator fun minus(days: IntDays): Date = plus(days.toLongDays().negateUnchecked())
-
-    operator fun minus(days: LongDays): Date {
+    operator fun minus(days: Days): Date {
         return if (days.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.days + 1.days
         } else {
@@ -274,19 +260,19 @@ class Date(
         /**
          * The earliest supported [Date], which can be used as a "far past" sentinel.
          */
-        val MIN = Date(Year.MIN_VALUE, Month.JANUARY, 1)
+        val MIN: Date = Date(Year.MIN_VALUE, Month.JANUARY, 1)
 
         /**
          * The latest supported [Date], which can be used as a "far future" sentinel.
          */
-        val MAX = Date(Year.MAX_VALUE, Month.DECEMBER, 31)
+        val MAX: Date = Date(Year.MAX_VALUE, Month.DECEMBER, 31)
 
         /**
          * Creates a [Date] from a duration of days relative to the Unix epoch of 1970-01-01.
          * @param days the number of days relative to the Unix epoch
          * @throws DateTimeException if outside of the supported date range
          */
-        fun fromDaysSinceUnixEpoch(days: LongDays): Date = fromDayOfUnixEpoch(days.value)
+        fun fromDaysSinceUnixEpoch(days: Days): Date = fromDayOfUnixEpoch(days.value)
 
         /**
          * Creates a [Date] from the day of the Unix epoch.
@@ -308,7 +294,8 @@ class Date(
             ReplaceWith("Date.fromDayOfUnixEpoch(day)"),
             DeprecationLevel.ERROR
         )
-        fun fromUnixEpochDay(day: Long): Date = fromDayOfUnixEpoch(day)
+        @Suppress("UNUSED_PARAMETER", "unused")
+        fun fromUnixEpochDay(day: Long): Date = deprecatedToError()
     }
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/DateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/DateTime.kt
@@ -135,12 +135,10 @@ class DateTime(
     }
 
     operator fun plus(duration: Duration): DateTime {
-        return this + duration.seconds + duration.nanosecondAdjustment
+        return duration.toComponents { seconds, nanoseconds -> this + seconds + nanoseconds }
     }
 
-    operator fun plus(years: IntYears) = plus(years.toLongYears())
-
-    operator fun plus(years: LongYears): DateTime {
+    operator fun plus(years: Years): DateTime {
         return if (years.value == 0L) {
             this
         } else {
@@ -148,9 +146,7 @@ class DateTime(
         }
     }
 
-    operator fun plus(months: IntMonths) = plus(months.toLongMonths())
-
-    operator fun plus(months: LongMonths): DateTime {
+    operator fun plus(months: Months): DateTime {
         return if (months.value == 0L) {
             this
         } else {
@@ -158,9 +154,7 @@ class DateTime(
         }
     }
 
-    operator fun plus(weeks: IntWeeks) = plus(weeks.toLongWeeks().inDaysUnchecked)
-
-    operator fun plus(weeks: LongWeeks): DateTime {
+    operator fun plus(weeks: Weeks): DateTime {
         return if (weeks.value == 0L) {
             this
         } else {
@@ -168,9 +162,7 @@ class DateTime(
         }
     }
 
-    operator fun plus(days: IntDays) = plus(days.toLongDays())
-
-    operator fun plus(days: LongDays): DateTime {
+    operator fun plus(days: Days): DateTime {
         return if (days.value == 0L) {
             this
         } else {
@@ -178,13 +170,11 @@ class DateTime(
         }
     }
 
-    operator fun plus(hours: IntHours) = plus(hours.toLongHours())
-
-    operator fun plus(hours: LongHours): DateTime {
+    operator fun plus(hours: Hours): DateTime {
         return if (hours.value == 0L) {
             this
         } else {
-            var daysToAdd = hours.inDays
+            var daysToAdd = hours.inWholeDays
             val wrappedHours = (hours % HOURS_PER_DAY).toInt()
             var newHour = time.hour + wrappedHours
             daysToAdd += (newHour floorDiv HOURS_PER_DAY).days
@@ -196,13 +186,11 @@ class DateTime(
         }
     }
 
-    operator fun plus(minutes: IntMinutes) = plus(minutes.toLongMinutes())
-
-    operator fun plus(minutes: LongMinutes): DateTime {
+    operator fun plus(minutes: Minutes): DateTime {
         return if (minutes.value == 0L) {
             this
         } else {
-            var daysToAdd = minutes.inDays
+            var daysToAdd = minutes.inWholeDays
             val currentMinuteOfDay = time.hour * MINUTES_PER_HOUR + minute
             val wrappedMinutes = (minutes % MINUTES_PER_DAY).toInt()
             var newMinuteOfDay = currentMinuteOfDay + wrappedMinutes
@@ -223,13 +211,11 @@ class DateTime(
         }
     }
 
-    operator fun plus(seconds: IntSeconds) = plus(seconds.toLongSeconds())
-
-    operator fun plus(seconds: LongSeconds): DateTime {
+    operator fun plus(seconds: Seconds): DateTime {
         return if (seconds.value == 0L) {
             this
         } else {
-            var daysToAdd = seconds.inDays
+            var daysToAdd = seconds.inWholeDays
             val currentSecondOfDay = time.secondOfDay
             val wrappedSeconds = (seconds % SECONDS_PER_DAY).toInt()
             var newSecondOfDay = currentSecondOfDay + wrappedSeconds
@@ -248,37 +234,31 @@ class DateTime(
         }
     }
 
-    operator fun plus(milliseconds: IntMilliseconds) = plus(milliseconds.toLongMilliseconds())
-
-    operator fun plus(milliseconds: LongMilliseconds): DateTime {
+    operator fun plus(milliseconds: Milliseconds): DateTime {
         return if (milliseconds.value == 0L) {
             this
         } else {
-            plus(milliseconds.inDays, (milliseconds % MILLISECONDS_PER_DAY).inNanosecondsUnchecked)
+            plus(milliseconds.inWholeDays, (milliseconds % MILLISECONDS_PER_DAY).inNanosecondsUnchecked)
         }
     }
 
-    operator fun plus(microseconds: IntMicroseconds) = plus(microseconds.toLongMicroseconds())
-
-    operator fun plus(microseconds: LongMicroseconds): DateTime {
+    operator fun plus(microseconds: Microseconds): DateTime {
         return if (microseconds.value == 0L) {
             this
         } else {
-            plus(microseconds.inDays, (microseconds % MICROSECONDS_PER_DAY).inNanosecondsUnchecked)
+            plus(microseconds.inWholeDays, (microseconds % MICROSECONDS_PER_DAY).inNanosecondsUnchecked)
         }
     }
 
-    operator fun plus(nanoseconds: IntNanoseconds) = plus(nanoseconds.toLongNanoseconds())
-
-    operator fun plus(nanoseconds: LongNanoseconds): DateTime {
+    operator fun plus(nanoseconds: Nanoseconds): DateTime {
         return if (nanoseconds.value == 0L) {
             this
         } else {
-            plus(nanoseconds.inDays, nanoseconds % NANOSECONDS_PER_DAY)
+            plus(nanoseconds.inWholeDays, nanoseconds % NANOSECONDS_PER_DAY)
         }
     }
 
-    private fun plus(days: LongDays, wrappedNanoseconds: LongNanoseconds): DateTime {
+    private fun plus(days: Days, wrappedNanoseconds: Nanoseconds): DateTime {
         val currentNanosecondOfDay = time.nanosecondOfDay
         var newNanosecondOfDay = currentNanosecondOfDay + wrappedNanoseconds.value
         val daysToAdd = (days.value + (newNanosecondOfDay floorDiv NANOSECONDS_PER_DAY)).days
@@ -307,9 +287,7 @@ class DateTime(
         return this - duration.seconds - duration.nanosecondAdjustment
     }
 
-    operator fun minus(years: IntYears) = plus(years.toLongYears().negateUnchecked())
-
-    operator fun minus(years: LongYears): DateTime {
+    operator fun minus(years: Years): DateTime {
         return if (years.value == 0L) {
             this
         } else {
@@ -317,9 +295,7 @@ class DateTime(
         }
     }
 
-    operator fun minus(months: IntMonths) = plus(months.toLongMonths().negateUnchecked())
-
-    operator fun minus(months: LongMonths): DateTime {
+    operator fun minus(months: Months): DateTime {
         return if (months.value == 0L) {
             this
         } else {
@@ -327,9 +303,7 @@ class DateTime(
         }
     }
 
-    operator fun minus(weeks: IntWeeks) = plus(weeks.toLongWeeks().inDaysUnchecked.negateUnchecked())
-
-    operator fun minus(weeks: LongWeeks): DateTime {
+    operator fun minus(weeks: Weeks): DateTime {
         return if (weeks.value == 0L) {
             this
         } else {
@@ -337,9 +311,7 @@ class DateTime(
         }
     }
 
-    operator fun minus(days: IntDays) = plus(days.toLongDays().negateUnchecked())
-
-    operator fun minus(days: LongDays): DateTime {
+    operator fun minus(days: Days): DateTime {
         return if (days.value == 0L) {
             this
         } else {
@@ -347,9 +319,7 @@ class DateTime(
         }
     }
 
-    operator fun minus(hours: IntHours) = plus(hours.toLongHours().negateUnchecked())
-
-    operator fun minus(hours: LongHours): DateTime {
+    operator fun minus(hours: Hours): DateTime {
         return if (hours.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.hours + 1.hours
         } else {
@@ -357,9 +327,7 @@ class DateTime(
         }
     }
 
-    operator fun minus(minutes: IntMinutes) = plus(minutes.toLongMinutes().negateUnchecked())
-
-    operator fun minus(minutes: LongMinutes): DateTime {
+    operator fun minus(minutes: Minutes): DateTime {
         return if (minutes.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.minutes + 1.minutes
         } else {
@@ -367,9 +335,7 @@ class DateTime(
         }
     }
 
-    operator fun minus(seconds: IntSeconds) = plus(seconds.toLongSeconds().negateUnchecked())
-
-    operator fun minus(seconds: LongSeconds): DateTime {
+    operator fun minus(seconds: Seconds): DateTime {
         return if (seconds.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.seconds + 1.seconds
         } else {
@@ -377,9 +343,7 @@ class DateTime(
         }
     }
 
-    operator fun minus(milliseconds: IntMilliseconds) = plus(milliseconds.toLongMilliseconds().negateUnchecked())
-
-    operator fun minus(milliseconds: LongMilliseconds): DateTime {
+    operator fun minus(milliseconds: Milliseconds): DateTime {
         return if (milliseconds.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.milliseconds + 1.milliseconds
         } else {
@@ -387,9 +351,7 @@ class DateTime(
         }
     }
 
-    operator fun minus(microseconds: IntMicroseconds) = plus(microseconds.toLongMicroseconds().negateUnchecked())
-
-    operator fun minus(microseconds: LongMicroseconds): DateTime {
+    operator fun minus(microseconds: Microseconds): DateTime {
         return if (microseconds.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.microseconds + 1.microseconds
         } else {
@@ -397,9 +359,7 @@ class DateTime(
         }
     }
 
-    operator fun minus(nanoseconds: IntNanoseconds) = plus(nanoseconds.toLongNanoseconds().negateUnchecked())
-
-    operator fun minus(nanoseconds: LongNanoseconds): DateTime {
+    operator fun minus(nanoseconds: Nanoseconds): DateTime {
         return if (nanoseconds.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.nanoseconds + 1.nanoseconds
         } else {
@@ -499,18 +459,14 @@ class DateTime(
      * @param offset the offset from UTC
      * @see additionalNanosecondsSinceUnixEpoch
      */
-    fun secondsSinceUnixEpochAt(offset: UtcOffset): LongSeconds {
-        return (date.daysSinceUnixEpoch.inSecondsUnchecked.value +
-            time.secondsSinceStartOfDay.value -
-            offset.totalSeconds.value).seconds
-    }
+    fun secondsSinceUnixEpochAt(offset: UtcOffset): Seconds = secondOfUnixEpochAt(offset).seconds
 
     /**
      * The number of additional nanoseconds that should be applied on top of the number of seconds since the Unix epoch
      * returned by [secondsSinceUnixEpochAt].
      * @see secondsSinceUnixEpochAt
      */
-    val additionalNanosecondsSinceUnixEpoch: IntNanoseconds
+    val additionalNanosecondsSinceUnixEpoch: Nanoseconds
         get() = nanosecond.nanoseconds
 
     /**
@@ -518,78 +474,76 @@ class DateTime(
      * "floor" value, so 1 nanosecond before the Unix epoch will be at a distance of 1 millisecond.
      * @param offset the offset from UTC
      */
-    fun millisecondsSinceUnixEpochAt(offset: UtcOffset): LongMilliseconds {
-        return (date.daysSinceUnixEpoch.inMillisecondsUnchecked.value +
-            time.nanosecondsSinceStartOfDay.inMilliseconds.value -
-            offset.totalSeconds.inMilliseconds.value).milliseconds
-    }
+    fun millisecondsSinceUnixEpochAt(offset: UtcOffset): Milliseconds = millisecondOfUnixEpochAt(offset).milliseconds
 
     /**
      * The second of the Unix epoch.
      *
      * @param offset the offset from UTC
-     * @see additionalNanosecondsSinceUnixEpoch
+     * @see nanosecond
      */
-    fun secondOfUnixEpochAt(offset: UtcOffset): Long = secondsSinceUnixEpochAt(offset).value
+    fun secondOfUnixEpochAt(offset: UtcOffset): Long {
+        return date.daysSinceUnixEpoch.inSecondsUnchecked.value + time.secondOfDay - offset.totalSecondsValue
+    }
 
     /**
      * The millisecond of the Unix epoch.
      * @param offset the offset from UTC
      */
-    fun millisecondOfUnixEpochAt(offset: UtcOffset): Long = millisecondsSinceUnixEpochAt(offset).value
-
-    @Deprecated(
-        "Use additionalNanosecondsSinceUnixEpoch instead.",
-        ReplaceWith("this.additionalNanosecondsSinceUnixEpoch"),
-        DeprecationLevel.ERROR
-    )
-    val nanoOfSecondsSinceUnixEpoch: IntNanoseconds
-        get() = additionalNanosecondsSinceUnixEpoch
+    fun millisecondOfUnixEpochAt(offset: UtcOffset): Long {
+        return date.daysSinceUnixEpoch.inMillisecondsUnchecked.value +
+            time.nanosecondsSinceStartOfDay.inWholeMilliseconds.value -
+            offset.totalSeconds.inMilliseconds.value
+    }
 
     @Deprecated(
         "Use secondOfUnixEpochAt() instead.",
         ReplaceWith("this.secondOfUnixEpochAt(offset)"),
         DeprecationLevel.ERROR
     )
-    fun unixEpochSecondAt(offset: UtcOffset): Long = secondOfUnixEpochAt(offset)
+    @Suppress("UNUSED_PARAMETER", "unused")
+    fun unixEpochSecondAt(offset: UtcOffset): Long = deprecatedToError()
 
     @Deprecated(
         "Use nanosecond instead.",
         ReplaceWith("this.nanosecond"),
         DeprecationLevel.ERROR
     )
+    @Suppress("unused")
     val unixEpochNanoOfSecond: Int
-        get() = nanosecond
+        get() = deprecatedToError()
 
     @Deprecated(
         "Use millisecondOfUnixEpoch() instead.",
         ReplaceWith("this.millisecondOfUnixEpochAt(offset)"),
         DeprecationLevel.ERROR
     )
-    fun unixEpochMillisecondAt(offset: UtcOffset): Long = millisecondOfUnixEpochAt(offset)
+    @Suppress("UNUSED_PARAMETER", "unused")
+    fun unixEpochMillisecondAt(offset: UtcOffset): Long = deprecatedToError()
 
     @Deprecated(
         "Use toInstantAt() instead.",
         ReplaceWith("this.toInstantAt(offset)"),
         DeprecationLevel.ERROR
     )
-    fun instantAt(offset: UtcOffset): Instant = toInstantAt(offset)
+    @Suppress("UNUSED_PARAMETER", "unused")
+    fun instantAt(offset: UtcOffset): Instant = deprecatedToError()
 
     companion object {
         /**
          * The earliest supported [DateTime], which can be used as a "far past" sentinel.
          */
-        val MIN = DateTime(Date.MIN, Time.MIN)
+        val MIN: DateTime = DateTime(Date.MIN, Time.MIN)
 
         /**
          * The latest supported [DateTime], which can be used as a "far future" sentinel.
          */
-        val MAX = DateTime(Date.MAX, Time.MAX)
+        val MAX: DateTime = DateTime(Date.MAX, Time.MAX)
 
         /**
          * Creates a [DateTime] from a duration of milliseconds relative to the Unix epoch at [offset].
          */
-        fun fromMillisecondsSinceUnixEpoch(millisecondsSinceUnixEpoch: LongMilliseconds, offset: UtcOffset): DateTime {
+        fun fromMillisecondsSinceUnixEpoch(millisecondsSinceUnixEpoch: Milliseconds, offset: UtcOffset): DateTime {
             val localMilliseconds = millisecondsSinceUnixEpoch + offset.totalSeconds
             val localEpochDay = localMilliseconds.value floorDiv MILLISECONDS_PER_DAY
             val nanosecondOfDay =
@@ -604,8 +558,8 @@ class DateTime(
          * number of additional nanoseconds added to it.
          */
         fun fromSecondsSinceUnixEpoch(
-            secondsSinceUnixEpoch: LongSeconds,
-            nanosecondAdjustment: IntNanoseconds = 0.nanoseconds,
+            secondsSinceUnixEpoch: Seconds,
+            nanosecondAdjustment: Nanoseconds = 0.nanoseconds,
             offset: UtcOffset
         ): DateTime {
             val adjustedSeconds =
@@ -613,7 +567,7 @@ class DateTime(
             val nanosecond = nanosecondAdjustment.value floorMod NANOSECONDS_PER_SECOND
             val localSeconds = adjustedSeconds + offset.totalSeconds
             val localEpochDay = (localSeconds.value floorDiv SECONDS_PER_DAY)
-            val secondOfDay = (localSeconds.value floorMod SECONDS_PER_DAY).toInt()
+            val secondOfDay = localSeconds.value floorMod SECONDS_PER_DAY
             val date = Date.fromDayOfUnixEpoch(localEpochDay)
             val time = Time.fromSecondOfDay(secondOfDay, nanosecond)
             return DateTime(date, time)
@@ -639,18 +593,17 @@ class DateTime(
             ReplaceWith("DateTime.fromMillisecondOfUnixEpoch(millisecond, offset)"),
             DeprecationLevel.ERROR
         )
-        fun fromUnixEpochMillisecond(millisecond: Long, offset: UtcOffset): DateTime {
-            return fromMillisecondOfUnixEpoch(millisecond, offset)
-        }
+        @Suppress("UNUSED_PARAMETER", "unused")
+        fun fromUnixEpochMillisecond(millisecond: Long, offset: UtcOffset): DateTime = deprecatedToError()
 
         @Deprecated(
             "Use fromSecondOfUnixEpoch() instead.",
             ReplaceWith("DateTime.fromSecondOfUnixEpoch(second, nanosecondAdjustment, offset)"),
             DeprecationLevel.ERROR
         )
-        fun fromUnixEpochSecond(second: Long, nanosecondAdjustment: Int = 0, offset: UtcOffset): DateTime {
-            return fromSecondOfUnixEpoch(second, nanosecondAdjustment, offset)
-        }
+        @Suppress("UNUSED_PARAMETER", "unused")
+        fun fromUnixEpochSecond(second: Long, nanosecondAdjustment: Int = 0, offset: UtcOffset): DateTime =
+            deprecatedToError()
     }
 }
 
@@ -663,7 +616,7 @@ class DateTime(
  * @throws DateTimeParseException if parsing fails
  * @throws DateTimeException if the parsed date-time is invalid
  */
-fun String.toDateTime() = toDateTime(DateTimeParsers.Iso.Extended.DATE_TIME)
+fun String.toDateTime(): DateTime = toDateTime(DateTimeParsers.Iso.Extended.DATE_TIME)
 
 /**
  * Converts a string to a [DateTime] using a specific parser.

--- a/core/src/commonMain/kotlin/io/islandtime/DayOfWeek.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/DayOfWeek.kt
@@ -6,8 +6,7 @@ import io.islandtime.format.DateTimeTextProvider
 import io.islandtime.format.TextStyle
 import io.islandtime.internal.DAYS_PER_WEEK
 import io.islandtime.locale.Locale
-import io.islandtime.measures.IntDays
-import io.islandtime.measures.LongDays
+import io.islandtime.measures.Days
 import io.islandtime.measures.days
 
 /**
@@ -72,22 +71,12 @@ enum class DayOfWeek {
     /**
      * Adds days to this day of the week, wrapping when the beginning or end of the week is reached.
      */
-    operator fun plus(days: IntDays): DayOfWeek = plus(days.value % DAYS_PER_WEEK)
-
-    /**
-     * Adds days to this day of the week, wrapping when the beginning or end of the week is reached.
-     */
-    operator fun plus(days: LongDays): DayOfWeek = plus((days.value % DAYS_PER_WEEK).toInt())
+    operator fun plus(days: Days): DayOfWeek = plus((days.value % DAYS_PER_WEEK).toInt())
 
     /**
      * Subtracts days from this day of the week, wrapping when the beginning or end of the week is reached.
      */
-    operator fun minus(days: IntDays): DayOfWeek = plus(-(days.value % DAYS_PER_WEEK))
-
-    /**
-     * Subtracts days from this day of the week, wrapping when the beginning or end of the week is reached.
-     */
-    operator fun minus(days: LongDays): DayOfWeek = plus(-(days.value % DAYS_PER_WEEK).toInt())
+    operator fun minus(days: Days): DayOfWeek = plus(-(days.value % DAYS_PER_WEEK).toInt())
 
     private fun plus(daysToAdd: Int): DayOfWeek {
         return values()[(ordinal + (daysToAdd + DAYS_PER_WEEK)) % DAYS_PER_WEEK]

--- a/core/src/commonMain/kotlin/io/islandtime/Month.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/Month.kt
@@ -3,65 +3,26 @@ package io.islandtime
 import io.islandtime.format.DateTimeTextProvider
 import io.islandtime.format.TextStyle
 import io.islandtime.locale.Locale
-import io.islandtime.measures.IntDays
-import io.islandtime.measures.IntMonths
-import io.islandtime.measures.LongMonths
+import io.islandtime.measures.Days
+import io.islandtime.measures.Months
 import io.islandtime.measures.days
 
 /**
  * A month of the year.
  */
 enum class Month {
-    JANUARY {
-        override val lengthInCommonYear = 31.days
-        override val firstDayOfCommonYear = 1
-    },
-    FEBRUARY {
-        override val lengthInCommonYear = 28.days
-        override val lengthInLeapYear = 29.days
-        override val firstDayOfCommonYear = 32
-    },
-    MARCH {
-        override val lengthInCommonYear = 31.days
-        override val firstDayOfCommonYear = 60
-    },
-    APRIL {
-        override val lengthInCommonYear = 30.days
-        override val firstDayOfCommonYear = 91
-    },
-    MAY {
-        override val lengthInCommonYear = 31.days
-        override val firstDayOfCommonYear = 121
-    },
-    JUNE {
-        override val lengthInCommonYear = 30.days
-        override val firstDayOfCommonYear = 152
-    },
-    JULY {
-        override val lengthInCommonYear = 31.days
-        override val firstDayOfCommonYear = 182
-    },
-    AUGUST {
-        override val lengthInCommonYear = 31.days
-        override val firstDayOfCommonYear = 213
-    },
-    SEPTEMBER {
-        override val lengthInCommonYear = 30.days
-        override val firstDayOfCommonYear = 244
-    },
-    OCTOBER {
-        override val lengthInCommonYear = 31.days
-        override val firstDayOfCommonYear = 272
-    },
-    NOVEMBER {
-        override val lengthInCommonYear = 30.days
-        override val firstDayOfCommonYear = 305
-    },
-    DECEMBER {
-        override val lengthInCommonYear = 31.days
-        override val firstDayOfCommonYear = 335
-    };
-
+    JANUARY,
+    FEBRUARY,
+    MARCH,
+    APRIL,
+    MAY,
+    JUNE,
+    JULY,
+    AUGUST,
+    SEPTEMBER,
+    OCTOBER,
+    NOVEMBER,
+    DECEMBER;
 
     /**
      * The ISO month number, from 1-12.
@@ -69,33 +30,65 @@ enum class Month {
     val number: Int get() = ordinal + 1
 
     /**
-     * The number of days in the month in a common year.
+     * Returns the last day of the month in a common year.
      */
-    abstract val lengthInCommonYear: IntDays
+    val lastDayInCommonYear: Int
+        get() = when (this) {
+            JANUARY, MARCH, MAY, JULY, AUGUST, OCTOBER, DECEMBER -> 31
+            APRIL, JUNE, SEPTEMBER, NOVEMBER -> 30
+            FEBRUARY -> 28
+        }
 
     /**
-     * The number of days in the month in a leap month.
+     * Returns the last day of the month in a leap year.
      */
-    open val lengthInLeapYear: IntDays
-        get() = lengthInCommonYear
+    val lastDayInLeapYear: Int
+        get() = when (this) {
+            FEBRUARY -> 29
+            else -> lastDayInCommonYear
+        }
 
     /**
      * The day of the year corresponding to the month's first day in a common year.
      *
      * For example, the first day of [MARCH] is the 60th day of a common year.
      */
-    abstract val firstDayOfCommonYear: Int
+    val firstDayOfYearInCommonYear: Int
+        get() = when (this) {
+            JANUARY -> 1
+            FEBRUARY -> 32
+            MARCH -> 60
+            APRIL -> 91
+            MAY -> 121
+            JUNE -> 152
+            JULY -> 182
+            AUGUST -> 213
+            SEPTEMBER -> 244
+            OCTOBER -> 272
+            NOVEMBER -> 305
+            DECEMBER -> 335
+        }
 
     /**
      * The day of the year corresponding to the month's first day in a leap year.
      *
      * For example, the first day of [MARCH] is the 61st day of a leap year.
      */
-    val firstDayOfLeapYear: Int
+    val firstDayOfYearInLeapYear: Int
         get() = when (this) {
-            JANUARY, FEBRUARY -> firstDayOfCommonYear
-            else -> firstDayOfCommonYear + 1
+            JANUARY, FEBRUARY -> firstDayOfYearInCommonYear
+            else -> firstDayOfYearInCommonYear + 1
         }
+
+    /**
+     * The number of days in the month in a common year.
+     */
+    val lengthInCommonYear: Days get() = lastDayInCommonYear.days
+
+    /**
+     * The number of days in the month in a leap month.
+     */
+    val lengthInLeapYear: Days get() = lastDayInLeapYear.days
 
     /**
      * The localized name of the month, if available for the [locale] in the specified style. The result depends on the
@@ -126,21 +119,19 @@ enum class Month {
     }
 
     /**
+     * Returns the last day of the month in a particular year.
+     */
+    fun lastDayIn(year: Int): Int = when (this) {
+        FEBRUARY -> if (isLeapYear(year)) 29 else 28
+        else -> lastDayInCommonYear
+    }
+
+    /**
      * Returns the number of days in the month for a particular year.
      * @param year retrieve the length of the month within this year
      * @return the number of days in the month
      */
-    fun lengthIn(year: Int): IntDays {
-        return when (this) {
-            FEBRUARY -> if (isLeapYear(year)) lengthInLeapYear else lengthInCommonYear
-            else -> lengthInCommonYear
-        }
-    }
-
-    /**
-     * Returns the last day of the month in a particular year.
-     */
-    fun lastDayIn(year: Int) = lengthIn(year).value
+    fun lengthIn(year: Int): Days = lastDayIn(year).days
 
     /**
      * Returns the day of the year that this month's first days falls on. This may vary depending on whether or not the
@@ -149,7 +140,7 @@ enum class Month {
      * @return the first day of year number
      */
     fun firstDayOfYearIn(year: Int): Int {
-        return if (isLeapYear(year)) firstDayOfLeapYear else firstDayOfCommonYear
+        return if (isLeapYear(year)) firstDayOfYearInLeapYear else firstDayOfYearInCommonYear
     }
 
     /**
@@ -162,9 +153,9 @@ enum class Month {
         val isLeap = isLeapYear(year)
 
         return if (isLeap) {
-            firstDayOfLeapYear + lengthInLeapYear.value - 1
+            firstDayOfYearInLeapYear + lastDayInLeapYear - 1
         } else {
-            firstDayOfCommonYear + lengthInCommonYear.value - 1
+            firstDayOfYearInCommonYear + lastDayInCommonYear - 1
         }
     }
 
@@ -173,37 +164,23 @@ enum class Month {
      * @param year retrieve the day range within this year
      * @return the range of valid days
      */
-    fun dayRangeIn(year: Int): IntRange {
-        return 1..lengthIn(year).value
-    }
+    fun dayRangeIn(year: Int): IntRange = 1..lastDayIn(year)
 
     /**
      * Adds months to this month, wrapping when the beginning or end of the year is reached.
      */
-    operator fun plus(months: IntMonths) = plus(months.value % 12)
-
-    /**
-     * Adds months to this month, wrapping when the beginning or end of the year is reached.
-     */
-    operator fun plus(months: LongMonths) = plus((months.value % 12).toInt())
+    operator fun plus(months: Months): Month = plus((months.value % 12).toInt())
 
     /**
      * Subtracts months from this month, wrapping when the beginning or end of the year is reached.
      */
-    operator fun minus(months: IntMonths) = plus(-(months.value % 12))
+    operator fun minus(months: Months): Month = plus(-(months.value % 12).toInt())
 
-    /**
-     * Subtracts months from this month, wrapping when the beginning or end of the year is reached.
-     */
-    operator fun minus(months: LongMonths) = plus(-(months.value % 12).toInt())
-
-    private fun plus(monthsToAdd: Int): Month {
-        return values()[(ordinal + (monthsToAdd + 12)) % 12]
-    }
+    private fun plus(monthsToAdd: Int): Month = values()[(ordinal + (monthsToAdd + 12)) % 12]
 
     companion object {
-        inline val MIN get() = JANUARY
-        inline val MAX get() = DECEMBER
+        inline val MIN: Month get() = JANUARY
+        inline val MAX: Month get() = DECEMBER
     }
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/OffsetDateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/OffsetDateTime.kt
@@ -1,6 +1,7 @@
 package io.islandtime
 
 import io.islandtime.base.TimePoint
+import io.islandtime.internal.deprecatedToError
 import io.islandtime.measures.*
 import io.islandtime.parser.*
 import io.islandtime.ranges.OffsetDateTimeInterval
@@ -158,14 +159,11 @@ class OffsetDateTime(
     inline val instant: Instant
         get() = toInstant()
 
-    override val secondsSinceUnixEpoch: LongSeconds
-        get() = dateTime.secondsSinceUnixEpochAt(offset)
+    override val secondOfUnixEpoch: Long
+        get() = dateTime.secondOfUnixEpochAt(offset)
 
-    override val additionalNanosecondsSinceUnixEpoch: IntNanoseconds
-        get() = dateTime.additionalNanosecondsSinceUnixEpoch
-
-    override val millisecondsSinceUnixEpoch: LongMilliseconds
-        get() = dateTime.millisecondsSinceUnixEpochAt(offset)
+    override val millisecondOfUnixEpoch: Long
+        get() = dateTime.millisecondOfUnixEpochAt(offset)
 
     /**
      * Changes the offset of this [OffsetDateTime], adjusting the date and time components such that the instant
@@ -186,30 +184,20 @@ class OffsetDateTime(
      * Years are added first, then months, then days. If the day exceeds the maximum month length at any step, it will
      * be coerced into the valid range.
      */
-    operator fun plus(period: Period) = copy(dateTime = dateTime + period)
+    operator fun plus(period: Period): OffsetDateTime = copy(dateTime = dateTime + period)
 
-    operator fun plus(duration: Duration) = copy(dateTime = dateTime + duration)
+    operator fun plus(duration: Duration): OffsetDateTime = copy(dateTime = dateTime + duration)
 
-    operator fun plus(years: LongYears) = copy(dateTime = dateTime + years)
-    operator fun plus(years: IntYears) = copy(dateTime = dateTime + years)
-    operator fun plus(months: LongMonths) = copy(dateTime = dateTime + months)
-    operator fun plus(months: IntMonths) = copy(dateTime = dateTime + months)
-    operator fun plus(weeks: LongWeeks) = copy(dateTime = dateTime + weeks)
-    operator fun plus(weeks: IntWeeks) = copy(dateTime = dateTime + weeks)
-    operator fun plus(days: LongDays) = copy(dateTime = dateTime + days)
-    operator fun plus(days: IntDays) = copy(dateTime = dateTime + days)
-    override operator fun plus(hours: LongHours) = copy(dateTime = dateTime + hours)
-    override operator fun plus(hours: IntHours) = copy(dateTime = dateTime + hours)
-    override operator fun plus(minutes: LongMinutes) = copy(dateTime = dateTime + minutes)
-    override operator fun plus(minutes: IntMinutes) = copy(dateTime = dateTime + minutes)
-    override operator fun plus(seconds: LongSeconds) = copy(dateTime = dateTime + seconds)
-    override operator fun plus(seconds: IntSeconds) = copy(dateTime = dateTime + seconds)
-    override operator fun plus(milliseconds: LongMilliseconds) = copy(dateTime = dateTime + milliseconds)
-    override operator fun plus(milliseconds: IntMilliseconds) = copy(dateTime = dateTime + milliseconds)
-    override operator fun plus(microseconds: LongMicroseconds) = copy(dateTime = dateTime + microseconds)
-    override operator fun plus(microseconds: IntMicroseconds) = copy(dateTime = dateTime + microseconds)
-    override operator fun plus(nanoseconds: LongNanoseconds) = copy(dateTime = dateTime + nanoseconds)
-    override operator fun plus(nanoseconds: IntNanoseconds) = copy(dateTime = dateTime + nanoseconds)
+    operator fun plus(years: Years): OffsetDateTime = copy(dateTime = dateTime + years)
+    operator fun plus(months: Months): OffsetDateTime = copy(dateTime = dateTime + months)
+    operator fun plus(weeks: Weeks): OffsetDateTime = copy(dateTime = dateTime + weeks)
+    operator fun plus(days: Days): OffsetDateTime = copy(dateTime = dateTime + days)
+    override operator fun plus(hours: Hours): OffsetDateTime = copy(dateTime = dateTime + hours)
+    override operator fun plus(minutes: Minutes): OffsetDateTime = copy(dateTime = dateTime + minutes)
+    override operator fun plus(seconds: Seconds): OffsetDateTime = copy(dateTime = dateTime + seconds)
+    override operator fun plus(milliseconds: Milliseconds): OffsetDateTime = copy(dateTime = dateTime + milliseconds)
+    override operator fun plus(microseconds: Microseconds): OffsetDateTime = copy(dateTime = dateTime + microseconds)
+    override operator fun plus(nanoseconds: Nanoseconds): OffsetDateTime = copy(dateTime = dateTime + nanoseconds)
 
     /**
      * Returns this date-time with [period] subtracted from it.
@@ -217,30 +205,20 @@ class OffsetDateTime(
      * Years are added first, then months, then days. If the day exceeds the maximum month length at any step, it will
      * be coerced into the valid range.
      */
-    operator fun minus(period: Period) = copy(dateTime = dateTime - period)
+    operator fun minus(period: Period): OffsetDateTime = copy(dateTime = dateTime - period)
 
-    operator fun minus(duration: Duration) = copy(dateTime = dateTime - duration)
+    operator fun minus(duration: Duration): OffsetDateTime = copy(dateTime = dateTime - duration)
 
-    operator fun minus(years: LongYears) = copy(dateTime = dateTime - years)
-    operator fun minus(years: IntYears) = copy(dateTime = dateTime - years)
-    operator fun minus(months: LongMonths) = copy(dateTime = dateTime - months)
-    operator fun minus(months: IntMonths) = copy(dateTime = dateTime - months)
-    operator fun minus(weeks: LongWeeks) = copy(dateTime = dateTime - weeks)
-    operator fun minus(weeks: IntWeeks) = copy(dateTime = dateTime - weeks)
-    operator fun minus(days: LongDays) = copy(dateTime = dateTime - days)
-    operator fun minus(days: IntDays) = copy(dateTime = dateTime - days)
-    override operator fun minus(hours: LongHours) = copy(dateTime = dateTime - hours)
-    override operator fun minus(hours: IntHours) = copy(dateTime = dateTime - hours)
-    override operator fun minus(minutes: LongMinutes) = copy(dateTime = dateTime - minutes)
-    override operator fun minus(minutes: IntMinutes) = copy(dateTime = dateTime - minutes)
-    override operator fun minus(seconds: LongSeconds) = copy(dateTime = dateTime - seconds)
-    override operator fun minus(seconds: IntSeconds) = copy(dateTime = dateTime - seconds)
-    override operator fun minus(milliseconds: LongMilliseconds) = copy(dateTime = dateTime - milliseconds)
-    override operator fun minus(milliseconds: IntMilliseconds) = copy(dateTime = dateTime - milliseconds)
-    override operator fun minus(microseconds: LongMicroseconds) = copy(dateTime = dateTime - microseconds)
-    override operator fun minus(microseconds: IntMicroseconds) = copy(dateTime = dateTime - microseconds)
-    override operator fun minus(nanoseconds: LongNanoseconds) = copy(dateTime = dateTime - nanoseconds)
-    override operator fun minus(nanoseconds: IntNanoseconds) = copy(dateTime = dateTime - nanoseconds)
+    operator fun minus(years: Years): OffsetDateTime = copy(dateTime = dateTime - years)
+    operator fun minus(months: Months): OffsetDateTime = copy(dateTime = dateTime - months)
+    operator fun minus(weeks: Weeks): OffsetDateTime = copy(dateTime = dateTime - weeks)
+    operator fun minus(days: Days): OffsetDateTime = copy(dateTime = dateTime - days)
+    override operator fun minus(hours: Hours): OffsetDateTime = copy(dateTime = dateTime - hours)
+    override operator fun minus(minutes: Minutes): OffsetDateTime = copy(dateTime = dateTime - minutes)
+    override operator fun minus(seconds: Seconds): OffsetDateTime = copy(dateTime = dateTime - seconds)
+    override operator fun minus(milliseconds: Milliseconds): OffsetDateTime = copy(dateTime = dateTime - milliseconds)
+    override operator fun minus(microseconds: Microseconds): OffsetDateTime = copy(dateTime = dateTime - microseconds)
+    override operator fun minus(nanoseconds: Nanoseconds): OffsetDateTime = copy(dateTime = dateTime - nanoseconds)
 
     operator fun rangeTo(other: OffsetDateTime): OffsetDateTimeInterval =
         OffsetDateTimeInterval.withInclusiveEnd(this, other)
@@ -269,7 +247,7 @@ class OffsetDateTime(
     fun copy(
         dateTime: DateTime = this.dateTime,
         offset: UtcOffset = this.offset
-    ) = OffsetDateTime(dateTime, offset)
+    ): OffsetDateTime = OffsetDateTime(dateTime, offset)
 
     /**
      * Returns a copy of this date-time with the values of any individual components replaced by the new values
@@ -280,7 +258,7 @@ class OffsetDateTime(
         date: Date = this.date,
         time: Time = this.time,
         offset: UtcOffset = this.offset
-    ) = OffsetDateTime(date, time, offset)
+    ): OffsetDateTime = OffsetDateTime(date, time, offset)
 
     /**
      * Returns a copy of this date-time with the values of any individual components replaced by the new values
@@ -295,7 +273,7 @@ class OffsetDateTime(
         second: Int = this.second,
         nanosecond: Int = this.nanosecond,
         offset: UtcOffset = this.offset
-    ) = OffsetDateTime(date.copy(year, dayOfYear), time.copy(hour, minute, second, nanosecond), offset)
+    ): OffsetDateTime = OffsetDateTime(date.copy(year, dayOfYear), time.copy(hour, minute, second, nanosecond), offset)
 
     /**
      * Returns a copy of this date-time with the values of any individual components replaced by the new values
@@ -311,18 +289,21 @@ class OffsetDateTime(
         second: Int = this.second,
         nanosecond: Int = this.nanosecond,
         offset: UtcOffset = this.offset
-    ) = OffsetDateTime(date.copy(year, month, dayOfMonth), time.copy(hour, minute, second, nanosecond), offset)
+    ): OffsetDateTime = OffsetDateTime(
+        date.copy(year, month, dayOfMonth), time.copy(hour, minute, second, nanosecond),
+        offset
+    )
 
     companion object {
         /**
          * The earliest supported [OffsetDateTime], which can be used as a "far past" sentinel.
          */
-        val MIN = DateTime.MIN at UtcOffset.MAX
+        val MIN: OffsetDateTime = DateTime.MIN at UtcOffset.MAX
 
         /**
          * The latest supported [OffsetDateTime], which can be used as a "far future" sentinel.
          */
-        val MAX = DateTime.MAX at UtcOffset.MIN
+        val MAX: OffsetDateTime = DateTime.MAX at UtcOffset.MIN
 
         /**
          * A [Comparator] that compares by instant, then date-time. Using this `Comparator` guarantees a deterministic
@@ -340,7 +321,7 @@ class OffsetDateTime(
         /**
          * Creates an [OffsetDateTime] from a duration of milliseconds relative to the Unix epoch at [offset].
          */
-        fun fromMillisecondsSinceUnixEpoch(milliseconds: LongMilliseconds, offset: UtcOffset): OffsetDateTime {
+        fun fromMillisecondsSinceUnixEpoch(milliseconds: Milliseconds, offset: UtcOffset): OffsetDateTime {
             return OffsetDateTime(DateTime.fromMillisecondsSinceUnixEpoch(milliseconds, offset), offset)
         }
 
@@ -349,8 +330,8 @@ class OffsetDateTime(
          * with some number of additional nanoseconds added to it.
          */
         fun fromSecondsSinceUnixEpoch(
-            seconds: LongSeconds,
-            nanosecondAdjustment: IntNanoseconds = 0.nanoseconds,
+            seconds: Seconds,
+            nanosecondAdjustment: Nanoseconds = 0.nanoseconds,
             offset: UtcOffset
         ): OffsetDateTime {
             return OffsetDateTime(DateTime.fromSecondsSinceUnixEpoch(seconds, nanosecondAdjustment, offset), offset)
@@ -376,18 +357,17 @@ class OffsetDateTime(
             ReplaceWith("OffsetDateTime.fromMillisecondOfUnixEpoch(millisecond, offset)"),
             DeprecationLevel.ERROR
         )
-        fun fromUnixEpochMillisecond(millisecond: Long, offset: UtcOffset): OffsetDateTime {
-            return fromMillisecondOfUnixEpoch(millisecond, offset)
-        }
+        @Suppress("UNUSED_PARAMETER", "unused")
+        fun fromUnixEpochMillisecond(millisecond: Long, offset: UtcOffset): OffsetDateTime = deprecatedToError()
 
         @Deprecated(
             "Use fromSecondOfUnixEpoch() instead.",
             ReplaceWith("OffsetDateTime.fromSecondOfUnixEpoch(second, nanoOfSecond, offset)"),
             DeprecationLevel.ERROR
         )
-        fun fromUnixEpochSecond(second: Long, nanoOfSecond: Int, offset: UtcOffset): OffsetDateTime {
-            return fromSecondOfUnixEpoch(second, nanoOfSecond, offset)
-        }
+        @Suppress("UNUSED_PARAMETER", "unused")
+        fun fromUnixEpochSecond(second: Long, nanoOfSecond: Int, offset: UtcOffset): OffsetDateTime =
+            deprecatedToError()
     }
 }
 
@@ -446,4 +426,5 @@ internal fun StringBuilder.appendOffsetDateTime(offsetDateTime: OffsetDateTime):
     ReplaceWith("this.toOffsetDateTime()"),
     DeprecationLevel.ERROR
 )
-fun ZonedDateTime.asOffsetDateTime() = toOffsetDateTime()
+@Suppress("unused")
+fun ZonedDateTime.asOffsetDateTime(): OffsetDateTime = deprecatedToError()

--- a/core/src/commonMain/kotlin/io/islandtime/OffsetTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/OffsetTime.kt
@@ -51,7 +51,7 @@ class OffsetTime(
      * The number of nanoseconds since the start of the day, but normalized to a UTC offset of zero, allowing
      * [OffsetTime] objects with different offsets to be compared.
      */
-    val nanosecondsSinceStartOfUtcDay: LongNanoseconds
+    val nanosecondsSinceStartOfUtcDay: Nanoseconds
         get() = (time.nanosecondsSinceStartOfDay.value - offset.totalSeconds.inNanoseconds.value).nanoseconds
 
     /**
@@ -67,33 +67,21 @@ class OffsetTime(
         }
     }
 
-    operator fun plus(duration: Duration) = copy(time = time + duration)
-    operator fun plus(hours: LongHours) = copy(time = time + hours)
-    operator fun plus(hours: IntHours) = copy(time = time + hours)
-    operator fun plus(minutes: LongMinutes) = copy(time = time + minutes)
-    operator fun plus(minutes: IntMinutes) = copy(time = time + minutes)
-    operator fun plus(seconds: LongSeconds) = copy(time = time + seconds)
-    operator fun plus(seconds: IntSeconds) = copy(time = time + seconds)
-    operator fun plus(milliseconds: LongMilliseconds) = copy(time = time + milliseconds)
-    operator fun plus(milliseconds: IntMilliseconds) = copy(time = time + milliseconds)
-    operator fun plus(microseconds: LongMicroseconds) = copy(time = time + microseconds)
-    operator fun plus(microseconds: IntMicroseconds) = copy(time = time + microseconds)
-    operator fun plus(nanoseconds: LongNanoseconds) = copy(time = time + nanoseconds)
-    operator fun plus(nanoseconds: IntNanoseconds) = copy(time = time + nanoseconds)
+    operator fun plus(duration: Duration): OffsetTime = copy(time = time + duration)
+    operator fun plus(hours: Hours): OffsetTime = copy(time = time + hours)
+    operator fun plus(minutes: Minutes): OffsetTime = copy(time = time + minutes)
+    operator fun plus(seconds: Seconds): OffsetTime = copy(time = time + seconds)
+    operator fun plus(milliseconds: Milliseconds): OffsetTime = copy(time = time + milliseconds)
+    operator fun plus(microseconds: Microseconds): OffsetTime = copy(time = time + microseconds)
+    operator fun plus(nanoseconds: Nanoseconds): OffsetTime = copy(time = time + nanoseconds)
 
-    operator fun minus(duration: Duration) = copy(time = time - duration)
-    operator fun minus(hours: LongHours) = copy(time = time - hours)
-    operator fun minus(hours: IntHours) = copy(time = time - hours)
-    operator fun minus(minutes: LongMinutes) = copy(time = time - minutes)
-    operator fun minus(minutes: IntMinutes) = copy(time = time - minutes)
-    operator fun minus(seconds: LongSeconds) = copy(time = time - seconds)
-    operator fun minus(seconds: IntSeconds) = copy(time = time - seconds)
-    operator fun minus(milliseconds: LongMilliseconds) = copy(time = time - milliseconds)
-    operator fun minus(milliseconds: IntMilliseconds) = copy(time = time - milliseconds)
-    operator fun minus(microseconds: LongMicroseconds) = copy(time = time - microseconds)
-    operator fun minus(microseconds: IntMicroseconds) = copy(time = time - microseconds)
-    operator fun minus(nanoseconds: LongNanoseconds) = copy(time = time - nanoseconds)
-    operator fun minus(nanoseconds: IntNanoseconds) = copy(time = time - nanoseconds)
+    operator fun minus(duration: Duration): OffsetTime = copy(time = time - duration)
+    operator fun minus(hours: Hours): OffsetTime = copy(time = time - hours)
+    operator fun minus(minutes: Minutes): OffsetTime = copy(time = time - minutes)
+    operator fun minus(seconds: Seconds): OffsetTime = copy(time = time - seconds)
+    operator fun minus(milliseconds: Milliseconds): OffsetTime = copy(time = time - milliseconds)
+    operator fun minus(microseconds: Microseconds): OffsetTime = copy(time = time - microseconds)
+    operator fun minus(nanoseconds: Nanoseconds): OffsetTime = copy(time = time - nanoseconds)
 
     /**
      * Compares to another [OffsetTime] based on timeline order, ignoring offset differences.
@@ -127,7 +115,7 @@ class OffsetTime(
     fun copy(
         time: Time = this.time,
         offset: UtcOffset = this.offset
-    ) = OffsetTime(time, offset)
+    ): OffsetTime = OffsetTime(time, offset)
 
     /**
      * Returns a copy of this time with the values of any individual components replaced by the new values
@@ -140,29 +128,30 @@ class OffsetTime(
         second: Int = this.second,
         nanosecond: Int = this.nanosecond,
         offset: UtcOffset = this.offset
-    ) = OffsetTime(time.copy(hour, minute, second, nanosecond), offset)
+    ): OffsetTime = OffsetTime(time.copy(hour, minute, second, nanosecond), offset)
 
     companion object {
         /**
          * The smallest allowed [OffsetTime] -- `00:00+18:00`.
          */
-        val MIN = Time.MIN at UtcOffset.MAX
+        val MIN: OffsetTime = Time.MIN at UtcOffset.MAX
 
         /**
          * The largest allowed [OffsetTime] -- `23:59:59.999999999-18:00`.
          */
-        val MAX = Time.MAX at UtcOffset.MIN
+        val MAX: OffsetTime = Time.MAX at UtcOffset.MIN
 
         /**
          * Compares by UTC equivalent instant, then time. Using this `Comparator` guarantees a deterministic order when
          * sorting.
          */
-        val DEFAULT_SORT_ORDER = compareBy<OffsetTime> { it.nanosecondsSinceStartOfUtcDay }.thenBy { it.time }
+        val DEFAULT_SORT_ORDER: Comparator<OffsetTime> =
+            compareBy<OffsetTime> { it.nanosecondsSinceStartOfUtcDay }.thenBy { it.time }
 
         /**
          * Compares by timeline order only, ignoring any offset differences.
          */
-        val TIMELINE_ORDER = compareBy<OffsetTime> { it.nanosecondsSinceStartOfUtcDay }
+        val TIMELINE_ORDER: Comparator<OffsetTime> = compareBy { it.nanosecondsSinceStartOfUtcDay }
     }
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/Time.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/Time.kt
@@ -54,7 +54,7 @@ class Time(
     /**
      * The number of seconds since the start of the day.
      */
-    inline val secondsSinceStartOfDay: IntSeconds
+    val secondsSinceStartOfDay: Seconds
         get() = secondOfDay.seconds
 
     /**
@@ -63,22 +63,22 @@ class Time(
     val nanosecondOfDay: Long
         get() {
             return hour.toLong() * NANOSECONDS_PER_HOUR +
-                    minute.toLong() * NANOSECONDS_PER_MINUTE +
-                    second.toLong() * NANOSECONDS_PER_SECOND +
-                    nanosecond
+                minute.toLong() * NANOSECONDS_PER_MINUTE +
+                second.toLong() * NANOSECONDS_PER_SECOND +
+                nanosecond
         }
 
     /**
      * The number of nanoseconds since the start of the day.
      */
-    inline val nanosecondsSinceStartOfDay: LongNanoseconds
+    val nanosecondsSinceStartOfDay: Nanoseconds
         get() = nanosecondOfDay.nanoseconds
 
     operator fun plus(duration: Duration): Time {
         return this + duration.seconds + duration.nanosecondAdjustment
     }
 
-    operator fun plus(hours: LongHours): Time {
+    operator fun plus(hours: Hours): Time {
         val wrappedHours = (hours % HOURS_PER_DAY).toInt()
 
         return if (wrappedHours == 0) {
@@ -89,9 +89,7 @@ class Time(
         }
     }
 
-    operator fun plus(hours: IntHours) = plus(hours.toLongHours())
-
-    operator fun plus(minutes: LongMinutes): Time {
+    operator fun plus(minutes: Minutes): Time {
         return if (minutes.value == 0L) {
             this
         } else {
@@ -109,9 +107,7 @@ class Time(
         }
     }
 
-    operator fun plus(minutes: IntMinutes) = plus(minutes.toLongMinutes())
-
-    operator fun plus(seconds: LongSeconds): Time {
+    operator fun plus(seconds: Seconds): Time {
         return if (seconds.value == 0L) {
             this
         } else {
@@ -127,25 +123,17 @@ class Time(
         }
     }
 
-    operator fun plus(seconds: IntSeconds) = plus(seconds.toLongSeconds())
-
-    operator fun plus(milliseconds: LongMilliseconds): Time {
+    operator fun plus(milliseconds: Milliseconds): Time {
         return plusWrapped((milliseconds % MILLISECONDS_PER_DAY).inNanosecondsUnchecked)
     }
 
-    operator fun plus(milliseconds: IntMilliseconds) = plus(milliseconds.toLongMilliseconds())
-
-    operator fun plus(microseconds: LongMicroseconds): Time {
+    operator fun plus(microseconds: Microseconds): Time {
         return plusWrapped((microseconds % MICROSECONDS_PER_DAY).inNanosecondsUnchecked)
     }
 
-    operator fun plus(microseconds: IntMicroseconds) = plus(microseconds.toLongMicroseconds())
+    operator fun plus(nanoseconds: Nanoseconds): Time = plusWrapped(nanoseconds % NANOSECONDS_PER_DAY)
 
-    operator fun plus(nanoseconds: LongNanoseconds): Time {
-        return plusWrapped(nanoseconds % NANOSECONDS_PER_DAY)
-    }
-
-    private fun plusWrapped(wrappedNanos: LongNanoseconds): Time {
+    private fun plusWrapped(wrappedNanos: Nanoseconds): Time {
         return if (wrappedNanos.value == 0L) {
             this
         } else {
@@ -154,46 +142,38 @@ class Time(
         }
     }
 
-    operator fun plus(nanoseconds: IntNanoseconds) = plus(nanoseconds.toLongNanoseconds())
-
     operator fun minus(duration: Duration): Time {
         return this - duration.seconds - duration.nanosecondAdjustment
     }
 
-    operator fun minus(hours: LongHours) = plus((hours % HOURS_PER_DAY).negateUnchecked())
-    operator fun minus(hours: IntHours) = plus(hours.toLongHours().negateUnchecked())
-    operator fun minus(minutes: LongMinutes) = plus((minutes % MINUTES_PER_DAY).negateUnchecked())
-    operator fun minus(minutes: IntMinutes) = plus(minutes.toLongMinutes().negateUnchecked())
-    operator fun minus(seconds: LongSeconds) = plus((seconds % SECONDS_PER_DAY).negateUnchecked())
-    operator fun minus(seconds: IntSeconds) = plus(seconds.toLongSeconds().negateUnchecked())
+    operator fun minus(hours: Hours): Time = plus((hours % HOURS_PER_DAY).negateUnchecked())
+    operator fun minus(minutes: Minutes): Time = plus((minutes % MINUTES_PER_DAY).negateUnchecked())
+    operator fun minus(seconds: Seconds): Time = plus((seconds % SECONDS_PER_DAY).negateUnchecked())
 
-    operator fun minus(milliseconds: LongMilliseconds) =
-        plusWrapped((milliseconds % MILLISECONDS_PER_DAY).inNanosecondsUnchecked.negateUnchecked())
+    operator fun minus(milliseconds: Milliseconds): Time {
+        return plusWrapped((milliseconds % MILLISECONDS_PER_DAY).inNanosecondsUnchecked.negateUnchecked())
+    }
 
-    operator fun minus(milliseconds: IntMilliseconds) = plus(milliseconds.toLongMilliseconds().negateUnchecked())
+    operator fun minus(microseconds: Microseconds): Time {
+        return plusWrapped((microseconds % MICROSECONDS_PER_DAY).inNanosecondsUnchecked.negateUnchecked())
+    }
 
-    operator fun minus(microseconds: LongMicroseconds) =
-        plusWrapped((microseconds % MICROSECONDS_PER_DAY).inNanosecondsUnchecked.negateUnchecked())
+    operator fun minus(nanoseconds: Nanoseconds): Time {
+        return plusWrapped((nanoseconds % NANOSECONDS_PER_DAY).negateUnchecked())
+    }
 
-    operator fun minus(microseconds: IntMicroseconds) = plus(microseconds.toLongMicroseconds().negateUnchecked())
-
-    operator fun minus(nanoseconds: LongNanoseconds) =
-        plusWrapped((nanoseconds % NANOSECONDS_PER_DAY).negateUnchecked())
-
-    operator fun minus(nanoseconds: IntNanoseconds) = plus(nanoseconds.toLongNanoseconds().negateUnchecked())
-
-    operator fun component1() = hour
-    operator fun component2() = minute
-    operator fun component3() = second
-    operator fun component4() = nanosecond
+    operator fun component1(): Int = hour
+    operator fun component2(): Int = minute
+    operator fun component3(): Int = second
+    operator fun component4(): Int = nanosecond
 
     override fun equals(other: Any?): Boolean {
         return this === other ||
-                (other is Time &&
-                        hour == other.hour &&
-                        minute == other.minute &&
-                        second == other.second &&
-                        nanosecond == other.nanosecond)
+            (other is Time &&
+                hour == other.hour &&
+                minute == other.minute &&
+                second == other.second &&
+                nanosecond == other.nanosecond)
     }
 
     override fun hashCode(): Int {
@@ -229,7 +209,7 @@ class Time(
     /**
      * Converts this time to a string in ISO-8601 extended format. For example, `17:31:45.923452091` or `02:30`.
      */
-    override fun toString() = buildString(MAX_TIME_STRING_LENGTH) { appendTime(this@Time) }
+    override fun toString(): String = buildString(MAX_TIME_STRING_LENGTH) { appendTime(this@Time) }
 
     /**
      * Returns a copy of this time with the values of any individual components replaced by the new values
@@ -241,13 +221,13 @@ class Time(
         minute: Int = this.minute,
         second: Int = this.second,
         nanosecond: Int = this.nanosecond
-    ) = Time(hour, minute, second, nanosecond)
+    ): Time = Time(hour, minute, second, nanosecond)
 
     companion object {
-        val MIN = Time(0, 0)
-        val MAX = Time(23, 59, 59, 999_999_999)
-        val MIDNIGHT = Time(0, 0)
-        val NOON = Time(12, 0)
+        val MIN: Time = Time(0, 0)
+        val MAX: Time = Time(23, 59, 59, 999_999_999)
+        val MIDNIGHT: Time = Time(0, 0)
+        val NOON: Time = Time(12, 0)
 
         /**
          * Creates a [Time] from the second of the day and optionally, the number of nanoseconds within that second.
@@ -258,7 +238,14 @@ class Time(
          * @throws DateTimeException if the time is invalid
          */
         fun fromSecondOfDay(secondOfDay: Int, nanosecond: Int = 0): Time {
-            return fromSecondsSinceStartOfDay(secondOfDay.seconds, nanosecond.nanoseconds)
+            if (secondOfDay !in 0 until SECONDS_PER_DAY) {
+                throw DateTimeException("'$secondOfDay' is not a valid second of the day")
+            }
+
+            val hour = secondOfDay / SECONDS_PER_HOUR
+            val minute = (secondOfDay % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
+            val second = secondOfDay % SECONDS_PER_MINUTE
+            return Time(hour, minute, second, nanosecond)
         }
 
         /**
@@ -271,15 +258,13 @@ class Time(
          * @throws DateTimeException if the time is invalid
          */
         fun fromSecondsSinceStartOfDay(
-            seconds: IntSeconds,
-            nanosecondAdjustment: IntNanoseconds = 0.nanoseconds
+            seconds: Seconds,
+            nanosecondAdjustment: Nanoseconds = 0.nanoseconds
         ): Time {
-            if (seconds.value !in 0 until SECONDS_PER_DAY) {
-                throw DateTimeException("'${seconds.value}' is not a valid second of the day")
-            }
-
-            return seconds.toComponents { hours, minutes, secondsPart ->
-                Time(hours.value, minutes.value, secondsPart.value, nanosecondAdjustment.value)
+            return try {
+                fromSecondOfDay(seconds.toInt(), nanosecondAdjustment.toInt())
+            } catch (e: ArithmeticException) {
+                throw DateTimeException("'$seconds' + '$nanosecondAdjustment' overflows an Int", e)
             }
         }
 
@@ -309,7 +294,7 @@ class Time(
          * @return a new [Time]
          * @throws DateTimeException if the time is invalid
          */
-        fun fromNanosecondsSinceStartOfDay(nanoseconds: LongNanoseconds): Time {
+        fun fromNanosecondsSinceStartOfDay(nanoseconds: Nanoseconds): Time {
             return fromNanosecondOfDay(nanoseconds.value)
         }
     }

--- a/core/src/commonMain/kotlin/io/islandtime/UtcOffset.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/UtcOffset.kt
@@ -4,9 +4,14 @@ package io.islandtime
 
 import dev.erikchristensen.javamath2kmp.toIntExact
 import io.islandtime.base.DateTimeField
+import io.islandtime.internal.SECONDS_PER_HOUR
+import io.islandtime.internal.SECONDS_PER_MINUTE
 import io.islandtime.internal.appendZeroPadded
 import io.islandtime.measures.*
 import io.islandtime.parser.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.jvm.JvmInline
 import kotlin.math.absoluteValue
 import kotlin.math.sign
@@ -14,18 +19,35 @@ import kotlin.math.sign
 /**
  * The time shift between a local time and UTC.
  *
- * @param totalSeconds the total number of seconds to offset by
+ * @constructor Creates an offset from the number of seconds relative to UTC.
+ * @param totalSecondsValue the total number of seconds to offset by
  * @throws DateTimeException if the offset is outside the supported range
- * @property totalSeconds The number of seconds relative to UTC.
+ * @property totalSecondsValue The number of seconds relative to UTC.
  */
 @JvmInline
-value class UtcOffset(val totalSeconds: IntSeconds) : Comparable<UtcOffset> {
+value class UtcOffset @PublishedApi internal constructor(val totalSecondsValue: Int) : Comparable<UtcOffset> {
+    /**
+     * The number of seconds relative to UTC.
+     */
+    val totalSeconds: Seconds get() = Seconds(totalSecondsValue)
 
-    init {
-        if (totalSeconds !in MIN_TOTAL_SECONDS..MAX_TOTAL_SECONDS) {
-            throw DateTimeException("'$totalSeconds' is outside the valid offset range of +/-18:00")
-        }
-    }
+    @PublishedApi
+    internal val hoursComponent: Int
+        get() = totalSecondsValue / SECONDS_PER_HOUR
+
+    @PublishedApi
+    internal val minutesComponent: Int
+        get() = (totalSecondsValue % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
+
+    @PublishedApi
+    internal val secondsComponent: Int
+        get() = totalSecondsValue % SECONDS_PER_MINUTE
+
+    /**
+     * Creates an offset from the number of seconds relative to UTC.
+     * @throws DateTimeException if the offset is outside the supported range
+     */
+    constructor(totalSeconds: Seconds) : this(checkValidOffset(totalSeconds.value))
 
     /**
      * Checks if this is the UTC offset of +00:00.
@@ -36,10 +58,13 @@ value class UtcOffset(val totalSeconds: IntSeconds) : Comparable<UtcOffset> {
      * Breaks a UTC offset down into components. The sign will indicate whether the offset is positive or negative while
      * each component will be positive.
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponents(
-        action: (sign: Int, hours: IntHours, minutes: IntMinutes, seconds: IntSeconds) -> T
+        action: (sign: Int, hours: Hours, minutes: Minutes, seconds: Seconds) -> T
     ): T {
-        return totalSeconds.value.absoluteValue.seconds.toComponents { hours, minutes, seconds ->
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
+
+        return Seconds(totalSecondsValue.absoluteValue).toComponents { hours, minutes, seconds ->
             action(totalSeconds.value.sign, hours, minutes, seconds)
         }
     }
@@ -47,14 +72,41 @@ value class UtcOffset(val totalSeconds: IntSeconds) : Comparable<UtcOffset> {
     /**
      * Breaks a UTC offset down into components. If the offset is negative, each component will be negative.
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponents(
-        action: (hours: IntHours, minutes: IntMinutes, seconds: IntSeconds) -> T
+        action: (hours: Hours, minutes: Minutes, seconds: Seconds) -> T
     ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
         return totalSeconds.toComponents(action)
     }
 
+    /**
+     * Breaks a UTC offset down into components. The sign will indicate whether the offset is positive or negative while
+     * each component will be positive.
+     */
+    @OptIn(ExperimentalContracts::class)
+    inline fun <T> toComponentValues(
+        action: (sign: Int, hours: Int, minutes: Int, seconds: Int) -> T
+    ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
 
-    override fun compareTo(other: UtcOffset): Int = totalSeconds.compareTo(other.totalSeconds)
+        return UtcOffset(totalSecondsValue.absoluteValue).toComponentValues { hours, minutes, seconds ->
+            action(totalSecondsValue.sign, hours, minutes, seconds)
+        }
+    }
+
+    /**
+     * Breaks a UTC offset down into components. If the offset is negative, each component will be negative.
+     */
+    @OptIn(ExperimentalContracts::class)
+    inline fun <T> toComponentValues(
+        action: (hours: Int, minutes: Int, seconds: Int) -> T
+    ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
+        return action(hoursComponent, minutesComponent, secondsComponent)
+    }
+
+    override fun compareTo(other: UtcOffset): Int = totalSecondsValue - other.totalSecondsValue
 
     /**
      * Converts this offset to a string in ISO-8601 extended format. For example, `-04:00` or `Z`.
@@ -68,12 +120,17 @@ value class UtcOffset(val totalSeconds: IntSeconds) : Comparable<UtcOffset> {
     }
 
     companion object {
-        val MAX_TOTAL_SECONDS: IntSeconds = 18.hours.inSecondsUnchecked
-        val MIN_TOTAL_SECONDS: IntSeconds = (-18).hours.inSecondsUnchecked
+        val MAX_TOTAL_SECONDS_VALUE: Int = 18.hours.inSecondsUnchecked.toInt()
+        val MIN_TOTAL_SECONDS_VALUE: Int = (-18).hours.inSecondsUnchecked.toInt()
+
+        val MAX_TOTAL_SECONDS: Seconds get() = MAX_TOTAL_SECONDS_VALUE.seconds
+        val MIN_TOTAL_SECONDS: Seconds get() = MIN_TOTAL_SECONDS_VALUE.seconds
 
         val MIN: UtcOffset = UtcOffset(MIN_TOTAL_SECONDS)
         val MAX: UtcOffset = UtcOffset(MAX_TOTAL_SECONDS)
-        val ZERO: UtcOffset = UtcOffset(0.seconds)
+        val ZERO: UtcOffset = UtcOffset(totalSecondsValue = 0)
+
+        fun fromTotalSeconds(value: Int): UtcOffset = UtcOffset(checkValidOffset(value))
     }
 }
 
@@ -87,30 +144,31 @@ value class UtcOffset(val totalSeconds: IntSeconds) : Comparable<UtcOffset> {
  * @return a [UtcOffset]
  */
 fun UtcOffset(
-    hours: IntHours,
-    minutes: IntMinutes = 0.minutes,
-    seconds: IntSeconds = 0.seconds
+    hours: Hours,
+    minutes: Minutes = 0.minutes,
+    seconds: Seconds = 0.seconds
 ): UtcOffset {
-    validateUtcOffsetComponents(hours, minutes, seconds)
-    return UtcOffset(hours + minutes + seconds)
+    validateUtcOffsetComponents(hours.value, minutes.value, seconds.value)
+    return UtcOffset(totalSeconds = hours + minutes + seconds)
 }
 
 /**
  * Converts a duration of hours into a [UtcOffset] of the same length.
  * @throws ArithmeticException if overflow occurs
  */
-fun IntHours.asUtcOffset(): UtcOffset = UtcOffset(this.inSeconds)
+fun Hours.asUtcOffset(): UtcOffset = UtcOffset(this.inSeconds)
 
 /**
  * Converts a duration of minutes into a [UtcOffset] of the same length.
  * @throws ArithmeticException if overflow occurs
  */
-fun IntMinutes.asUtcOffset(): UtcOffset = UtcOffset(this.inSeconds)
+fun Minutes.asUtcOffset(): UtcOffset = UtcOffset(this.inSeconds)
 
 /**
  * Converts a duration of seconds into a [UtcOffset] of the same length.
+ * @throws ArithmeticException if overflow occurs
  */
-fun IntSeconds.asUtcOffset(): UtcOffset = UtcOffset(this)
+fun Seconds.asUtcOffset(): UtcOffset = UtcOffset(totalSeconds = this)
 
 /**
  * Converts a string to a [UtcOffset].
@@ -156,9 +214,9 @@ internal fun DateTimeParseResult.toUtcOffset(): UtcOffset? {
     val sign = fields[DateTimeField.UTC_OFFSET_SIGN]
 
     if (sign != null) {
-        val hours = (fields[DateTimeField.UTC_OFFSET_HOURS]?.toIntExact() ?: 0).hours
-        val minutes = (fields[DateTimeField.UTC_OFFSET_MINUTES]?.toIntExact() ?: 0).minutes
-        val seconds = (fields[DateTimeField.UTC_OFFSET_SECONDS]?.toIntExact() ?: 0).seconds
+        val hours = (fields[DateTimeField.UTC_OFFSET_HOURS] ?: 0L).hours
+        val minutes = (fields[DateTimeField.UTC_OFFSET_MINUTES] ?: 0L).minutes
+        val seconds = (fields[DateTimeField.UTC_OFFSET_SECONDS] ?: 0L).seconds
 
         return if (sign < 0L) {
             UtcOffset(-hours, -minutes, -seconds)
@@ -176,41 +234,59 @@ internal fun StringBuilder.appendUtcOffset(offset: UtcOffset): StringBuilder {
     if (offset.isZero()) {
         append('Z')
     } else {
-        offset.toComponents { sign, hours, minutes, seconds ->
+        offset.toComponentValues { sign, hours, minutes, seconds ->
             append(if (sign < 0) '-' else '+')
-            appendZeroPadded(hours.value, 2)
+            appendZeroPadded(hours, 2)
             append(':')
-            appendZeroPadded(minutes.value, 2)
+            appendZeroPadded(minutes, 2)
 
-            if (seconds.value != 0) {
+            if (seconds != 0) {
                 append(':')
-                appendZeroPadded(seconds.value, 2)
+                appendZeroPadded(seconds, 2)
             }
         }
     }
     return this
 }
 
-private fun validateUtcOffsetComponents(hours: IntHours, minutes: IntMinutes, seconds: IntSeconds) {
+private fun validateUtcOffsetComponents(hours: Long, minutes: Long, seconds: Long) {
     when {
-        hours.value > 0 -> if (minutes.value < 0 || seconds.value < 0) {
+        hours > 0 -> if (minutes < 0 || seconds < 0) {
             throw DateTimeException("Time offset minutes and seconds must be positive when hours are positive")
         }
-        hours.value < 0 -> if (minutes.value > 0 || seconds.value > 0) {
+        hours < 0 -> if (minutes > 0 || seconds > 0) {
             throw DateTimeException("Time offset minutes and seconds must be negative when hours are negative")
         }
-        else -> if ((minutes.value < 0 && seconds.value > 0) || (minutes.value > 0 && seconds.value < 0)) {
+        else -> if ((minutes < 0 && seconds > 0) || (minutes > 0 && seconds < 0)) {
             throw DateTimeException("Time offset minutes and seconds must have the same sign")
         }
     }
 
-    if (hours.value !in -18..18) {
-        throw DateTimeException("Time offset hours must be within +/-18, got '${hours.value}'")
+    if (hours !in -18..18) {
+        throw DateTimeException("Time offset hours must be within +/-18, got '$hours'")
     }
-    if (minutes.value !in -59..59) {
-        throw DateTimeException("Time offset minutes must be within +/-59, got '${minutes.value}'")
+    if (minutes !in -59..59) {
+        throw DateTimeException("Time offset minutes must be within +/-59, got '$minutes'")
     }
-    if (seconds.value !in -59..59) {
-        throw DateTimeException("Time offset seconds must be within +/-59, got '${seconds.value}'")
+    if (seconds !in -59..59) {
+        throw DateTimeException("Time offset seconds must be within +/-59, got '$seconds'")
     }
+}
+
+private fun checkValidOffset(totalSeconds: Int): Int {
+    if (totalSeconds !in UtcOffset.MIN_TOTAL_SECONDS_VALUE..UtcOffset.MAX_TOTAL_SECONDS_VALUE) {
+        throwInvalidTotalSecondsException(totalSeconds.toLong())
+    }
+    return totalSeconds
+}
+
+private fun checkValidOffset(totalSeconds: Long): Int {
+    if (totalSeconds !in UtcOffset.MIN_TOTAL_SECONDS_VALUE..UtcOffset.MAX_TOTAL_SECONDS_VALUE) {
+        throwInvalidTotalSecondsException(totalSeconds)
+    }
+    return totalSeconds.toInt()
+}
+
+private fun throwInvalidTotalSecondsException(totalSeconds: Long): Nothing {
+    throw DateTimeException("'$totalSeconds seconds' is outside the valid offset range of +/-18:00")
 }

--- a/core/src/commonMain/kotlin/io/islandtime/Year.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/Year.kt
@@ -2,7 +2,10 @@ package io.islandtime
 
 import io.islandtime.base.DateTimeField
 import io.islandtime.internal.toZeroPaddedString
-import io.islandtime.measures.*
+import io.islandtime.measures.Days
+import io.islandtime.measures.Years
+import io.islandtime.measures.days
+import io.islandtime.measures.years
 import io.islandtime.parser.*
 import io.islandtime.ranges.DateRange
 import kotlin.jvm.JvmInline
@@ -37,7 +40,7 @@ value class Year(val value: Int) : Comparable<Year> {
     /**
      * The length of the year in days.
      */
-    val length: IntDays get() = lengthOfYear(value)
+    val length: Days get() = lengthOfYear(value)
 
     /**
      * The last day of the year. This will be either `365` or `366` depending on whether this is a common or leap year.
@@ -65,21 +68,17 @@ value class Year(val value: Int) : Comparable<Year> {
      */
     val endDate: Date get() = Date(value, Month.DECEMBER, 31)
 
-    operator fun plus(years: LongYears): Year {
+    operator fun plus(years: Years): Year {
         return Year(value + years.value)
     }
 
-    operator fun plus(years: IntYears): Year = plus(years.toLongYears())
-
-    operator fun minus(years: LongYears): Year {
+    operator fun minus(years: Years): Year {
         return if (years.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.years + 1L.years
         } else {
             plus(years.negateUnchecked())
         }
     }
-
-    operator fun minus(years: IntYears): Year = plus(years.toLongYears().negateUnchecked())
 
     operator fun contains(yearMonth: YearMonth): Boolean = yearMonth.year == value
     operator fun contains(date: Date): Boolean = date.year == value
@@ -169,11 +168,9 @@ internal fun isLeapYear(year: Int): Boolean {
     return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
 }
 
-internal fun lengthOfYear(year: Int): IntDays {
-    return if (isLeapYear(year)) 366.days else 365.days
-}
+internal fun lengthOfYear(year: Int): Days = lastDayOfYear(year).days
 
-internal fun lastDayOfYear(year: Int): Int = lengthOfYear(year).value
+internal fun lastDayOfYear(year: Int): Int = if (isLeapYear(year)) 366 else 365
 
 internal fun checkValidYear(year: Int): Int {
     if (!isValidYear(year)) {

--- a/core/src/commonMain/kotlin/io/islandtime/YearMonth.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/YearMonth.kt
@@ -58,12 +58,12 @@ class YearMonth(
     /**
      * The length of the year-month in days.
      */
-    val lengthOfMonth: IntDays get() = month.lengthIn(year)
+    val lengthOfMonth: Days get() = month.lengthIn(year)
 
     /**
      * The length of the year in days.
      */
-    val lengthOfYear: IntDays get() = lengthOfYear(year)
+    val lengthOfYear: Days get() = lengthOfYear(year)
 
     /**
      * The last day of the year-month.
@@ -133,9 +133,7 @@ class YearMonth(
      */
     fun copy(year: Int = this.year, monthNumber: Int): YearMonth = YearMonth(year, monthNumber)
 
-    operator fun plus(years: IntYears): YearMonth = plus(years.toLongYears())
-
-    operator fun plus(years: LongYears): YearMonth {
+    operator fun plus(years: Years): YearMonth {
         return if (years.value == 0L) {
             this
         } else {
@@ -144,22 +142,18 @@ class YearMonth(
         }
     }
 
-    operator fun plus(months: IntMonths): YearMonth = plus(months.toLongMonths())
-
-    operator fun plus(months: LongMonths): YearMonth {
+    operator fun plus(months: Months): YearMonth {
         return if (months.value == 0L) {
             this
         } else {
             val newMonthsSinceYear0 = year.toLong() * MONTHS_PER_YEAR + month.ordinal + months.value
             val newYear = checkValidYear(newMonthsSinceYear0 floorDiv MONTHS_PER_YEAR)
-            val newMonth = Month.values()[(newMonthsSinceYear0 floorMod MONTHS_PER_YEAR).toInt()]
+            val newMonth = Month.values()[newMonthsSinceYear0 floorMod MONTHS_PER_YEAR]
             YearMonth(newYear, newMonth)
         }
     }
 
-    operator fun minus(years: IntYears): YearMonth = plus(years.toLongYears().negateUnchecked())
-
-    operator fun minus(years: LongYears): YearMonth {
+    operator fun minus(years: Years): YearMonth {
         return if (years.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.years + 1L.years
         } else {
@@ -167,9 +161,7 @@ class YearMonth(
         }
     }
 
-    operator fun minus(months: IntMonths): YearMonth = plus(months.toLongMonths().negateUnchecked())
-
-    operator fun minus(months: LongMonths): YearMonth {
+    operator fun minus(months: Months): YearMonth {
         return if (months.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.months + 1L.months
         } else {
@@ -183,12 +175,12 @@ class YearMonth(
         /**
          * The earliest supported [YearMonth], which may be used to indicate the "far past".
          */
-        val MIN = YearMonth(Year.MIN_VALUE, Month.MIN)
+        val MIN: YearMonth = YearMonth(Year.MIN_VALUE, Month.MIN)
 
         /**
          * The latest supported [YearMonth], which may be used to indicate the "far future".
          */
-        val MAX = YearMonth(Year.MAX_VALUE, Month.MAX)
+        val MAX: YearMonth = YearMonth(Year.MAX_VALUE, Month.MAX)
     }
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/ZonedDateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ZonedDateTime.kt
@@ -3,6 +3,7 @@
 package io.islandtime
 
 import io.islandtime.base.TimePoint
+import io.islandtime.internal.deprecatedToError
 import io.islandtime.measures.*
 import io.islandtime.parser.*
 import io.islandtime.ranges.ZonedDateTimeInterval
@@ -113,14 +114,11 @@ class ZonedDateTime private constructor(
     inline val instant: Instant
         get() = toInstant()
 
-    override val secondsSinceUnixEpoch: LongSeconds
-        get() = dateTime.secondsSinceUnixEpochAt(offset)
+    override val secondOfUnixEpoch: Long
+        get() = dateTime.secondOfUnixEpochAt(offset)
 
-    override val additionalNanosecondsSinceUnixEpoch: IntNanoseconds
-        get() = dateTime.additionalNanosecondsSinceUnixEpoch
-
-    override val millisecondsSinceUnixEpoch: LongMilliseconds
-        get() = dateTime.millisecondsSinceUnixEpochAt(offset)
+    override val millisecondOfUnixEpoch: Long
+        get() = dateTime.millisecondOfUnixEpochAt(offset)
 
     override fun equals(other: Any?): Boolean {
         return this === other || (other is ZonedDateTime &&
@@ -155,38 +153,21 @@ class ZonedDateTime private constructor(
     operator fun plus(period: Period): ZonedDateTime = copy(dateTime = dateTime + period)
 
     operator fun plus(duration: Duration): ZonedDateTime = resolveInstant(dateTime + duration)
+    operator fun plus(years: Years): ZonedDateTime = copy(dateTime = dateTime + years)
+    operator fun plus(months: Months): ZonedDateTime = copy(dateTime = dateTime + months)
+    operator fun plus(weeks: Weeks): ZonedDateTime = copy(dateTime = dateTime + weeks)
+    operator fun plus(days: Days): ZonedDateTime = copy(dateTime = dateTime + days)
+    override operator fun plus(hours: Hours): ZonedDateTime = resolveInstant(dateTime + hours)
+    override operator fun plus(minutes: Minutes): ZonedDateTime = resolveInstant(dateTime + minutes)
+    override operator fun plus(seconds: Seconds): ZonedDateTime = resolveInstant(dateTime + seconds)
 
-    operator fun plus(years: IntYears): ZonedDateTime = copy(dateTime = dateTime + years)
-    operator fun plus(years: LongYears): ZonedDateTime = copy(dateTime = dateTime + years)
-    operator fun plus(months: IntMonths): ZonedDateTime = copy(dateTime = dateTime + months)
-    operator fun plus(months: LongMonths): ZonedDateTime = copy(dateTime = dateTime + months)
-    operator fun plus(weeks: IntWeeks): ZonedDateTime = copy(dateTime = dateTime + weeks)
-    operator fun plus(weeks: LongWeeks): ZonedDateTime = copy(dateTime = dateTime + weeks)
-    operator fun plus(days: IntDays): ZonedDateTime = copy(dateTime = dateTime + days)
-    operator fun plus(days: LongDays): ZonedDateTime = copy(dateTime = dateTime + days)
-    override operator fun plus(hours: IntHours): ZonedDateTime = resolveInstant(dateTime + hours)
-    override operator fun plus(hours: LongHours): ZonedDateTime = resolveInstant(dateTime + hours)
-    override operator fun plus(minutes: IntMinutes): ZonedDateTime = resolveInstant(dateTime + minutes)
-    override operator fun plus(minutes: LongMinutes): ZonedDateTime = resolveInstant(dateTime + minutes)
-    override operator fun plus(seconds: IntSeconds): ZonedDateTime = resolveInstant(dateTime + seconds)
-    override operator fun plus(seconds: LongSeconds): ZonedDateTime = resolveInstant(dateTime + seconds)
-
-    override operator fun plus(milliseconds: IntMilliseconds): ZonedDateTime =
+    override operator fun plus(milliseconds: Milliseconds): ZonedDateTime =
         resolveInstant(dateTime + milliseconds)
 
-    override operator fun plus(milliseconds: LongMilliseconds): ZonedDateTime =
-        resolveInstant(dateTime + milliseconds)
-
-    override operator fun plus(microseconds: IntMicroseconds): ZonedDateTime =
+    override operator fun plus(microseconds: Microseconds): ZonedDateTime =
         resolveInstant(dateTime + microseconds)
 
-    override operator fun plus(microseconds: LongMicroseconds): ZonedDateTime =
-        resolveInstant(dateTime + microseconds)
-
-    override operator fun plus(nanoseconds: IntNanoseconds): ZonedDateTime =
-        resolveInstant(dateTime + nanoseconds)
-
-    override operator fun plus(nanoseconds: LongNanoseconds): ZonedDateTime =
+    override operator fun plus(nanoseconds: Nanoseconds): ZonedDateTime =
         resolveInstant(dateTime + nanoseconds)
 
     /**
@@ -198,38 +179,21 @@ class ZonedDateTime private constructor(
     operator fun minus(period: Period): ZonedDateTime = copy(dateTime = dateTime - period)
 
     operator fun minus(duration: Duration): ZonedDateTime = resolveInstant(dateTime - duration)
+    operator fun minus(years: Years): ZonedDateTime = copy(dateTime = dateTime - years)
+    operator fun minus(months: Months): ZonedDateTime = copy(dateTime = dateTime - months)
+    operator fun minus(weeks: Weeks): ZonedDateTime = copy(dateTime = dateTime - weeks)
+    operator fun minus(days: Days): ZonedDateTime = copy(dateTime = dateTime - days)
+    override operator fun minus(hours: Hours): ZonedDateTime = resolveInstant(dateTime - hours)
+    override operator fun minus(minutes: Minutes): ZonedDateTime = resolveInstant(dateTime - minutes)
+    override operator fun minus(seconds: Seconds): ZonedDateTime = resolveInstant(dateTime - seconds)
 
-    operator fun minus(years: IntYears): ZonedDateTime = copy(dateTime = dateTime - years)
-    operator fun minus(years: LongYears): ZonedDateTime = copy(dateTime = dateTime - years)
-    operator fun minus(months: IntMonths): ZonedDateTime = copy(dateTime = dateTime - months)
-    operator fun minus(months: LongMonths): ZonedDateTime = copy(dateTime = dateTime - months)
-    operator fun minus(weeks: IntWeeks): ZonedDateTime = copy(dateTime = dateTime - weeks)
-    operator fun minus(weeks: LongWeeks): ZonedDateTime = copy(dateTime = dateTime - weeks)
-    operator fun minus(days: IntDays): ZonedDateTime = copy(dateTime = dateTime - days)
-    operator fun minus(days: LongDays): ZonedDateTime = copy(dateTime = dateTime - days)
-    override operator fun minus(hours: IntHours): ZonedDateTime = resolveInstant(dateTime - hours)
-    override operator fun minus(hours: LongHours): ZonedDateTime = resolveInstant(dateTime - hours)
-    override operator fun minus(minutes: IntMinutes): ZonedDateTime = resolveInstant(dateTime - minutes)
-    override operator fun minus(minutes: LongMinutes): ZonedDateTime = resolveInstant(dateTime - minutes)
-    override operator fun minus(seconds: IntSeconds): ZonedDateTime = resolveInstant(dateTime - seconds)
-    override operator fun minus(seconds: LongSeconds): ZonedDateTime = resolveInstant(dateTime - seconds)
-
-    override operator fun minus(milliseconds: IntMilliseconds): ZonedDateTime =
+    override operator fun minus(milliseconds: Milliseconds): ZonedDateTime =
         resolveInstant(dateTime - milliseconds)
 
-    override operator fun minus(milliseconds: LongMilliseconds): ZonedDateTime =
-        resolveInstant(dateTime - milliseconds)
-
-    override operator fun minus(microseconds: IntMicroseconds): ZonedDateTime =
+    override operator fun minus(microseconds: Microseconds): ZonedDateTime =
         resolveInstant(dateTime - microseconds)
 
-    override operator fun minus(microseconds: LongMicroseconds): ZonedDateTime =
-        resolveInstant(dateTime - microseconds)
-
-    override operator fun minus(nanoseconds: IntNanoseconds): ZonedDateTime =
-        resolveInstant(dateTime - nanoseconds)
-
-    override operator fun minus(nanoseconds: LongNanoseconds): ZonedDateTime =
+    override operator fun minus(nanoseconds: Nanoseconds): ZonedDateTime =
         resolveInstant(dateTime - nanoseconds)
 
     operator fun rangeTo(other: ZonedDateTime): ZonedDateTimeInterval =
@@ -468,7 +432,7 @@ class ZonedDateTime private constructor(
         /**
          * Creates a [ZonedDateTime] from a duration of milliseconds relative to the Unix epoch at [zone].
          */
-        fun fromMillisecondsSinceUnixEpoch(milliseconds: LongMilliseconds, zone: TimeZone): ZonedDateTime {
+        fun fromMillisecondsSinceUnixEpoch(milliseconds: Milliseconds, zone: TimeZone): ZonedDateTime {
             val offset = zone.rules.offsetAt(milliseconds)
             val dateTime = DateTime.fromMillisecondsSinceUnixEpoch(milliseconds, offset)
             return create(dateTime, offset, zone)
@@ -479,8 +443,8 @@ class ZonedDateTime private constructor(
          * with some number of additional nanoseconds added to it.
          */
         fun fromSecondsSinceUnixEpoch(
-            seconds: LongSeconds,
-            nanosecondAdjustment: IntNanoseconds = 0.nanoseconds,
+            seconds: Seconds,
+            nanosecondAdjustment: Nanoseconds = 0.nanoseconds,
             zone: TimeZone
         ): ZonedDateTime {
             val offset = zone.rules.offsetAt(seconds, nanosecondAdjustment)
@@ -507,18 +471,16 @@ class ZonedDateTime private constructor(
             ReplaceWith("ZonedDateTime.fromMillisecondOfUnixEpoch(millisecond, zone)"),
             DeprecationLevel.ERROR
         )
-        fun fromUnixEpochMillisecond(millisecond: Long, zone: TimeZone): ZonedDateTime {
-            return fromMillisecondOfUnixEpoch(millisecond, zone)
-        }
+        @Suppress("UNUSED_PARAMETER", "unused")
+        fun fromUnixEpochMillisecond(millisecond: Long, zone: TimeZone): ZonedDateTime = deprecatedToError()
 
         @Deprecated(
             "Use fromSecondOfUnixEpoch() instead.",
             ReplaceWith("ZonedDateTime.fromSecondOfUnixEpoch(second, nanoOfSecond, zone)"),
             DeprecationLevel.ERROR
         )
-        fun fromUnixEpochSecond(second: Long, nanoOfSecond: Int, zone: TimeZone): ZonedDateTime {
-            return fromSecondOfUnixEpoch(second, nanoOfSecond, zone)
-        }
+        @Suppress("UNUSED_PARAMETER", "unused")
+        fun fromUnixEpochSecond(second: Long, nanoOfSecond: Int, zone: TimeZone): ZonedDateTime = deprecatedToError()
 
         /**
          * Creates a [ZonedDateTime] with no additional validation.
@@ -674,9 +636,8 @@ internal fun StringBuilder.appendZonedDateTime(zonedDateTime: ZonedDateTime): St
     ),
     DeprecationLevel.ERROR
 )
-fun OffsetDateTime.similarLocalTimeAt(zone: TimeZone): ZonedDateTime {
-    return toZonedDateTime(zone, OffsetConversionStrategy.PRESERVE_LOCAL_TIME)
-}
+@Suppress("UNUSED_PARAMETER", "unused")
+fun OffsetDateTime.similarLocalTimeAt(zone: TimeZone): ZonedDateTime = deprecatedToError()
 
 @Deprecated(
     "Use toZonedDateTime() instead.",
@@ -686,9 +647,8 @@ fun OffsetDateTime.similarLocalTimeAt(zone: TimeZone): ZonedDateTime {
     ),
     DeprecationLevel.ERROR
 )
-fun OffsetDateTime.dateTimeAt(zone: TimeZone): ZonedDateTime {
-    return toZonedDateTime(zone, OffsetConversionStrategy.PRESERVE_LOCAL_TIME)
-}
+@Suppress("UNUSED_PARAMETER", "unused")
+fun OffsetDateTime.dateTimeAt(zone: TimeZone): ZonedDateTime = deprecatedToError()
 
 @Deprecated(
     "Use toZonedDateTime() instead.",
@@ -698,9 +658,8 @@ fun OffsetDateTime.dateTimeAt(zone: TimeZone): ZonedDateTime {
     ),
     DeprecationLevel.ERROR
 )
-fun OffsetDateTime.sameInstantAt(zone: TimeZone): ZonedDateTime {
-    return toZonedDateTime(zone, OffsetConversionStrategy.PRESERVE_INSTANT)
-}
+@Suppress("UNUSED_PARAMETER", "unused")
+fun OffsetDateTime.sameInstantAt(zone: TimeZone): ZonedDateTime = deprecatedToError()
 
 @Deprecated(
     "Use toZonedDateTime() instead.",
@@ -710,6 +669,5 @@ fun OffsetDateTime.sameInstantAt(zone: TimeZone): ZonedDateTime {
     ),
     DeprecationLevel.ERROR
 )
-fun OffsetDateTime.instantAt(zone: TimeZone): ZonedDateTime {
-    return toZonedDateTime(zone, OffsetConversionStrategy.PRESERVE_INSTANT)
-}
+@Suppress("UNUSED_PARAMETER", "unused")
+fun OffsetDateTime.instantAt(zone: TimeZone): ZonedDateTime = deprecatedToError()

--- a/core/src/commonMain/kotlin/io/islandtime/base/TimePoint.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/base/TimePoint.kt
@@ -1,5 +1,6 @@
 package io.islandtime.base
 
+import io.islandtime.internal.deprecatedToError
 import io.islandtime.measures.*
 
 /**
@@ -10,62 +11,55 @@ import io.islandtime.measures.*
  */
 interface TimePoint<T> {
     /**
+     * The second of the Unix epoch.
+     */
+    val secondOfUnixEpoch: Long
+
+    /**
+     * The nanosecond of the second.
+     */
+    val nanosecond: Int
+
+    /**
+     * The millisecond of the Unix epoch.
+     */
+    val millisecondOfUnixEpoch: Long
+    
+    /**
      * The number of seconds since the Unix epoch of 1970-01-01T00:00Z.
      */
-    val secondsSinceUnixEpoch: LongSeconds
-
-    @Deprecated(
-        "Use additionalNanosecondsSinceUnixEpoch instead.",
-        ReplaceWith("this.additionalNanosecondsSinceUnixEpoch"),
-        DeprecationLevel.ERROR
-    )
-    val nanoOfSecondsSinceUnixEpoch: IntNanoseconds get() = additionalNanosecondsSinceUnixEpoch
+    val secondsSinceUnixEpoch: Seconds get() = secondOfUnixEpoch.seconds
 
     /**
      * The number of additional nanoseconds on top of [secondsSinceUnixEpoch].
      */
-    val additionalNanosecondsSinceUnixEpoch: IntNanoseconds
+    val additionalNanosecondsSinceUnixEpoch: Nanoseconds get() = nanosecond.nanoseconds
 
     /**
      * The number of milliseconds since the Unix epoch of 1970-01-01T00:00Z.
      */
-    val millisecondsSinceUnixEpoch: LongMilliseconds
+    val millisecondsSinceUnixEpoch: Milliseconds get() = millisecondOfUnixEpoch.milliseconds
 
     @Deprecated(
         "Use secondOfUnixEpoch instead.",
         ReplaceWith("this.secondOfUnixEpoch"),
         DeprecationLevel.ERROR
     )
-    val unixEpochSecond: Long get() = secondOfUnixEpoch
-
-    /**
-     * The second of the Unix epoch.
-     */
-    val secondOfUnixEpoch: Long get() = secondsSinceUnixEpoch.value
+    val unixEpochSecond: Long get() = deprecatedToError()
 
     @Deprecated(
         "Use nanosecond instead.",
         ReplaceWith("this.nanosecond"),
         DeprecationLevel.ERROR
     )
-    val unixEpochNanoOfSecond: Int get() = nanosecond
-
-    /**
-     * The nanosecond of the second.
-     */
-    val nanosecond: Int get() = additionalNanosecondsSinceUnixEpoch.value
+    val unixEpochNanoOfSecond: Int get() = deprecatedToError()
 
     @Deprecated(
         "Use millisecondOfUnixEpoch instead.",
         ReplaceWith("this.millisecondOfUnixEpoch"),
         DeprecationLevel.ERROR
     )
-    val unixEpochMillisecond: Long get() = millisecondOfUnixEpoch
-
-    /**
-     * The millisecond of the Unix epoch.
-     */
-    val millisecondOfUnixEpoch: Long get() = millisecondsSinceUnixEpoch.value
+    val unixEpochMillisecond: Long get() = deprecatedToError()
 
     /**
      * Checks if this time point represents the same instant as [other]. Unlike the equals operator, equality is
@@ -95,31 +89,19 @@ interface TimePoint<T> {
         }
     }
 
-    operator fun plus(hours: IntHours): T
-    operator fun plus(hours: LongHours): T
-    operator fun plus(minutes: IntMinutes): T
-    operator fun plus(minutes: LongMinutes): T
-    operator fun plus(seconds: IntSeconds): T
-    operator fun plus(seconds: LongSeconds): T
-    operator fun plus(milliseconds: IntMilliseconds): T
-    operator fun plus(milliseconds: LongMilliseconds): T
-    operator fun plus(microseconds: IntMicroseconds): T
-    operator fun plus(microseconds: LongMicroseconds): T
-    operator fun plus(nanoseconds: IntNanoseconds): T
-    operator fun plus(nanoseconds: LongNanoseconds): T
+    operator fun plus(hours: Hours): T
+    operator fun plus(minutes: Minutes): T
+    operator fun plus(seconds: Seconds): T
+    operator fun plus(milliseconds: Milliseconds): T
+    operator fun plus(microseconds: Microseconds): T
+    operator fun plus(nanoseconds: Nanoseconds): T
 
-    operator fun minus(hours: IntHours): T
-    operator fun minus(hours: LongHours): T
-    operator fun minus(minutes: IntMinutes): T
-    operator fun minus(minutes: LongMinutes): T
-    operator fun minus(seconds: IntSeconds): T
-    operator fun minus(seconds: LongSeconds): T
-    operator fun minus(milliseconds: IntMilliseconds): T
-    operator fun minus(milliseconds: LongMilliseconds): T
-    operator fun minus(microseconds: IntMicroseconds): T
-    operator fun minus(microseconds: LongMicroseconds): T
-    operator fun minus(nanoseconds: IntNanoseconds): T
-    operator fun minus(nanoseconds: LongNanoseconds): T
+    operator fun minus(hours: Hours): T
+    operator fun minus(minutes: Minutes): T
+    operator fun minus(seconds: Seconds): T
+    operator fun minus(milliseconds: Milliseconds): T
+    operator fun minus(microseconds: Microseconds): T
+    operator fun minus(nanoseconds: Nanoseconds): T
 
     companion object {
         /**

--- a/core/src/commonMain/kotlin/io/islandtime/clock/Clock.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/clock/Clock.kt
@@ -5,8 +5,7 @@ package io.islandtime.clock
 import io.islandtime.Instant
 import io.islandtime.PlatformInstant
 import io.islandtime.TimeZone
-import io.islandtime.internal.deprecatedToError
-import io.islandtime.measures.*
+import io.islandtime.measures.Milliseconds
 
 /**
  * An abstraction providing the current time.
@@ -26,7 +25,7 @@ interface Clock {
     /**
      * Reads the current number of milliseconds that have elapsed since the Unix epoch of `1970-01-01T00:00` in UTC.
      */
-    fun readMilliseconds(): LongMilliseconds
+    fun readMilliseconds(): Milliseconds
 
     /**
      * Reads the current [Instant].
@@ -38,93 +37,3 @@ interface Clock {
      */
     fun readPlatformInstant(): PlatformInstant
 }
-
-@Deprecated(
-    message = "Specify the instant explicitly.",
-    replaceWith = ReplaceWith(
-        "FixedClock(Instant(days.inSeconds), zone)",
-        "io.islandtime.Instant"
-    ),
-    level = DeprecationLevel.ERROR
-)
-fun FixedClock(days: LongDays, zone: TimeZone = TimeZone.UTC): FixedClock = deprecatedToError()
-
-@Deprecated(
-    message = "Specify the instant explicitly.",
-    replaceWith = ReplaceWith(
-        "FixedClock(Instant(days.toLong().inSeconds), zone)",
-        "io.islandtime.Instant"
-    ),
-    level = DeprecationLevel.ERROR
-)
-fun FixedClock(days: IntDays, zone: TimeZone = TimeZone.UTC): FixedClock = deprecatedToError()
-
-@Deprecated(
-    message = "Specify the instant explicitly.",
-    replaceWith = ReplaceWith(
-        "FixedClock(Instant(hours.inSeconds), zone)",
-        "io.islandtime.Instant"
-    ),
-    level = DeprecationLevel.ERROR
-)
-fun FixedClock(hours: LongHours, zone: TimeZone = TimeZone.UTC): FixedClock = deprecatedToError()
-
-@Deprecated(
-    message = "Specify the instant explicitly.",
-    replaceWith = ReplaceWith(
-        "FixedClock(Instant(hours.toLong().inSeconds), zone)",
-        "io.islandtime.Instant"
-    ),
-    level = DeprecationLevel.ERROR
-)
-fun FixedClock(hours: IntHours, zone: TimeZone = TimeZone.UTC): FixedClock = deprecatedToError()
-
-@Deprecated(
-    message = "Specify the instant explicitly.",
-    replaceWith = ReplaceWith(
-        "FixedClock(Instant(minutes.inSeconds), zone)",
-        "io.islandtime.Instant"
-    ),
-    level = DeprecationLevel.ERROR
-)
-fun FixedClock(minutes: LongMinutes, zone: TimeZone = TimeZone.UTC): FixedClock = deprecatedToError()
-
-@Deprecated(
-    message = "Specify the instant explicitly.",
-    replaceWith = ReplaceWith(
-        "FixedClock(Instant(minutes.toLong().inSeconds), zone)",
-        "io.islandtime.Instant"
-    ),
-    level = DeprecationLevel.ERROR
-)
-fun FixedClock(minutes: IntMinutes, zone: TimeZone = TimeZone.UTC): FixedClock = deprecatedToError()
-
-@Deprecated(
-    message = "Specify the instant explicitly.",
-    replaceWith = ReplaceWith(
-        "FixedClock(Instant(seconds), zone)",
-        "io.islandtime.Instant"
-    ),
-    level = DeprecationLevel.ERROR
-)
-fun FixedClock(seconds: LongSeconds, zone: TimeZone = TimeZone.UTC): FixedClock = deprecatedToError()
-
-@Deprecated(
-    message = "Specify the instant explicitly.",
-    replaceWith = ReplaceWith(
-        "FixedClock(Instant(seconds.toLongSeconds()), zone)",
-        "io.islandtime.Instant"
-    ),
-    level = DeprecationLevel.ERROR
-)
-fun FixedClock(seconds: IntSeconds, zone: TimeZone = TimeZone.UTC): FixedClock = deprecatedToError()
-
-@Deprecated(
-    message = "Specify the instant explicitly.",
-    replaceWith = ReplaceWith(
-        "FixedClock(Instant(milliseconds.toLongMilliseconds()), zone)",
-        "io.islandtime.Instant"
-    ),
-    level = DeprecationLevel.ERROR
-)
-fun FixedClock(milliseconds: IntMilliseconds, zone: TimeZone = TimeZone.UTC): FixedClock = deprecatedToError()

--- a/core/src/commonMain/kotlin/io/islandtime/clock/FixedClock.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/clock/FixedClock.kt
@@ -21,119 +21,63 @@ class FixedClock(
         this.instant = instant
     }
 
-    operator fun plusAssign(days: LongDays) {
+    operator fun plusAssign(days: Days) {
         instant += days
     }
 
-    operator fun plusAssign(days: IntDays) {
-        instant += days
-    }
-
-    operator fun plusAssign(hours: LongHours) {
+    operator fun plusAssign(hours: Hours) {
         instant += hours
     }
 
-    operator fun plusAssign(hours: IntHours) {
-        instant += hours
-    }
-
-    operator fun plusAssign(minutes: LongMinutes) {
+    operator fun plusAssign(minutes: Minutes) {
         instant += minutes
     }
 
-    operator fun plusAssign(minutes: IntMinutes) {
-        instant += minutes
-    }
-
-    operator fun plusAssign(seconds: LongSeconds) {
+    operator fun plusAssign(seconds: Seconds) {
         instant += seconds
     }
 
-    operator fun plusAssign(seconds: IntSeconds) {
-        instant += seconds
-    }
-
-    operator fun plusAssign(milliseconds: LongMilliseconds) {
+    operator fun plusAssign(milliseconds: Milliseconds) {
         instant += milliseconds
     }
 
-    operator fun plusAssign(milliseconds: IntMilliseconds) {
-        instant += milliseconds
-    }
-
-    operator fun plusAssign(microseconds: LongMicroseconds) {
+    operator fun plusAssign(microseconds: Microseconds) {
         instant += microseconds
     }
 
-    operator fun plusAssign(microseconds: IntMicroseconds) {
-        instant += microseconds
-    }
-
-    operator fun plusAssign(nanoseconds: LongNanoseconds) {
+    operator fun plusAssign(nanoseconds: Nanoseconds) {
         instant += nanoseconds
     }
 
-    operator fun plusAssign(nanoseconds: IntNanoseconds) {
-        instant += nanoseconds
-    }
-
-    operator fun minusAssign(days: LongDays) {
+    operator fun minusAssign(days: Days) {
         instant -= days
     }
 
-    operator fun minusAssign(days: IntDays) {
-        instant -= days
-    }
-
-    operator fun minusAssign(hours: LongHours) {
+    operator fun minusAssign(hours: Hours) {
         instant -= hours
     }
 
-    operator fun minusAssign(hours: IntHours) {
-        instant -= hours
-    }
-
-    operator fun minusAssign(minutes: LongMinutes) {
+    operator fun minusAssign(minutes: Minutes) {
         instant -= minutes
     }
 
-    operator fun minusAssign(minutes: IntMinutes) {
-        instant -= minutes
-    }
-
-    operator fun minusAssign(seconds: LongSeconds) {
+    operator fun minusAssign(seconds: Seconds) {
         instant -= seconds
     }
 
-    operator fun minusAssign(seconds: IntSeconds) {
-        instant -= seconds
-    }
-
-    operator fun minusAssign(milliseconds: LongMilliseconds) {
+    operator fun minusAssign(milliseconds: Milliseconds) {
         instant -= milliseconds
     }
 
-    operator fun minusAssign(milliseconds: IntMilliseconds) {
-        instant -= milliseconds
-    }
-
-    operator fun minusAssign(microseconds: LongMicroseconds) {
+    operator fun minusAssign(microseconds: Microseconds) {
         instant -= microseconds
     }
 
-    operator fun minusAssign(microseconds: IntMicroseconds) {
-        instant -= microseconds
-    }
-
-    operator fun minusAssign(nanoseconds: LongNanoseconds) {
+    operator fun minusAssign(nanoseconds: Nanoseconds) {
         instant -= nanoseconds
     }
 
-    operator fun minusAssign(nanoseconds: IntNanoseconds) {
-        instant -= nanoseconds
-    }
-
-    override fun readMilliseconds(): LongMilliseconds {
+    override fun readMilliseconds(): Milliseconds {
         return instant.millisecondsSinceUnixEpoch
     }
 

--- a/core/src/commonMain/kotlin/io/islandtime/internal/RoundImpl.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/internal/RoundImpl.kt
@@ -5,61 +5,51 @@ import io.islandtime.Time
 import io.islandtime.measures.*
 import io.islandtime.startOfDay
 
-internal fun checkRoundingIncrement(increment: IntHours) {
+internal fun checkRoundingIncrement(increment: Hours) {
     require(increment.value in 1..HOURS_PER_DAY) {
         "The increment must be greater than zero and no more than 24 hours"
     }
 
-    require(HOURS_PER_DAY % increment.value == 0) {
+    require(HOURS_PER_DAY % increment.value == 0L) {
         "The increment must multiply evenly into a 24-hour day"
     }
 }
 
-internal fun checkRoundingIncrement(increment: IntMinutes) {
+internal fun checkRoundingIncrement(increment: Minutes) {
     require(increment.value in 1..MINUTES_PER_HOUR) {
         "The increment must be greater than zero and no more than an hour"
     }
 
-    require(MINUTES_PER_HOUR % increment.value == 0) {
+    require(MINUTES_PER_HOUR % increment.value == 0L) {
         "The increment must multiply evenly into an hour"
     }
 }
 
-internal fun checkRoundingIncrement(increment: IntSeconds) {
+internal fun checkRoundingIncrement(increment: Seconds) {
     require(increment.value in 1..SECONDS_PER_MINUTE) {
         "The increment must be greater than zero and no more than a minute"
     }
 
-    require(SECONDS_PER_MINUTE % increment.value == 0) {
+    require(SECONDS_PER_MINUTE % increment.value == 0L) {
         "The increment must multiply evenly into a minute"
     }
 }
 
-internal fun checkRoundingIncrement(increment: IntMilliseconds) {
+internal fun checkRoundingIncrement(increment: Milliseconds) {
     checkFractionalSecondRoundingIncrement(increment.value, MILLISECONDS_PER_SECOND)
 }
 
-internal fun checkRoundingIncrement(increment: IntMicroseconds) {
+internal fun checkRoundingIncrement(increment: Microseconds) {
     checkFractionalSecondRoundingIncrement(increment.value, MICROSECONDS_PER_SECOND)
 }
 
-internal fun checkRoundingIncrement(increment: IntNanoseconds) {
+internal fun checkRoundingIncrement(increment: Nanoseconds) {
     checkFractionalSecondRoundingIncrement(increment.value, NANOSECONDS_PER_SECOND)
 }
 
-internal fun checkRoundingIncrement(increment: LongNanoseconds) {
-    require(increment.value in 1..NANOSECONDS_PER_SECOND) {
-        "The increment must be greater than zero and no more than a second"
-    }
-
-    require(NANOSECONDS_PER_SECOND % increment.value == 0L) {
-        "The increment must multiply evenly into a second"
-    }
-}
-
-private fun checkFractionalSecondRoundingIncrement(value: Int, maxValue: Int) {
+private fun checkFractionalSecondRoundingIncrement(value: Long, maxValue: Int) {
     require(value in 1..maxValue) { "The increment must be greater than zero and no more than a second" }
-    require(maxValue % value == 0) { "The increment must multiply evenly into a second" }
+    require(maxValue % value == 0L) { "The increment must multiply evenly into a second" }
 }
 
 internal fun Time.nextWholeHour(): Time = nextWholeHourOrNull() ?: Time.MIDNIGHT

--- a/core/src/commonMain/kotlin/io/islandtime/internal/WeekNumbers.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/internal/WeekNumbers.kt
@@ -5,7 +5,7 @@ package io.islandtime.internal
 import dev.erikchristensen.javamath2kmp.floorMod
 import io.islandtime.*
 import io.islandtime.calendar.WeekSettings
-import io.islandtime.measures.IntWeeks
+import io.islandtime.measures.Weeks
 import io.islandtime.measures.weeks
 import io.islandtime.measures.years
 
@@ -21,7 +21,7 @@ internal fun Date.weekBasedYearImpl(settings: WeekSettings): Int {
         year - 1
     } else {
         val weekOfNextYear = weekNumber(
-            dayOfMonthOrYear = lengthOfYear.value + settings.minimumDaysInFirstWeek,
+            dayOfMonthOrYear = lengthOfYear.toIntUnchecked() + settings.minimumDaysInFirstWeek,
             startOfWeekOffset = offset
         )
 
@@ -38,7 +38,7 @@ internal fun Date.weekOfWeekBasedYearImpl(settings: WeekSettings): Int {
         (toYear() - 1.years).endDate.weekOfWeekBasedYear(settings)
     } else {
         val weekOfNextYear = weekNumber(
-            dayOfMonthOrYear = lengthOfYear.value + settings.minimumDaysInFirstWeek,
+            dayOfMonthOrYear = lengthOfYear.toIntUnchecked() + settings.minimumDaysInFirstWeek,
             startOfWeekOffset = offset
         )
 
@@ -46,7 +46,7 @@ internal fun Date.weekOfWeekBasedYearImpl(settings: WeekSettings): Int {
     }
 }
 
-internal fun lengthOfWeekBasedYear(weekBasedYear: Int): IntWeeks {
+internal fun lengthOfWeekBasedYear(weekBasedYear: Int): Weeks {
     return lastWeekOfWeekBasedYear(weekBasedYear).weeks
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/measures/Duration.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/measures/Duration.kt
@@ -113,44 +113,44 @@ class Duration private constructor(
         ReplaceWith("truncatedTo(DAYS)", "io.islandtime.measures.TimeUnit.DAYS"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToDays() = truncatedTo(DAYS)
+    fun truncatedToDays(): Duration = truncatedTo(DAYS)
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(HOURS)", "io.islandtime.measures.TimeUnit.HOURS"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToHours() = truncatedTo(HOURS)
+    fun truncatedToHours(): Duration = truncatedTo(HOURS)
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(MINUTES)", "io.islandtime.measures.TimeUnit.MINUTES"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToMinutes() = truncatedTo(MINUTES)
+    fun truncatedToMinutes(): Duration = truncatedTo(MINUTES)
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(SECONDS)", "io.islandtime.measures.TimeUnit.SECONDS"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToSeconds() = truncatedTo(SECONDS)
+    fun truncatedToSeconds(): Duration = truncatedTo(SECONDS)
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(MILLISECONDS)", "io.islandtime.measures.TimeUnit.MILLISECONDS"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToMilliseconds() = truncatedTo(MILLISECONDS)
+    fun truncatedToMilliseconds(): Duration = truncatedTo(MILLISECONDS)
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(MICROSECONDS)", "io.islandtime.measures.TimeUnit.MICROSECONDS"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToMicroseconds() = truncatedTo(MICROSECONDS)
+    fun truncatedToMicroseconds(): Duration = truncatedTo(MICROSECONDS)
 
-    operator fun unaryMinus() = create(-seconds, nanosecondAdjustment.negateUnchecked())
+    operator fun unaryMinus(): Duration = create(-seconds, nanosecondAdjustment.negateUnchecked())
 
     operator fun plus(other: Duration): Duration {
         return when {
@@ -160,19 +160,19 @@ class Duration private constructor(
         }
     }
 
-    operator fun plus(days: IntDays) = plus(days.toLongDays().inSecondsUnchecked, 0.nanoseconds)
-    operator fun plus(days: LongDays) = plus(days.inSeconds, 0.nanoseconds)
+    operator fun plus(days: IntDays): Duration = plus(days.toLongDays().inSecondsUnchecked, 0.nanoseconds)
+    operator fun plus(days: LongDays): Duration = plus(days.inSeconds, 0.nanoseconds)
 
-    operator fun plus(hours: IntHours) = plus(hours.toLongHours().inSecondsUnchecked, 0.nanoseconds)
-    operator fun plus(hours: LongHours) = plus(hours.inSeconds, 0.nanoseconds)
+    operator fun plus(hours: IntHours): Duration = plus(hours.toLongHours().inSecondsUnchecked, 0.nanoseconds)
+    operator fun plus(hours: LongHours): Duration = plus(hours.inSeconds, 0.nanoseconds)
 
-    operator fun plus(minutes: IntMinutes) = plus(minutes.toLongMinutes().inSecondsUnchecked, 0.nanoseconds)
-    operator fun plus(minutes: LongMinutes) = plus(minutes.inSeconds, 0.nanoseconds)
+    operator fun plus(minutes: IntMinutes): Duration = plus(minutes.toLongMinutes().inSecondsUnchecked, 0.nanoseconds)
+    operator fun plus(minutes: LongMinutes): Duration = plus(minutes.inSeconds, 0.nanoseconds)
 
-    operator fun plus(seconds: IntSeconds) = plus(seconds.toLongSeconds(), 0.nanoseconds)
-    operator fun plus(seconds: LongSeconds) = plus(seconds, 0.nanoseconds)
+    operator fun plus(seconds: IntSeconds): Duration = plus(seconds.toLongSeconds(), 0.nanoseconds)
+    operator fun plus(seconds: LongSeconds): Duration = plus(seconds, 0.nanoseconds)
 
-    operator fun plus(milliseconds: IntMilliseconds) = plus(milliseconds.inNanoseconds)
+    operator fun plus(milliseconds: IntMilliseconds): Duration = plus(milliseconds.inNanoseconds)
 
     operator fun plus(milliseconds: LongMilliseconds): Duration {
         return plus(
@@ -181,7 +181,7 @@ class Duration private constructor(
         )
     }
 
-    operator fun plus(microseconds: IntMicroseconds) = plus(microseconds.inNanoseconds)
+    operator fun plus(microseconds: IntMicroseconds): Duration = plus(microseconds.inNanoseconds)
 
     operator fun plus(microseconds: LongMicroseconds): Duration {
         return plus(
@@ -190,7 +190,7 @@ class Duration private constructor(
         )
     }
 
-    operator fun plus(nanoseconds: IntNanoseconds) = plus(nanoseconds.toLongNanoseconds())
+    operator fun plus(nanoseconds: IntNanoseconds): Duration = plus(nanoseconds.toLongNanoseconds())
 
     operator fun plus(nanoseconds: LongNanoseconds): Duration {
         return plus(
@@ -210,7 +210,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(days: IntDays) = plus(days.toLongDays().negateUnchecked())
+    operator fun minus(days: IntDays): Duration = plus(days.toLongDays().negateUnchecked())
 
     operator fun minus(days: LongDays): Duration {
         return if (days.value == Long.MIN_VALUE) {
@@ -220,7 +220,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(hours: IntHours) = plus(hours.toLongHours().negateUnchecked())
+    operator fun minus(hours: IntHours): Duration = plus(hours.toLongHours().negateUnchecked())
 
     operator fun minus(hours: LongHours): Duration {
         return if (hours.value == Long.MIN_VALUE) {
@@ -230,7 +230,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(minutes: IntMinutes) = plus(minutes.toLongMinutes().negateUnchecked())
+    operator fun minus(minutes: IntMinutes): Duration = plus(minutes.toLongMinutes().negateUnchecked())
 
     operator fun minus(minutes: LongMinutes): Duration {
         return if (minutes.value == Long.MIN_VALUE) {
@@ -240,7 +240,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(seconds: IntSeconds) = plus(seconds.toLongSeconds().negateUnchecked())
+    operator fun minus(seconds: IntSeconds): Duration = plus(seconds.toLongSeconds().negateUnchecked())
 
     operator fun minus(seconds: LongSeconds): Duration {
         return if (seconds.value == Long.MIN_VALUE) {
@@ -250,7 +250,8 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(milliseconds: IntMilliseconds) = plus(milliseconds.toLongMilliseconds().negateUnchecked())
+    operator fun minus(milliseconds: IntMilliseconds): Duration =
+        plus(milliseconds.toLongMilliseconds().negateUnchecked())
 
     operator fun minus(milliseconds: LongMilliseconds): Duration {
         return if (milliseconds.value == Long.MIN_VALUE) {
@@ -260,7 +261,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(microseconds: IntMicroseconds) = plus(microseconds.toLongMicroseconds().negateUnchecked())
+    operator fun minus(microseconds: IntMicroseconds): Duration = plus(microseconds.toLongMicroseconds().negateUnchecked())
 
     operator fun minus(microseconds: LongMicroseconds): Duration {
         return if (microseconds.value == Long.MIN_VALUE) {
@@ -270,7 +271,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(nanoseconds: IntNanoseconds) = plus(nanoseconds.toLongNanoseconds().negateUnchecked())
+    operator fun minus(nanoseconds: IntNanoseconds): Duration = plus(nanoseconds.toLongNanoseconds().negateUnchecked())
 
     operator fun minus(nanoseconds: LongNanoseconds): Duration {
         return if (nanoseconds.value == Long.MIN_VALUE) {
@@ -430,17 +431,17 @@ class Duration private constructor(
         /**
          * The minimum supported [Duration].
          */
-        val MIN = Duration(Long.MIN_VALUE.seconds, (-999_999_999).nanoseconds)
+        val MIN: Duration = Duration(Long.MIN_VALUE.seconds, (-999_999_999).nanoseconds)
 
         /**
          * The maximum supported [Duration].
          */
-        val MAX = Duration(Long.MAX_VALUE.seconds, 999_999_999.nanoseconds)
+        val MAX: Duration = Duration(Long.MAX_VALUE.seconds, 999_999_999.nanoseconds)
 
         /**
          * A [Duration] of zero length.
          */
-        val ZERO = Duration(0L.seconds)
+        val ZERO: Duration = Duration(0L.seconds)
 
         internal fun create(
             seconds: LongSeconds,
@@ -633,24 +634,24 @@ internal fun StringBuilder.appendDuration(duration: Duration): StringBuilder {
     duration.toComponents { hours, minutes, seconds, nanoseconds ->
         append("PT")
 
-        if (!hours.isZero()) {
+        if (hours != 0L.hours) {
             append(hours.value)
             append('H')
         }
 
-        if (!minutes.isZero()) {
+        if (minutes != 0.minutes) {
             append(minutes.value)
             append('M')
         }
 
-        if (!seconds.isZero() || !nanoseconds.isZero()) {
+        if (seconds != 0.seconds || nanoseconds != 0.nanoseconds) {
             if (seconds.value == 0 && nanoseconds.value < 0) {
                 append('-')
             }
 
             append(seconds.value)
 
-            if (!nanoseconds.isZero()) {
+            if (nanoseconds != 0.nanoseconds) {
                 append('.')
                 append(
                     nanoseconds.value.absoluteValue
@@ -669,12 +670,12 @@ internal fun StringBuilder.appendDuration(duration: Duration): StringBuilder {
  * Multiplies this value by a duration.
  * @throws ArithmeticException if overflow occurs
  */
-operator fun Int.times(duration: Duration) = duration * this
+operator fun Int.times(duration: Duration): Duration = duration * this
 
 /**
  * Converts an ISO-8601 duration string to a [Duration].
  */
-fun String.toDuration() = toDuration(DateTimeParsers.Iso.DURATION)
+fun String.toDuration(): Duration = toDuration(DateTimeParsers.Iso.DURATION)
 
 /**
  * Converts a string to a [Duration] using [parser].

--- a/core/src/commonMain/kotlin/io/islandtime/measures/Duration.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/measures/Duration.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalContracts::class)
+
 package io.islandtime.measures
 
 import dev.erikchristensen.javamath2kmp.negateExact
@@ -312,7 +314,6 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components, assuming a 24-hour day length.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponentValues(
         action: (
             days: Long,
@@ -329,7 +330,6 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponentValues(
         action: (
             hours: Long,
@@ -345,7 +345,6 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponentValues(
         action: (
             minutes: Long,
@@ -360,7 +359,6 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponentValues(
         action: (
             seconds: Long,
@@ -374,7 +372,6 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components, assuming a 24-hour day length.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponents(
         action: (
             days: Days,
@@ -394,7 +391,6 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponents(
         action: (
             hours: Hours,
@@ -413,7 +409,6 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponents(
         action: (
             minutes: Minutes,
@@ -431,7 +426,6 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components.
      */
-    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponents(
         action: (
             seconds: Seconds,

--- a/core/src/commonMain/kotlin/io/islandtime/measures/Duration.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/measures/Duration.kt
@@ -1,28 +1,35 @@
 package io.islandtime.measures
 
+import dev.erikchristensen.javamath2kmp.negateExact
 import io.islandtime.base.DateTimeField
 import io.islandtime.internal.*
 import io.islandtime.measures.Duration.Companion.create
 import io.islandtime.measures.TimeUnit.*
-import io.islandtime.measures.internal.plusWithOverflow
+import io.islandtime.measures.internal.plusUnchecked
 import io.islandtime.parser.DateTimeParseResult
 import io.islandtime.parser.DateTimeParser
 import io.islandtime.parser.DateTimeParserSettings
 import io.islandtime.parser.DateTimeParsers
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.math.absoluteValue
 
 /**
  * A duration of time at nanosecond precision.
  *
- * For many applications, working with specific units like [IntHours] or [LongSeconds] is more efficient and plenty
- * adequate. However, when working with larger durations at sub-second precision, overflow is a very real possibility.
- * `Duration` is capable of representing fixed, nanosecond-precision durations that span the entire supported time
- * scale, making it more suitable for these use cases.
+ * For many applications, working with specific units like [Hours] or [Seconds] is more efficient and plenty adequate.
+ * However, when working with larger durations at sub-second precision, overflow is a very real possibility. `Duration`
+ * is capable of representing fixed, nanosecond-precision durations that span the entire supported time scale, making it
+ * more suitable for these use cases.
  */
 class Duration private constructor(
-    val seconds: LongSeconds,
-    val nanosecondAdjustment: IntNanoseconds = 0.nanoseconds
+    @PublishedApi internal val secondValue: Long,
+    @PublishedApi internal val nanosecondValue: Int = 0
 ) : Comparable<Duration> {
+
+    val seconds: Seconds get() = secondValue.seconds
+    val nanosecondAdjustment: Nanoseconds get() = nanosecondValue.nanoseconds
 
     /**
      * Checks if this duration is zero.
@@ -32,12 +39,12 @@ class Duration private constructor(
     /**
      * Checks if this duration is positive.
      */
-    fun isPositive(): Boolean = seconds.value > 0L || nanosecondAdjustment.value > 0
+    fun isPositive(): Boolean = secondValue > 0L || nanosecondValue > 0
 
     /**
      * Checks if this duration is negative.
      */
-    fun isNegative(): Boolean = seconds.value < 0L || nanosecondAdjustment.value < 0
+    fun isNegative(): Boolean = secondValue < 0L || nanosecondValue < 0
 
     /**
      * The absolute value of this duration.
@@ -48,61 +55,73 @@ class Duration private constructor(
     /**
      * Converts this duration into the number of 24-hour days represented by it.
      */
-    inline val inDays: LongDays get() = seconds.inDays
+    inline val inDays: Days get() = seconds.inWholeDays
 
     /**
      * Converts this duration into the number of whole hours represented by it.
      */
-    inline val inHours: LongHours get() = seconds.inHours
+    inline val inHours: Hours get() = seconds.inWholeHours
 
     /**
      * Converts this duration into the number of whole minutes represented by it.
      */
-    inline val inMinutes: LongMinutes get() = seconds.inMinutes
+    inline val inMinutes: Minutes get() = seconds.inWholeMinutes
 
     /**
      * Returns the number of whole seconds in this duration.
      * @see seconds
      */
-    inline val inSeconds: LongSeconds get() = seconds
+    inline val inSeconds: Seconds get() = seconds
 
     /**
      * Converts this duration into the number of whole milliseconds represented by it.
      * @throws ArithmeticException if the duration cannot be represented without overflow
      */
-    val inMilliseconds: LongMilliseconds
-        get() = seconds.inMilliseconds + nanosecondAdjustment.inMilliseconds.toLongMilliseconds()
+    val inMilliseconds: Milliseconds
+        get() = seconds + nanosecondAdjustment.inWholeMilliseconds
 
     /**
      * Converts this duration into the number of whole microseconds represented by it.
      * @throws ArithmeticException if the duration cannot be represented without overflow
      */
-    val inMicroseconds: LongMicroseconds
-        get() = seconds.inMicroseconds + nanosecondAdjustment.inMicroseconds.toLongMicroseconds()
+    val inMicroseconds: Microseconds
+        get() = seconds + nanosecondAdjustment.inWholeMicroseconds
 
     /**
-     * Converts this duration into [LongNanoseconds].
+     * Converts this duration into [Nanoseconds].
      * @throws ArithmeticException if the duration cannot be represented without overflow
      */
-    val inNanoseconds: LongNanoseconds
-        get() = seconds.inNanoseconds + nanosecondAdjustment
+    val inNanoseconds: Nanoseconds
+        get() = seconds + nanosecondAdjustment
+
+    @PublishedApi
+    internal val hoursComponent: Int
+        get() = ((secondValue % SECONDS_PER_DAY) / SECONDS_PER_HOUR).toInt()
+
+    @PublishedApi
+    internal val minutesComponent: Int
+        get() = ((secondValue % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE).toInt()
+
+    @PublishedApi
+    internal val secondsComponent: Int
+        get() = (secondValue % SECONDS_PER_MINUTE).toInt()
 
     /**
      * Returns this duration, rounded down to match the precision of a given [unit].
      */
     fun truncatedTo(unit: TimeUnit): Duration {
         return when (unit) {
-            DAYS -> create(seconds / SECONDS_PER_DAY * SECONDS_PER_DAY, 0.nanoseconds)
-            HOURS -> create(seconds / SECONDS_PER_HOUR * SECONDS_PER_HOUR, 0.nanoseconds)
-            MINUTES -> create(seconds / SECONDS_PER_MINUTE * SECONDS_PER_MINUTE, 0.nanoseconds)
-            SECONDS -> create(seconds, 0.nanoseconds)
+            DAYS -> create(secondValue / SECONDS_PER_DAY * SECONDS_PER_DAY, 0)
+            HOURS -> create(secondValue / SECONDS_PER_HOUR * SECONDS_PER_HOUR, 0)
+            MINUTES -> create(secondValue / SECONDS_PER_MINUTE * SECONDS_PER_MINUTE, 0)
+            SECONDS -> create(secondValue, 0)
             MILLISECONDS -> create(
-                seconds,
-                (nanosecondAdjustment.value / NANOSECONDS_PER_MILLISECOND * NANOSECONDS_PER_MILLISECOND).nanoseconds
+                secondValue,
+                nanosecondValue / NANOSECONDS_PER_MILLISECOND * NANOSECONDS_PER_MILLISECOND
             )
             MICROSECONDS -> create(
-                seconds,
-                (nanosecondAdjustment.value / NANOSECONDS_PER_MICROSECOND * NANOSECONDS_PER_MICROSECOND).nanoseconds
+                secondValue,
+                nanosecondValue / NANOSECONDS_PER_MICROSECOND * NANOSECONDS_PER_MICROSECOND
             )
             NANOSECONDS -> this
         }
@@ -113,44 +132,44 @@ class Duration private constructor(
         ReplaceWith("truncatedTo(DAYS)", "io.islandtime.measures.TimeUnit.DAYS"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToDays(): Duration = truncatedTo(DAYS)
+    fun truncatedToDays(): Duration = deprecatedToError()
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(HOURS)", "io.islandtime.measures.TimeUnit.HOURS"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToHours(): Duration = truncatedTo(HOURS)
+    fun truncatedToHours(): Duration = deprecatedToError()
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(MINUTES)", "io.islandtime.measures.TimeUnit.MINUTES"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToMinutes(): Duration = truncatedTo(MINUTES)
+    fun truncatedToMinutes(): Duration = deprecatedToError()
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(SECONDS)", "io.islandtime.measures.TimeUnit.SECONDS"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToSeconds(): Duration = truncatedTo(SECONDS)
+    fun truncatedToSeconds(): Duration = deprecatedToError()
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(MILLISECONDS)", "io.islandtime.measures.TimeUnit.MILLISECONDS"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToMilliseconds(): Duration = truncatedTo(MILLISECONDS)
+    fun truncatedToMilliseconds(): Duration = deprecatedToError()
 
     @Deprecated(
         "Use truncatedTo().",
         ReplaceWith("truncatedTo(MICROSECONDS)", "io.islandtime.measures.TimeUnit.MICROSECONDS"),
         DeprecationLevel.ERROR
     )
-    fun truncatedToMicroseconds(): Duration = truncatedTo(MICROSECONDS)
+    fun truncatedToMicroseconds(): Duration = deprecatedToError()
 
-    operator fun unaryMinus(): Duration = create(-seconds, nanosecondAdjustment.negateUnchecked())
+    operator fun unaryMinus(): Duration = create(secondValue.negateExact(), -nanosecondValue)
 
     operator fun plus(other: Duration): Duration {
         return when {
@@ -160,59 +179,44 @@ class Duration private constructor(
         }
     }
 
-    operator fun plus(days: IntDays): Duration = plus(days.toLongDays().inSecondsUnchecked, 0.nanoseconds)
-    operator fun plus(days: LongDays): Duration = plus(days.inSeconds, 0.nanoseconds)
+    operator fun plus(days: Days): Duration = plus(days.inSeconds, 0.nanoseconds)
+    operator fun plus(hours: Hours): Duration = plus(hours.inSeconds, 0.nanoseconds)
+    operator fun plus(minutes: Minutes): Duration = plus(minutes.inSeconds, 0.nanoseconds)
+    operator fun plus(seconds: Seconds): Duration = plus(seconds, 0.nanoseconds)
 
-    operator fun plus(hours: IntHours): Duration = plus(hours.toLongHours().inSecondsUnchecked, 0.nanoseconds)
-    operator fun plus(hours: LongHours): Duration = plus(hours.inSeconds, 0.nanoseconds)
-
-    operator fun plus(minutes: IntMinutes): Duration = plus(minutes.toLongMinutes().inSecondsUnchecked, 0.nanoseconds)
-    operator fun plus(minutes: LongMinutes): Duration = plus(minutes.inSeconds, 0.nanoseconds)
-
-    operator fun plus(seconds: IntSeconds): Duration = plus(seconds.toLongSeconds(), 0.nanoseconds)
-    operator fun plus(seconds: LongSeconds): Duration = plus(seconds, 0.nanoseconds)
-
-    operator fun plus(milliseconds: IntMilliseconds): Duration = plus(milliseconds.inNanoseconds)
-
-    operator fun plus(milliseconds: LongMilliseconds): Duration {
+    operator fun plus(milliseconds: Milliseconds): Duration {
         return plus(
-            milliseconds.inSeconds,
-            ((milliseconds.value % MILLISECONDS_PER_SECOND).toInt() * NANOSECONDS_PER_MILLISECOND).nanoseconds
+            milliseconds.inWholeSeconds,
+            ((milliseconds.value % MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND).nanoseconds
         )
     }
 
-    operator fun plus(microseconds: IntMicroseconds): Duration = plus(microseconds.inNanoseconds)
-
-    operator fun plus(microseconds: LongMicroseconds): Duration {
+    operator fun plus(microseconds: Microseconds): Duration {
         return plus(
-            microseconds.inSeconds,
-            ((microseconds.value % MICROSECONDS_PER_SECOND).toInt() * NANOSECONDS_PER_MICROSECOND).nanoseconds
+            microseconds.inWholeSeconds,
+            ((microseconds.value % MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND).nanoseconds
         )
     }
 
-    operator fun plus(nanoseconds: IntNanoseconds): Duration = plus(nanoseconds.toLongNanoseconds())
-
-    operator fun plus(nanoseconds: LongNanoseconds): Duration {
+    operator fun plus(nanoseconds: Nanoseconds): Duration {
         return plus(
-            nanoseconds.inSeconds,
-            (nanoseconds % NANOSECONDS_PER_SECOND).toIntNanosecondsUnchecked()
+            nanoseconds.inWholeSeconds,
+            nanoseconds % NANOSECONDS_PER_SECOND
         )
     }
 
     operator fun minus(other: Duration): Duration {
-        return if (other.seconds.value == Long.MIN_VALUE) {
+        return if (other.secondValue == Long.MIN_VALUE) {
             plus(
                 Long.MAX_VALUE.seconds,
-                other.nanosecondAdjustment.negateUnchecked() plusWithOverflow 1.seconds
+                other.nanosecondAdjustment.negateUnchecked() plusUnchecked 1.seconds
             )
         } else {
             plus(other.seconds.negateUnchecked(), other.nanosecondAdjustment.negateUnchecked())
         }
     }
 
-    operator fun minus(days: IntDays): Duration = plus(days.toLongDays().negateUnchecked())
-
-    operator fun minus(days: LongDays): Duration {
+    operator fun minus(days: Days): Duration {
         return if (days.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.days + 1.days
         } else {
@@ -220,9 +224,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(hours: IntHours): Duration = plus(hours.toLongHours().negateUnchecked())
-
-    operator fun minus(hours: LongHours): Duration {
+    operator fun minus(hours: Hours): Duration {
         return if (hours.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.hours + 1.hours
         } else {
@@ -230,9 +232,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(minutes: IntMinutes): Duration = plus(minutes.toLongMinutes().negateUnchecked())
-
-    operator fun minus(minutes: LongMinutes): Duration {
+    operator fun minus(minutes: Minutes): Duration {
         return if (minutes.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.minutes + 1.minutes
         } else {
@@ -240,9 +240,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(seconds: IntSeconds): Duration = plus(seconds.toLongSeconds().negateUnchecked())
-
-    operator fun minus(seconds: LongSeconds): Duration {
+    operator fun minus(seconds: Seconds): Duration {
         return if (seconds.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.seconds + 1.seconds
         } else {
@@ -250,10 +248,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(milliseconds: IntMilliseconds): Duration =
-        plus(milliseconds.toLongMilliseconds().negateUnchecked())
-
-    operator fun minus(milliseconds: LongMilliseconds): Duration {
+    operator fun minus(milliseconds: Milliseconds): Duration {
         return if (milliseconds.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.milliseconds + 1.milliseconds
         } else {
@@ -261,9 +256,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(microseconds: IntMicroseconds): Duration = plus(microseconds.toLongMicroseconds().negateUnchecked())
-
-    operator fun minus(microseconds: LongMicroseconds): Duration {
+    operator fun minus(microseconds: Microseconds): Duration {
         return if (microseconds.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.microseconds + 1.microseconds
         } else {
@@ -271,9 +264,7 @@ class Duration private constructor(
         }
     }
 
-    operator fun minus(nanoseconds: IntNanoseconds): Duration = plus(nanoseconds.toLongNanoseconds().negateUnchecked())
-
-    operator fun minus(nanoseconds: LongNanoseconds): Duration {
+    operator fun minus(nanoseconds: Nanoseconds): Duration {
         return if (nanoseconds.value == Long.MIN_VALUE) {
             this + Long.MAX_VALUE.nanoseconds + 1.nanoseconds
         } else {
@@ -292,9 +283,9 @@ class Duration private constructor(
             else -> {
                 var newSeconds = seconds * scalar
                 var newNanoseconds = nanosecondAdjustment * scalar
-                newSeconds += newNanoseconds.inSeconds
+                newSeconds += newNanoseconds.inWholeSeconds
                 newNanoseconds %= NANOSECONDS_PER_SECOND
-                create(newSeconds, newNanoseconds.toIntNanosecondsUnchecked())
+                create(newSeconds.value, newNanoseconds.toIntUnchecked())
             }
         }
     }
@@ -309,11 +300,11 @@ class Duration private constructor(
             1 -> this
             -1 -> -this
             else -> {
-                val fractionalSeconds = seconds.value.toDouble() / scalar
-                val newSeconds = fractionalSeconds.toLong()
-                val newNanoseconds = nanosecondAdjustment.value / scalar +
-                    ((fractionalSeconds - newSeconds) * NANOSECONDS_PER_SECOND).toInt()
-                create(newSeconds.seconds, newNanoseconds.nanoseconds)
+                val fractionalSeconds = secondValue.toDouble() / scalar
+                val newSecondValue = fractionalSeconds.toLong()
+                val newNanosecondValue = nanosecondValue / scalar +
+                    ((fractionalSeconds - newSecondValue) * NANOSECONDS_PER_SECOND).toInt()
+                create(newSecondValue, newNanosecondValue)
             }
         }
     }
@@ -321,15 +312,80 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components, assuming a 24-hour day length.
      */
-    inline fun <T> toComponents(
+    @OptIn(ExperimentalContracts::class)
+    inline fun <T> toComponentValues(
         action: (
-            days: LongDays,
-            hours: IntHours,
-            minutes: IntMinutes,
-            seconds: IntSeconds,
-            nanoseconds: IntNanoseconds
+            days: Long,
+            hours: Int,
+            minutes: Int,
+            seconds: Int,
+            nanoseconds: Int
         ) -> T
     ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
+        return action(seconds.inWholeDays.value, hoursComponent, minutesComponent, secondsComponent, nanosecondValue)
+    }
+
+    /**
+     * Breaks this duration down into individual unit components.
+     */
+    @OptIn(ExperimentalContracts::class)
+    inline fun <T> toComponentValues(
+        action: (
+            hours: Long,
+            minutes: Int,
+            seconds: Int,
+            nanoseconds: Int
+        ) -> T
+    ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
+        return action(seconds.inWholeHours.value, minutesComponent, secondsComponent, nanosecondValue)
+    }
+
+    /**
+     * Breaks this duration down into individual unit components.
+     */
+    @OptIn(ExperimentalContracts::class)
+    inline fun <T> toComponentValues(
+        action: (
+            minutes: Long,
+            seconds: Int,
+            nanoseconds: Int
+        ) -> T
+    ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
+        return action(seconds.inWholeMinutes.value, secondsComponent, nanosecondValue)
+    }
+
+    /**
+     * Breaks this duration down into individual unit components.
+     */
+    @OptIn(ExperimentalContracts::class)
+    inline fun <T> toComponentValues(
+        action: (
+            seconds: Long,
+            nanoseconds: Int
+        ) -> T
+    ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
+        return action(secondValue, nanosecondValue)
+    }
+
+    /**
+     * Breaks this duration down into individual unit components, assuming a 24-hour day length.
+     */
+    @OptIn(ExperimentalContracts::class)
+    inline fun <T> toComponents(
+        action: (
+            days: Days,
+            hours: Hours,
+            minutes: Minutes,
+            seconds: Seconds,
+            nanoseconds: Nanoseconds
+        ) -> T
+    ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
+
         return seconds.toComponents { days, hours, minutes, seconds ->
             action(days, hours, minutes, seconds, nanosecondAdjustment)
         }
@@ -338,14 +394,17 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components.
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponents(
         action: (
-            hours: LongHours,
-            minutes: IntMinutes,
-            seconds: IntSeconds,
-            nanoseconds: IntNanoseconds
+            hours: Hours,
+            minutes: Minutes,
+            seconds: Seconds,
+            nanoseconds: Nanoseconds
         ) -> T
     ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
+
         return seconds.toComponents { hours, minutes, seconds ->
             action(hours, minutes, seconds, nanosecondAdjustment)
         }
@@ -354,13 +413,16 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components.
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponents(
         action: (
-            minutes: LongMinutes,
-            seconds: IntSeconds,
-            nanoseconds: IntNanoseconds
+            minutes: Minutes,
+            seconds: Seconds,
+            nanoseconds: Nanoseconds
         ) -> T
     ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
+
         return seconds.toComponents { minutes, seconds ->
             action(minutes, seconds, nanosecondAdjustment)
         }
@@ -369,12 +431,14 @@ class Duration private constructor(
     /**
      * Breaks this duration down into individual unit components.
      */
+    @OptIn(ExperimentalContracts::class)
     inline fun <T> toComponents(
         action: (
-            seconds: LongSeconds,
-            nanoseconds: IntNanoseconds
+            seconds: Seconds,
+            nanoseconds: Nanoseconds
         ) -> T
     ): T {
+        contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
         return action(seconds, nanosecondAdjustment)
     }
 
@@ -390,12 +454,12 @@ class Duration private constructor(
     override fun equals(other: Any?): Boolean {
         return other === this ||
             (other is Duration &&
-                other.seconds == seconds &&
-                other.nanosecondAdjustment == nanosecondAdjustment)
+                other.secondValue == secondValue &&
+                other.nanosecondValue == nanosecondValue)
     }
 
     override fun hashCode(): Int {
-        return 31 * seconds.hashCode() + nanosecondAdjustment.hashCode()
+        return 31 * secondValue.hashCode() + nanosecondValue
     }
 
     override fun toString(): String {
@@ -407,22 +471,22 @@ class Duration private constructor(
     }
 
     override fun compareTo(other: Duration): Int {
-        val secondsDiff = seconds.value.compareTo(other.seconds.value)
+        val secondsDiff = secondValue.compareTo(other.secondValue)
 
         return if (secondsDiff != 0) {
             secondsDiff
         } else {
-            nanosecondAdjustment.value - other.nanosecondAdjustment.value
+            nanosecondValue - other.nanosecondValue
         }
     }
 
-    private fun plus(secondsToAdd: LongSeconds, nanosecondsToAdd: IntNanoseconds): Duration {
-        return if (secondsToAdd.value == 0L && nanosecondsToAdd.value == 0) {
+    private fun plus(secondsToAdd: Seconds, nanosecondsToAdd: Nanoseconds): Duration {
+        return if (secondsToAdd.value == 0L && nanosecondsToAdd.value == 0L) {
             this
         } else {
             durationOf(
                 seconds + secondsToAdd,
-                nanosecondAdjustment plusWithOverflow nanosecondsToAdd
+                (nanosecondValue + nanosecondsToAdd.value).nanoseconds
             )
         }
     }
@@ -431,26 +495,23 @@ class Duration private constructor(
         /**
          * The minimum supported [Duration].
          */
-        val MIN: Duration = Duration(Long.MIN_VALUE.seconds, (-999_999_999).nanoseconds)
+        val MIN: Duration = Duration(Long.MIN_VALUE, -999_999_999)
 
         /**
          * The maximum supported [Duration].
          */
-        val MAX: Duration = Duration(Long.MAX_VALUE.seconds, 999_999_999.nanoseconds)
+        val MAX: Duration = Duration(Long.MAX_VALUE, 999_999_999)
 
         /**
          * A [Duration] of zero length.
          */
-        val ZERO: Duration = Duration(0L.seconds)
+        val ZERO: Duration = Duration(0L)
 
-        internal fun create(
-            seconds: LongSeconds,
-            nanosecondAdjustment: IntNanoseconds = 0.nanoseconds
-        ): Duration {
-            return if (seconds.value == 0L && nanosecondAdjustment.value == 0) {
+        internal fun create(secondValue: Long, nanosecondValue: Int = 0): Duration {
+            return if (secondValue == 0L && nanosecondValue == 0) {
                 ZERO
             } else {
-                Duration(seconds, nanosecondAdjustment)
+                Duration(secondValue, nanosecondValue)
             }
         }
     }
@@ -462,141 +523,70 @@ class Duration private constructor(
  * @param seconds the number of seconds in the duration
  * @param nanoseconds the number of additional nanoseconds to be applied on top of [seconds]
  */
-fun durationOf(
-    seconds: IntSeconds,
-    nanoseconds: IntNanoseconds
-) = durationOf(seconds.toLongSeconds(), nanoseconds.toLongNanoseconds())
+fun durationOf(seconds: Seconds, nanoseconds: Nanoseconds): Duration {
+    var secondValue = (seconds + nanoseconds.inWholeSeconds).value
+    var nanosecondValue = (nanoseconds % NANOSECONDS_PER_SECOND).toIntUnchecked()
 
-/**
- * Creates a [Duration].
- *
- * @param seconds the number of seconds in the duration
- * @param nanoseconds the number of additional nanoseconds to be applied on top of [seconds]
- */
-fun durationOf(
-    seconds: LongSeconds,
-    nanoseconds: IntNanoseconds
-) = durationOf(seconds, nanoseconds.toLongNanoseconds())
-
-/**
- * Creates a [Duration].
- *
- * @param seconds the number of seconds in the duration
- * @param nanoseconds the number of additional nanoseconds to be applied on top of [seconds]
- */
-fun durationOf(
-    seconds: IntSeconds,
-    nanoseconds: LongNanoseconds
-) = durationOf(seconds.toLongSeconds(), nanoseconds)
-
-/**
- * Creates a [Duration].
- *
- * @param seconds the number of seconds in the duration
- * @param nanoseconds the number of additional nanoseconds to be applied on top of [seconds]
- */
-fun durationOf(seconds: LongSeconds, nanoseconds: LongNanoseconds): Duration {
-    var adjustedSeconds = seconds + nanoseconds.inSeconds
-    var newNanoOfSeconds = (nanoseconds % NANOSECONDS_PER_SECOND).toIntNanosecondsUnchecked()
-
-    if (newNanoOfSeconds.value < 0 && adjustedSeconds.value > 0) {
-        adjustedSeconds = (adjustedSeconds.value - 1L).seconds
-        newNanoOfSeconds = (newNanoOfSeconds.value + NANOSECONDS_PER_SECOND).nanoseconds
-    } else if (newNanoOfSeconds.value > 0 && adjustedSeconds.value < 0) {
-        adjustedSeconds = (adjustedSeconds.value + 1L).seconds
-        newNanoOfSeconds = (newNanoOfSeconds.value - NANOSECONDS_PER_SECOND).nanoseconds
+    if (nanosecondValue < 0 && secondValue > 0) {
+        secondValue -= 1L
+        nanosecondValue += NANOSECONDS_PER_SECOND
+    } else if (nanosecondValue > 0 && secondValue < 0) {
+        secondValue += 1L
+        nanosecondValue -= NANOSECONDS_PER_SECOND
     }
 
-    return create(adjustedSeconds, newNanoOfSeconds)
+    return create(secondValue, nanosecondValue)
 }
-
-/**
- * Creates a [Duration] of 24-hour days.
- */
-fun durationOf(days: IntDays) = create(days.toLongDays().inSecondsUnchecked)
 
 /**
  * Creates a [Duration] of 24-hour days.
  * @throws ArithmeticException if overflow occurs
  */
-fun durationOf(days: LongDays) = create(days.inSeconds)
-
-/**
- * Creates a [Duration] of hours.
- */
-fun durationOf(hours: IntHours) = create(hours.toLongHours().inSecondsUnchecked)
+fun durationOf(days: Days): Duration = create(days.inSeconds.value)
 
 /**
  * Creates a [Duration] of hours.
  * @throws ArithmeticException if overflow occurs
  */
-fun durationOf(hours: LongHours) = create(hours.inSeconds)
-
-/**
- * Creates a [Duration] of minutes.
- */
-fun durationOf(minutes: IntMinutes) = create(minutes.toLongMinutes().inSecondsUnchecked)
+fun durationOf(hours: Hours): Duration = create(hours.inSeconds.value)
 
 /**
  * Creates a [Duration] of minutes.
  * @throws ArithmeticException if overflow occurs
  */
-fun durationOf(minutes: LongMinutes) = create(minutes.inSeconds)
-
-/**
- * Creates a [Duration] of seconds.
- */
-fun durationOf(seconds: IntSeconds) = create(seconds.toLongSeconds())
+fun durationOf(minutes: Minutes): Duration = create(minutes.inSeconds.value)
 
 /**
  * Creates a [Duration] of seconds.
  * @throws ArithmeticException if overflow occurs
  */
-fun durationOf(seconds: LongSeconds) = create(seconds)
+fun durationOf(seconds: Seconds): Duration = create(seconds.value)
 
 /**
  * Creates a [Duration] of milliseconds.
  */
-fun durationOf(milliseconds: IntMilliseconds) = durationOf(milliseconds.toLongMilliseconds())
-
-/**
- * Creates a [Duration] of milliseconds.
- */
-fun durationOf(milliseconds: LongMilliseconds): Duration {
-    val seconds = milliseconds.inSeconds
-    val nanoOfSeconds = (milliseconds % MILLISECONDS_PER_SECOND).inNanoseconds.toIntNanosecondsUnchecked()
-
-    return create(seconds, nanoOfSeconds)
+fun durationOf(milliseconds: Milliseconds): Duration {
+    val secondValue = milliseconds.inWholeSeconds.value
+    val nanosecondValue = (milliseconds % MILLISECONDS_PER_SECOND).inNanosecondsUnchecked.toIntUnchecked()
+    return create(secondValue, nanosecondValue)
 }
 
 /**
  * Creates a [Duration] of microseconds.
  */
-fun durationOf(microseconds: IntMicroseconds) = durationOf(microseconds.toLongMicroseconds())
-
-/**
- * Creates a [Duration] of microseconds.
- */
-fun durationOf(microseconds: LongMicroseconds): Duration {
-    val seconds = microseconds.inSeconds
-    val nanoOfSeconds = (microseconds % MICROSECONDS_PER_SECOND).inNanoseconds.toIntNanosecondsUnchecked()
-
-    return create(seconds, nanoOfSeconds)
+fun durationOf(microseconds: Microseconds): Duration {
+    val secondValue = microseconds.inWholeSeconds.value
+    val nanosecondValue = (microseconds % MICROSECONDS_PER_SECOND).inNanosecondsUnchecked.toIntUnchecked()
+    return create(secondValue, nanosecondValue)
 }
 
 /**
  * Creates a [Duration] of nanoseconds.
  */
-fun durationOf(nanoseconds: IntNanoseconds) = durationOf(nanoseconds.toLongNanoseconds())
-
-/**
- * Creates a [Duration] of nanoseconds.
- */
-fun durationOf(nanoseconds: LongNanoseconds): Duration {
-    val seconds = nanoseconds.inSeconds
-    val nanoOfSeconds = (nanoseconds % NANOSECONDS_PER_SECOND).toIntNanosecondsUnchecked()
-
-    return create(seconds, nanoOfSeconds)
+fun durationOf(nanoseconds: Nanoseconds): Duration {
+    val secondValue = nanoseconds.inWholeSeconds.value
+    val nanosecondValue = (nanoseconds % NANOSECONDS_PER_SECOND).toIntUnchecked()
+    return create(secondValue, nanosecondValue)
 }
 
 /**
@@ -604,60 +594,46 @@ fun durationOf(nanoseconds: LongNanoseconds): Duration {
  */
 fun abs(duration: Duration) = duration.absoluteValue
 
-fun LongDays.asDuration() = durationOf(this)
-fun LongHours.asDuration() = durationOf(this)
-fun LongMinutes.asDuration() = durationOf(this)
-fun LongSeconds.asDuration() = durationOf(this)
-fun LongMilliseconds.asDuration() = durationOf(this)
-fun LongMicroseconds.asDuration() = durationOf(this)
-fun LongNanoseconds.asDuration() = durationOf(this)
-
-fun IntDays.asDuration() = durationOf(this)
-fun IntHours.asDuration() = durationOf(this)
-fun IntMinutes.asDuration() = durationOf(this)
-fun IntSeconds.asDuration() = durationOf(this)
-fun IntMilliseconds.asDuration() = durationOf(this)
-fun IntMicroseconds.asDuration() = durationOf(this)
-fun IntNanoseconds.asDuration() = durationOf(this)
+fun Days.asDuration(): Duration = durationOf(this)
+fun Hours.asDuration(): Duration = durationOf(this)
+fun Minutes.asDuration(): Duration = durationOf(this)
+fun Seconds.asDuration(): Duration = durationOf(this)
+fun Milliseconds.asDuration(): Duration = durationOf(this)
+fun Microseconds.asDuration(): Duration = durationOf(this)
+fun Nanoseconds.asDuration(): Duration = durationOf(this)
 
 /**
  * Converts this duration to an equivalent Island Time [Duration].
  */
 @kotlin.time.ExperimentalTime
 fun kotlin.time.Duration.toIslandDuration(): Duration {
-    return toComponents { seconds, nanoseconds ->
-        durationOf(seconds.seconds, nanoseconds.nanoseconds)
-    }
+    return toComponents { seconds, nanoseconds -> durationOf(seconds.seconds, nanoseconds.nanoseconds) }
 }
 
 internal fun StringBuilder.appendDuration(duration: Duration): StringBuilder {
-    duration.toComponents { hours, minutes, seconds, nanoseconds ->
+    duration.toComponentValues { hours, minutes, seconds, nanoseconds ->
         append("PT")
 
-        if (hours != 0L.hours) {
-            append(hours.value)
+        if (hours != 0L) {
+            append(hours)
             append('H')
         }
 
-        if (minutes != 0.minutes) {
-            append(minutes.value)
+        if (minutes != 0) {
+            append(minutes)
             append('M')
         }
 
-        if (seconds != 0.seconds || nanoseconds != 0.nanoseconds) {
-            if (seconds.value == 0 && nanoseconds.value < 0) {
+        if (seconds != 0 || nanoseconds != 0) {
+            if (seconds == 0 && nanoseconds < 0) {
                 append('-')
             }
 
-            append(seconds.value)
+            append(seconds)
 
-            if (nanoseconds != 0.nanoseconds) {
+            if (nanoseconds != 0) {
                 append('.')
-                append(
-                    nanoseconds.value.absoluteValue
-                        .toZeroPaddedString(9)
-                        .dropLastWhile { it == '0' }
-                )
+                append(nanoseconds.absoluteValue.toZeroPaddedString(9).dropLastWhile { it == '0' })
             }
 
             append('S')

--- a/core/src/commonMain/kotlin/io/islandtime/measures/Period.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/measures/Period.kt
@@ -1,7 +1,6 @@
 package io.islandtime.measures
 
 import dev.erikchristensen.javamath2kmp.timesExact
-import dev.erikchristensen.javamath2kmp.toIntExact
 import io.islandtime.base.DateTimeField
 import io.islandtime.internal.MONTHS_PER_YEAR
 import io.islandtime.parser.*
@@ -15,16 +14,15 @@ import io.islandtime.parser.*
  * @property days The number of days in this period.
  */
 class Period private constructor(
-    val years: IntYears = 0.years,
-    val months: IntMonths = 0.months,
-    val days: IntDays = 0.days
+    val years: Years = 0.years,
+    val months: Months = 0.months,
+    val days: Days = 0.days
 ) {
 
     /**
      * The total number of months in this period, including years.
      */
-    val totalMonths: LongMonths
-        get() = (years.toLongYears().inMonthsUnchecked.value + months.value).months
+    val totalMonths: Months get() = years + months
 
     /**
      * Checks if this period is zero.
@@ -62,45 +60,37 @@ class Period private constructor(
         days - other.days
     )
 
-    operator fun plus(years: IntYears): Period = copy(years = this.years + years)
-    operator fun plus(months: IntMonths): Period = copy(months = this.months + months)
-    operator fun plus(weeks: IntWeeks): Period = plus(weeks.toLongWeeks().inDaysUnchecked)
-    operator fun plus(days: IntDays): Period = copy(days = this.days + days)
+    operator fun plus(years: Years): Period = copy(years = this.years + years)
+    operator fun plus(months: Months): Period = copy(months = this.months + months)
+    operator fun plus(weeks: Weeks): Period = plus(weeks.inDays)
+    operator fun plus(days: Days): Period = copy(days = this.days + days)
 
-    operator fun plus(years: LongYears): Period = copy(years = (this.years.toLong() + years.value).toIntExact().years)
-    operator fun plus(months: LongMonths): Period =
-        copy(months = (this.months.toLong() + months.value).toIntExact().months)
-
-    operator fun plus(weeks: LongWeeks): Period = plus(weeks.inDays)
-    operator fun plus(days: LongDays): Period = copy(days = (this.days.toLong() + days.value).toIntExact().days)
-
-    operator fun minus(years: IntYears): Period = copy(years = this.years - years)
-    operator fun minus(months: IntMonths): Period = copy(months = this.months - months)
-    operator fun minus(weeks: IntWeeks): Period = minus(weeks.toLongWeeks().inDaysUnchecked)
-    operator fun minus(days: IntDays): Period = copy(days = this.days - days)
-
-    operator fun minus(years: LongYears): Period = copy(years = (this.years.toLong() - years.value).toIntExact().years)
-    operator fun minus(months: LongMonths): Period =
-        copy(months = (this.months.toLong() - months.value).toIntExact().months)
-
-    operator fun minus(weeks: LongWeeks): Period = minus(weeks.inDays)
-    operator fun minus(days: LongDays): Period = copy(days = (this.days.toLong() - days.value).toIntExact().days)
+    operator fun minus(years: Years): Period = copy(years = this.years - years)
+    operator fun minus(months: Months): Period = copy(months = this.months - months)
+    operator fun minus(weeks: Weeks): Period = minus(weeks.inDays)
+    operator fun minus(days: Days): Period = copy(days = this.days - days)
 
     /**
      * Multiplies each component of this period by a scalar value.
      * @throws ArithmeticException if overflow occurs
      */
-    operator fun times(scalar: Int): Period {
-        return if (this.isZero() || scalar == 1) {
+    operator fun times(scalar: Int): Period = times(scalar.toLong())
+
+    /**
+     * Multiplies each component of this period by a scalar value.
+     * @throws ArithmeticException if overflow occurs
+     */
+    operator fun times(scalar: Long): Period {
+        return if (this.isZero() || scalar == 1L) {
             this
         } else {
             create(years * scalar, months * scalar, days * scalar)
         }
     }
 
-    operator fun component1(): IntYears = years
-    operator fun component2(): IntMonths = months
-    operator fun component3(): IntDays = days
+    operator fun component1(): Years = years
+    operator fun component2(): Months = months
+    operator fun component3(): Days = days
 
     /**
      * Normalizes the number of years and months such that "1 year, 15 months" becomes "2 years, 3 months". Only the
@@ -108,8 +98,8 @@ class Period private constructor(
      */
     fun normalized(): Period {
         val monthTotal = totalMonths
-        val newYears = monthTotal.inYears.toIntYears()
-        val newMonths = (monthTotal % MONTHS_PER_YEAR).toIntMonthsUnchecked()
+        val newYears = monthTotal.inWholeYears
+        val newMonths = monthTotal % MONTHS_PER_YEAR
 
         return if (newYears == years && newMonths == months) {
             this
@@ -143,17 +133,17 @@ class Period private constructor(
             buildString {
                 append('P')
 
-                if (years.value != 0) {
+                if (years.value != 0L) {
                     append(years.value)
                     append('Y')
                 }
 
-                if (months.value != 0) {
+                if (months.value != 0L) {
                     append(months.value)
                     append('M')
                 }
 
-                if (days.value != 0) {
+                if (days.value != 0L) {
                     append(days.value)
                     append('D')
                 }
@@ -169,9 +159,9 @@ class Period private constructor(
      * @return a new Period with the supplied values
      */
     fun copy(
-        years: IntYears = this.years,
-        months: IntMonths = this.months,
-        days: IntDays = this.days
+        years: Years = this.years,
+        months: Months = this.months,
+        days: Days = this.days
     ): Period = create(years, months, days)
 
     companion object {
@@ -181,11 +171,11 @@ class Period private constructor(
         val ZERO: Period = Period()
 
         internal fun create(
-            years: IntYears = 0.years,
-            months: IntMonths = 0.months,
-            days: IntDays = 0.days
+            years: Years = 0.years,
+            months: Months = 0.months,
+            days: Days = 0.days
         ): Period {
-            return if (years.value or months.value or days.value == 0) {
+            return if (years.value or months.value or days.value == 0L) {
                 ZERO
             } else {
                 Period(years, months, days)
@@ -197,127 +187,79 @@ class Period private constructor(
 /**
  * Creates a [Period].
  */
-fun periodOf(years: IntYears, months: IntMonths = 0.months, days: IntDays = 0.days): Period {
+fun periodOf(years: Years, months: Months = 0.months, days: Days = 0.days): Period {
     return Period.create(years, months, days)
 }
 
 /**
  * Creates a [Period].
  */
-fun periodOf(years: IntYears, days: IntDays): Period = Period.create(years = years, days = days)
+fun periodOf(years: Years, days: Days): Period = Period.create(years = years, days = days)
 
 /**
  * Creates a [Period].
  */
-fun periodOf(months: IntMonths, days: IntDays = 0.days): Period = Period.create(months = months, days = days)
+fun periodOf(months: Months, days: Days = 0.days): Period = Period.create(months = months, days = days)
 
 /**
  * Creates a [Period].
  * @throws ArithmeticException if overflow occurs
  */
-fun periodOf(weeks: IntWeeks): Period = Period.create(days = weeks.inDays)
+fun periodOf(weeks: Weeks): Period = Period.create(days = weeks.inDays)
 
 /**
  * Creates a [Period].
  */
-fun periodOf(days: IntDays): Period = Period.create(days = days)
+fun periodOf(days: Days): Period = Period.create(days = days)
 
 /**
  * Converts this duration into a [Period] with the same number of years.
  */
-fun IntYears.asPeriod(): Period = Period.create(years = this)
+fun Years.asPeriod(): Period = Period.create(years = this)
 
 /**
  * Converts this duration into a [Period] with the same number of months.
  */
-fun IntMonths.asPeriod(): Period = Period.create(months = this)
+fun Months.asPeriod(): Period = Period.create(months = this)
 
 /**
  * Converts this duration into a [Period] with the same number of weeks.
  * @throws ArithmeticException if the resulting [Period] would overflow
  */
-fun IntWeeks.asPeriod(): Period = Period.create(days = this.inDays)
+fun Weeks.asPeriod(): Period = Period.create(days = this.inDays)
 
 /**
  * Converts this duration into a [Period] with the same number of days.
  */
-fun IntDays.asPeriod(): Period = Period.create(days = this)
+fun Days.asPeriod(): Period = Period.create(days = this)
 
-/**
- * Converts this duration into a [Period] with the same number of years.
- * @throws ArithmeticException if the resulting [Period] would overflow
- */
-fun LongYears.asPeriod(): Period = this.toIntYears().asPeriod()
+operator fun Years.plus(period: Period): Period = period.copy(years = this + period.years)
+operator fun Months.plus(period: Period): Period = period.copy(months = this + period.months)
+operator fun Weeks.plus(period: Period): Period = this.inDays + period
+operator fun Days.plus(period: Period): Period = period.copy(days = this + period.days)
 
-/**
- * Converts this duration into a [Period] with the same number of months.
- * @throws ArithmeticException if the resulting [Period] would overflow
- */
-fun LongMonths.asPeriod(): Period = this.toIntMonths().asPeriod()
-
-/**
- * Converts this duration into a [Period] with the same number of weeks.
- * @throws ArithmeticException if the resulting [Period] would overflow
- */
-fun LongWeeks.asPeriod(): Period = this.inDays.asPeriod()
-
-/**
- * Converts this duration into a [Period] with the same number of days.
- * @throws ArithmeticException if the resulting [Period] would overflow
- */
-fun LongDays.asPeriod(): Period = this.toIntDays().asPeriod()
-
-operator fun IntYears.plus(period: Period): Period = period.copy(years = this + period.years)
-operator fun IntMonths.plus(period: Period): Period = period.copy(months = this + period.months)
-operator fun IntWeeks.plus(period: Period): Period = this.toLongWeeks().inDaysUnchecked + period
-operator fun IntDays.plus(period: Period): Period = period.copy(days = this + period.days)
-
-operator fun LongYears.plus(period: Period): Period = period.copy(years = (this + period.years).toIntYears())
-operator fun LongMonths.plus(period: Period): Period = period.copy(months = (this + period.months).toIntMonths())
-operator fun LongWeeks.plus(period: Period): Period = this.inDays + period
-operator fun LongDays.plus(period: Period): Period = period.copy(days = (this + period.days).toIntDays())
-
-operator fun IntYears.minus(period: Period): Period = Period.create(
+operator fun Years.minus(period: Period): Period = Period.create(
     this - period.years,
     -period.months,
     -period.days
 )
 
-operator fun IntMonths.minus(period: Period): Period = Period.create(
+operator fun Months.minus(period: Period): Period = Period.create(
     -period.years,
     this - period.months,
     -period.days
 )
 
-operator fun IntWeeks.minus(period: Period): Period = this.toLongWeeks().inDaysUnchecked - period
+operator fun Weeks.minus(period: Period): Period = this.inDays - period
 
-operator fun IntDays.minus(period: Period): Period = Period.create(
+operator fun Days.minus(period: Period): Period = Period.create(
     -period.years,
     -period.months,
     this - period.days
 )
 
-operator fun LongYears.minus(period: Period): Period = Period.create(
-    (this - period.years).toIntYears(),
-    -period.months,
-    -period.days
-)
-
-operator fun LongMonths.minus(period: Period): Period = Period.create(
-    -period.years,
-    (this - period.months).toIntMonths(),
-    -period.days
-)
-
-operator fun LongWeeks.minus(period: Period): Period = this.inDays - period
-
-operator fun LongDays.minus(period: Period): Period = Period.create(
-    -period.years,
-    -period.months,
-    (this - period.days).toIntDays()
-)
-
 operator fun Int.times(period: Period): Period = period * this
+operator fun Long.times(period: Period): Period = period * this
 
 fun String.toPeriod(): Period = toPeriod(DateTimeParsers.Iso.PERIOD)
 
@@ -340,12 +282,12 @@ internal fun DateTimeParseResult.toPeriod(): Period? {
     return if (yearsValue == null && monthsValue == null && weeksValue == null && daysValue == null) {
         null
     } else {
-        val years = yearsValue?.toIntExact()?.timesExact(sign)?.years ?: 0.years
-        val months = monthsValue?.toIntExact()?.timesExact(sign)?.months ?: 0.months
-        var days = daysValue?.toIntExact()?.timesExact(sign)?.days ?: 0.days
+        val years = yearsValue?.timesExact(sign)?.years ?: 0.years
+        val months = monthsValue?.timesExact(sign)?.months ?: 0.months
+        var days = daysValue?.timesExact(sign)?.days ?: 0.days
 
         if (weeksValue != null) {
-            days += weeksValue.toIntExact().timesExact(sign).weeks.inDays
+            days += weeksValue.timesExact(sign).weeks
         }
 
         periodOf(years, months, days)

--- a/core/src/commonMain/kotlin/io/islandtime/measures/Period.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/measures/Period.kt
@@ -40,13 +40,13 @@ class Period private constructor(
      * Reverses the sign of each component in the period.
      * @throws ArithmeticException if overflow occurs
      */
-    operator fun unaryMinus() = create(-years, -months, -days)
+    operator fun unaryMinus(): Period = create(-years, -months, -days)
 
     /**
      * Adds each component of another period to each component of this period.
      * @throws ArithmeticException if overflow occurs
      */
-    operator fun plus(other: Period) = create(
+    operator fun plus(other: Period): Period = create(
         years + other.years,
         months + other.months,
         days + other.days
@@ -56,31 +56,35 @@ class Period private constructor(
      * Subtracts each component of another period from this period.
      * @throws ArithmeticException if overflow occurs
      */
-    operator fun minus(other: Period) = create(
+    operator fun minus(other: Period): Period = create(
         years - other.years,
         months - other.months,
         days - other.days
     )
 
-    operator fun plus(years: IntYears) = copy(years = this.years + years)
-    operator fun plus(months: IntMonths) = copy(months = this.months + months)
-    operator fun plus(weeks: IntWeeks) = plus(weeks.toLongWeeks().inDaysUnchecked)
-    operator fun plus(days: IntDays) = copy(days = this.days + days)
+    operator fun plus(years: IntYears): Period = copy(years = this.years + years)
+    operator fun plus(months: IntMonths): Period = copy(months = this.months + months)
+    operator fun plus(weeks: IntWeeks): Period = plus(weeks.toLongWeeks().inDaysUnchecked)
+    operator fun plus(days: IntDays): Period = copy(days = this.days + days)
 
-    operator fun plus(years: LongYears) = copy(years = (this.years.toLong() + years.value).toIntExact().years)
-    operator fun plus(months: LongMonths) = copy(months = (this.months.toLong() + months.value).toIntExact().months)
-    operator fun plus(weeks: LongWeeks) = plus(weeks.inDays)
-    operator fun plus(days: LongDays) = copy(days = (this.days.toLong() + days.value).toIntExact().days)
+    operator fun plus(years: LongYears): Period = copy(years = (this.years.toLong() + years.value).toIntExact().years)
+    operator fun plus(months: LongMonths): Period =
+        copy(months = (this.months.toLong() + months.value).toIntExact().months)
 
-    operator fun minus(years: IntYears) = copy(years = this.years - years)
-    operator fun minus(months: IntMonths) = copy(months = this.months - months)
-    operator fun minus(weeks: IntWeeks) = minus(weeks.toLongWeeks().inDaysUnchecked)
-    operator fun minus(days: IntDays) = copy(days = this.days - days)
+    operator fun plus(weeks: LongWeeks): Period = plus(weeks.inDays)
+    operator fun plus(days: LongDays): Period = copy(days = (this.days.toLong() + days.value).toIntExact().days)
 
-    operator fun minus(years: LongYears) = copy(years = (this.years.toLong() - years.value).toIntExact().years)
-    operator fun minus(months: LongMonths) = copy(months = (this.months.toLong() - months.value).toIntExact().months)
-    operator fun minus(weeks: LongWeeks) = minus(weeks.inDays)
-    operator fun minus(days: LongDays) = copy(days = (this.days.toLong() - days.value).toIntExact().days)
+    operator fun minus(years: IntYears): Period = copy(years = this.years - years)
+    operator fun minus(months: IntMonths): Period = copy(months = this.months - months)
+    operator fun minus(weeks: IntWeeks): Period = minus(weeks.toLongWeeks().inDaysUnchecked)
+    operator fun minus(days: IntDays): Period = copy(days = this.days - days)
+
+    operator fun minus(years: LongYears): Period = copy(years = (this.years.toLong() - years.value).toIntExact().years)
+    operator fun minus(months: LongMonths): Period =
+        copy(months = (this.months.toLong() - months.value).toIntExact().months)
+
+    operator fun minus(weeks: LongWeeks): Period = minus(weeks.inDays)
+    operator fun minus(days: LongDays): Period = copy(days = (this.days.toLong() - days.value).toIntExact().days)
 
     /**
      * Multiplies each component of this period by a scalar value.
@@ -94,9 +98,9 @@ class Period private constructor(
         }
     }
 
-    operator fun component1() = years
-    operator fun component2() = months
-    operator fun component3() = days
+    operator fun component1(): IntYears = years
+    operator fun component2(): IntMonths = months
+    operator fun component3(): IntDays = days
 
     /**
      * Normalizes the number of years and months such that "1 year, 15 months" becomes "2 years, 3 months". Only the
@@ -168,13 +172,13 @@ class Period private constructor(
         years: IntYears = this.years,
         months: IntMonths = this.months,
         days: IntDays = this.days
-    ) = create(years, months, days)
+    ): Period = create(years, months, days)
 
     companion object {
         /**
          * A [Period] of zero length.
          */
-        val ZERO = Period()
+        val ZERO: Period = Period()
 
         internal fun create(
             years: IntYears = 0.years,
@@ -200,122 +204,122 @@ fun periodOf(years: IntYears, months: IntMonths = 0.months, days: IntDays = 0.da
 /**
  * Creates a [Period].
  */
-fun periodOf(years: IntYears, days: IntDays) = Period.create(years = years, days = days)
+fun periodOf(years: IntYears, days: IntDays): Period = Period.create(years = years, days = days)
 
 /**
  * Creates a [Period].
  */
-fun periodOf(months: IntMonths, days: IntDays = 0.days) = Period.create(months = months, days = days)
+fun periodOf(months: IntMonths, days: IntDays = 0.days): Period = Period.create(months = months, days = days)
 
 /**
  * Creates a [Period].
  * @throws ArithmeticException if overflow occurs
  */
-fun periodOf(weeks: IntWeeks) = Period.create(days = weeks.inDays)
+fun periodOf(weeks: IntWeeks): Period = Period.create(days = weeks.inDays)
 
 /**
  * Creates a [Period].
  */
-fun periodOf(days: IntDays) = Period.create(days = days)
+fun periodOf(days: IntDays): Period = Period.create(days = days)
 
 /**
  * Converts this duration into a [Period] with the same number of years.
  */
-fun IntYears.asPeriod() = Period.create(years = this)
+fun IntYears.asPeriod(): Period = Period.create(years = this)
 
 /**
  * Converts this duration into a [Period] with the same number of months.
  */
-fun IntMonths.asPeriod() = Period.create(months = this)
+fun IntMonths.asPeriod(): Period = Period.create(months = this)
 
 /**
  * Converts this duration into a [Period] with the same number of weeks.
  * @throws ArithmeticException if the resulting [Period] would overflow
  */
-fun IntWeeks.asPeriod() = Period.create(days = this.inDays)
+fun IntWeeks.asPeriod(): Period = Period.create(days = this.inDays)
 
 /**
  * Converts this duration into a [Period] with the same number of days.
  */
-fun IntDays.asPeriod() = Period.create(days = this)
+fun IntDays.asPeriod(): Period = Period.create(days = this)
 
 /**
  * Converts this duration into a [Period] with the same number of years.
  * @throws ArithmeticException if the resulting [Period] would overflow
  */
-fun LongYears.asPeriod() = this.toIntYears().asPeriod()
+fun LongYears.asPeriod(): Period = this.toIntYears().asPeriod()
 
 /**
  * Converts this duration into a [Period] with the same number of months.
  * @throws ArithmeticException if the resulting [Period] would overflow
  */
-fun LongMonths.asPeriod() = this.toIntMonths().asPeriod()
+fun LongMonths.asPeriod(): Period = this.toIntMonths().asPeriod()
 
 /**
  * Converts this duration into a [Period] with the same number of weeks.
  * @throws ArithmeticException if the resulting [Period] would overflow
  */
-fun LongWeeks.asPeriod() = this.inDays.asPeriod()
+fun LongWeeks.asPeriod(): Period = this.inDays.asPeriod()
 
 /**
  * Converts this duration into a [Period] with the same number of days.
  * @throws ArithmeticException if the resulting [Period] would overflow
  */
-fun LongDays.asPeriod() = this.toIntDays().asPeriod()
+fun LongDays.asPeriod(): Period = this.toIntDays().asPeriod()
 
-operator fun IntYears.plus(period: Period) = period.copy(years = this + period.years)
-operator fun IntMonths.plus(period: Period) = period.copy(months = this + period.months)
-operator fun IntWeeks.plus(period: Period) = this.toLongWeeks().inDaysUnchecked + period
-operator fun IntDays.plus(period: Period) = period.copy(days = this + period.days)
+operator fun IntYears.plus(period: Period): Period = period.copy(years = this + period.years)
+operator fun IntMonths.plus(period: Period): Period = period.copy(months = this + period.months)
+operator fun IntWeeks.plus(period: Period): Period = this.toLongWeeks().inDaysUnchecked + period
+operator fun IntDays.plus(period: Period): Period = period.copy(days = this + period.days)
 
-operator fun LongYears.plus(period: Period) = period.copy(years = (this + period.years).toIntYears())
-operator fun LongMonths.plus(period: Period) = period.copy(months = (this + period.months).toIntMonths())
-operator fun LongWeeks.plus(period: Period) = this.inDays + period
-operator fun LongDays.plus(period: Period) = period.copy(days = (this + period.days).toIntDays())
+operator fun LongYears.plus(period: Period): Period = period.copy(years = (this + period.years).toIntYears())
+operator fun LongMonths.plus(period: Period): Period = period.copy(months = (this + period.months).toIntMonths())
+operator fun LongWeeks.plus(period: Period): Period = this.inDays + period
+operator fun LongDays.plus(period: Period): Period = period.copy(days = (this + period.days).toIntDays())
 
-operator fun IntYears.minus(period: Period) = Period.create(
+operator fun IntYears.minus(period: Period): Period = Period.create(
     this - period.years,
     -period.months,
     -period.days
 )
 
-operator fun IntMonths.minus(period: Period) = Period.create(
+operator fun IntMonths.minus(period: Period): Period = Period.create(
     -period.years,
     this - period.months,
     -period.days
 )
 
-operator fun IntWeeks.minus(period: Period) = this.toLongWeeks().inDaysUnchecked - period
+operator fun IntWeeks.minus(period: Period): Period = this.toLongWeeks().inDaysUnchecked - period
 
-operator fun IntDays.minus(period: Period) = Period.create(
+operator fun IntDays.minus(period: Period): Period = Period.create(
     -period.years,
     -period.months,
     this - period.days
 )
 
-operator fun LongYears.minus(period: Period) = Period.create(
+operator fun LongYears.minus(period: Period): Period = Period.create(
     (this - period.years).toIntYears(),
     -period.months,
     -period.days
 )
 
-operator fun LongMonths.minus(period: Period) = Period.create(
+operator fun LongMonths.minus(period: Period): Period = Period.create(
     -period.years,
     (this - period.months).toIntMonths(),
     -period.days
 )
 
-operator fun LongWeeks.minus(period: Period) = this.inDays - period
+operator fun LongWeeks.minus(period: Period): Period = this.inDays - period
 
-operator fun LongDays.minus(period: Period) = Period.create(
+operator fun LongDays.minus(period: Period): Period = Period.create(
     -period.years,
     -period.months,
     (this - period.days).toIntDays()
 )
 
-operator fun Int.times(period: Period) = period * this
+operator fun Int.times(period: Period): Period = period * this
 
-fun String.toPeriod() = toPeriod(DateTimeParsers.Iso.PERIOD)
+fun String.toPeriod(): Period = toPeriod(DateTimeParsers.Iso.PERIOD)
 
 fun String.toPeriod(
     parser: DateTimeParser,

--- a/core/src/commonMain/kotlin/io/islandtime/measures/internal/Extensions.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/measures/internal/Extensions.kt
@@ -1,26 +1,8 @@
 package io.islandtime.measures.internal
 
-import io.islandtime.internal.NANOSECONDS_PER_MICROSECOND
-import io.islandtime.internal.NANOSECONDS_PER_MILLISECOND
 import io.islandtime.internal.NANOSECONDS_PER_SECOND
-import io.islandtime.measures.IntMicroseconds
-import io.islandtime.measures.IntMilliseconds
-import io.islandtime.measures.IntNanoseconds
-import io.islandtime.measures.IntSeconds
+import io.islandtime.measures.Nanoseconds
+import io.islandtime.measures.Seconds
 
-internal infix fun IntNanoseconds.plusWithOverflow(nanoseconds: IntNanoseconds) =
-    IntNanoseconds(value + nanoseconds.value)
-
-internal infix fun IntNanoseconds.plusWithOverflow(microseconds: IntMicroseconds) =
-    IntNanoseconds(value + microseconds.value * NANOSECONDS_PER_MICROSECOND)
-
-internal infix fun IntNanoseconds.plusWithOverflow(milliseconds: IntMilliseconds) =
-    IntNanoseconds(value + milliseconds.value * NANOSECONDS_PER_MILLISECOND)
-
-internal infix fun IntNanoseconds.plusWithOverflow(seconds: IntSeconds) =
-    IntNanoseconds(value + seconds.value * NANOSECONDS_PER_SECOND)
-
-internal infix fun IntNanoseconds.minusWithOverflow(nanoseconds: IntNanoseconds) = plusWithOverflow(-nanoseconds)
-internal infix fun IntNanoseconds.minusWithOverflow(microseconds: IntMicroseconds) = plusWithOverflow(-microseconds)
-internal infix fun IntNanoseconds.minusWithOverflow(milliseconds: IntMilliseconds) = plusWithOverflow(-milliseconds)
-internal infix fun IntNanoseconds.minusWithOverflow(seconds: IntSeconds) = plusWithOverflow(-seconds)
+internal infix fun Nanoseconds.plusUnchecked(seconds: Seconds): Nanoseconds =
+    Nanoseconds(value + seconds.value * NANOSECONDS_PER_SECOND)

--- a/core/src/commonMain/kotlin/io/islandtime/operators/Round.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/operators/Round.kt
@@ -19,9 +19,9 @@ import kotlin.jvm.JvmName
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun Time.roundedToNearest(increment: IntHours): Time {
+fun Time.roundedToNearest(increment: Hours): Time {
     checkRoundingIncrement(increment)
-    return roundedToNearestUnchecked(increment.inNanoseconds)
+    return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -30,9 +30,9 @@ fun Time.roundedToNearest(increment: IntHours): Time {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun Time.roundedToNearest(increment: IntMinutes): Time {
+fun Time.roundedToNearest(increment: Minutes): Time {
     checkRoundingIncrement(increment)
-    return roundedToNearestUnchecked(increment.inNanoseconds)
+    return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -41,9 +41,9 @@ fun Time.roundedToNearest(increment: IntMinutes): Time {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun Time.roundedToNearest(increment: IntSeconds): Time {
+fun Time.roundedToNearest(increment: Seconds): Time {
     checkRoundingIncrement(increment)
-    return roundedToNearestUnchecked(increment.inNanoseconds)
+    return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -52,8 +52,9 @@ fun Time.roundedToNearest(increment: IntSeconds): Time {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Time.roundedToNearest(increment: IntMilliseconds): Time {
-    return roundedToNearest(increment.inNanoseconds)
+fun Time.roundedToNearest(increment: Milliseconds): Time {
+    checkRoundingIncrement(increment)
+    return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -62,8 +63,9 @@ fun Time.roundedToNearest(increment: IntMilliseconds): Time {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Time.roundedToNearest(increment: IntMicroseconds): Time {
-    return roundedToNearest(increment.inNanoseconds)
+fun Time.roundedToNearest(increment: Microseconds): Time {
+    checkRoundingIncrement(increment)
+    return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -72,8 +74,9 @@ fun Time.roundedToNearest(increment: IntMicroseconds): Time {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Time.roundedToNearest(increment: IntNanoseconds): Time {
-    return roundedToNearest(increment.toLongNanoseconds())
+fun Time.roundedToNearest(increment: Nanoseconds): Time {
+    checkRoundingIncrement(increment)
+    return roundedToNearestUnchecked(increment)
 }
 
 /**
@@ -98,7 +101,7 @@ fun Time.roundedTo(unit: TimeUnit): Time {
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun OffsetTime.roundedToNearest(increment: IntHours): OffsetTime {
+fun OffsetTime.roundedToNearest(increment: Hours): OffsetTime {
     return copyIfChanged(time = time.roundedToNearest(increment))
 }
 
@@ -108,7 +111,7 @@ fun OffsetTime.roundedToNearest(increment: IntHours): OffsetTime {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun OffsetTime.roundedToNearest(increment: IntMinutes): OffsetTime {
+fun OffsetTime.roundedToNearest(increment: Minutes): OffsetTime {
     return copyIfChanged(time = time.roundedToNearest(increment))
 }
 
@@ -118,7 +121,7 @@ fun OffsetTime.roundedToNearest(increment: IntMinutes): OffsetTime {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun OffsetTime.roundedToNearest(increment: IntSeconds): OffsetTime {
+fun OffsetTime.roundedToNearest(increment: Seconds): OffsetTime {
     return copyIfChanged(time = time.roundedToNearest(increment))
 }
 
@@ -128,7 +131,7 @@ fun OffsetTime.roundedToNearest(increment: IntSeconds): OffsetTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetTime.roundedToNearest(increment: IntMilliseconds): OffsetTime {
+fun OffsetTime.roundedToNearest(increment: Milliseconds): OffsetTime {
     return copyIfChanged(time = time.roundedToNearest(increment))
 }
 
@@ -138,7 +141,7 @@ fun OffsetTime.roundedToNearest(increment: IntMilliseconds): OffsetTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetTime.roundedToNearest(increment: IntMicroseconds): OffsetTime {
+fun OffsetTime.roundedToNearest(increment: Microseconds): OffsetTime {
     return copyIfChanged(time = time.roundedToNearest(increment))
 }
 
@@ -148,7 +151,7 @@ fun OffsetTime.roundedToNearest(increment: IntMicroseconds): OffsetTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetTime.roundedToNearest(increment: IntNanoseconds): OffsetTime {
+fun OffsetTime.roundedToNearest(increment: Nanoseconds): OffsetTime {
     return copyIfChanged(time = time.roundedToNearest(increment))
 }
 
@@ -166,7 +169,7 @@ fun OffsetTime.roundedTo(unit: TimeUnit): OffsetTime {
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun DateTime.roundedToNearest(increment: IntHours): DateTime {
+fun DateTime.roundedToNearest(increment: Hours): DateTime {
     checkRoundingIncrement(increment)
     return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
@@ -177,7 +180,7 @@ fun DateTime.roundedToNearest(increment: IntHours): DateTime {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun DateTime.roundedToNearest(increment: IntMinutes): DateTime {
+fun DateTime.roundedToNearest(increment: Minutes): DateTime {
     checkRoundingIncrement(increment)
     return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
@@ -188,9 +191,9 @@ fun DateTime.roundedToNearest(increment: IntMinutes): DateTime {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun DateTime.roundedToNearest(increment: IntSeconds): DateTime {
+fun DateTime.roundedToNearest(increment: Seconds): DateTime {
     checkRoundingIncrement(increment)
-    return roundedToNearestUnchecked(increment.inNanoseconds)
+    return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -199,8 +202,9 @@ fun DateTime.roundedToNearest(increment: IntSeconds): DateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun DateTime.roundedToNearest(increment: IntMilliseconds): DateTime {
-    return roundedToNearest(increment.inNanoseconds)
+fun DateTime.roundedToNearest(increment: Milliseconds): DateTime {
+    checkRoundingIncrement(increment)
+    return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -209,8 +213,9 @@ fun DateTime.roundedToNearest(increment: IntMilliseconds): DateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun DateTime.roundedToNearest(increment: IntMicroseconds): DateTime {
-    return roundedToNearest(increment.inNanoseconds)
+fun DateTime.roundedToNearest(increment: Microseconds): DateTime {
+    checkRoundingIncrement(increment)
+    return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -219,8 +224,9 @@ fun DateTime.roundedToNearest(increment: IntMicroseconds): DateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun DateTime.roundedToNearest(increment: IntNanoseconds): DateTime {
-    return roundedToNearest(increment.toLongNanoseconds())
+fun DateTime.roundedToNearest(increment: Nanoseconds): DateTime {
+    checkRoundingIncrement(increment)
+    return roundedToNearestUnchecked(increment)
 }
 
 /**
@@ -245,7 +251,7 @@ fun DateTime.roundedTo(unit: TimeUnit): DateTime {
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun OffsetDateTime.roundedToNearest(increment: IntHours): OffsetDateTime {
+fun OffsetDateTime.roundedToNearest(increment: Hours): OffsetDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -255,7 +261,7 @@ fun OffsetDateTime.roundedToNearest(increment: IntHours): OffsetDateTime {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun OffsetDateTime.roundedToNearest(increment: IntMinutes): OffsetDateTime {
+fun OffsetDateTime.roundedToNearest(increment: Minutes): OffsetDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -265,7 +271,7 @@ fun OffsetDateTime.roundedToNearest(increment: IntMinutes): OffsetDateTime {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun OffsetDateTime.roundedToNearest(increment: IntSeconds): OffsetDateTime {
+fun OffsetDateTime.roundedToNearest(increment: Seconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -275,7 +281,7 @@ fun OffsetDateTime.roundedToNearest(increment: IntSeconds): OffsetDateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetDateTime.roundedToNearest(increment: IntMilliseconds): OffsetDateTime {
+fun OffsetDateTime.roundedToNearest(increment: Milliseconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -285,7 +291,7 @@ fun OffsetDateTime.roundedToNearest(increment: IntMilliseconds): OffsetDateTime 
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetDateTime.roundedToNearest(increment: IntMicroseconds): OffsetDateTime {
+fun OffsetDateTime.roundedToNearest(increment: Microseconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -295,7 +301,7 @@ fun OffsetDateTime.roundedToNearest(increment: IntMicroseconds): OffsetDateTime 
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetDateTime.roundedToNearest(increment: IntNanoseconds): OffsetDateTime {
+fun OffsetDateTime.roundedToNearest(increment: Nanoseconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -318,7 +324,7 @@ fun OffsetDateTime.roundedTo(unit: TimeUnit): OffsetDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedToNearest(increment: IntHours): ZonedDateTime {
+fun ZonedDateTime.roundedToNearest(increment: Hours): ZonedDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -333,7 +339,7 @@ fun ZonedDateTime.roundedToNearest(increment: IntHours): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedToNearest(increment: IntMinutes): ZonedDateTime {
+fun ZonedDateTime.roundedToNearest(increment: Minutes): ZonedDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -348,7 +354,7 @@ fun ZonedDateTime.roundedToNearest(increment: IntMinutes): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedToNearest(increment: IntSeconds): ZonedDateTime {
+fun ZonedDateTime.roundedToNearest(increment: Seconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -363,7 +369,7 @@ fun ZonedDateTime.roundedToNearest(increment: IntSeconds): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedToNearest(increment: IntMilliseconds): ZonedDateTime {
+fun ZonedDateTime.roundedToNearest(increment: Milliseconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -378,7 +384,7 @@ fun ZonedDateTime.roundedToNearest(increment: IntMilliseconds): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedToNearest(increment: IntMicroseconds): ZonedDateTime {
+fun ZonedDateTime.roundedToNearest(increment: Microseconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -393,7 +399,7 @@ fun ZonedDateTime.roundedToNearest(increment: IntMicroseconds): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedToNearest(increment: IntNanoseconds): ZonedDateTime {
+fun ZonedDateTime.roundedToNearest(increment: Nanoseconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedToNearest(increment))
 }
 
@@ -416,7 +422,7 @@ fun ZonedDateTime.roundedTo(unit: TimeUnit): ZonedDateTime {
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun Instant.roundedToNearest(increment: IntHours): Instant {
+fun Instant.roundedToNearest(increment: Hours): Instant {
     checkRoundingIncrement(increment)
     return roundedToNearestUnchecked(increment.inSecondsUnchecked)
 }
@@ -427,7 +433,7 @@ fun Instant.roundedToNearest(increment: IntHours): Instant {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun Instant.roundedToNearest(increment: IntMinutes): Instant {
+fun Instant.roundedToNearest(increment: Minutes): Instant {
     checkRoundingIncrement(increment)
     return roundedToNearestUnchecked(increment.inSecondsUnchecked)
 }
@@ -438,7 +444,7 @@ fun Instant.roundedToNearest(increment: IntMinutes): Instant {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun Instant.roundedToNearest(increment: IntSeconds): Instant {
+fun Instant.roundedToNearest(increment: Seconds): Instant {
     checkRoundingIncrement(increment)
     return roundedToNearestUnchecked(increment)
 }
@@ -449,9 +455,9 @@ fun Instant.roundedToNearest(increment: IntSeconds): Instant {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Instant.roundedToNearest(increment: IntMilliseconds): Instant {
+fun Instant.roundedToNearest(increment: Milliseconds): Instant {
     checkRoundingIncrement(increment)
-    return roundedToNearestUnchecked((increment.value * NANOSECONDS_PER_MILLISECOND).nanoseconds)
+    return roundedToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -460,7 +466,7 @@ fun Instant.roundedToNearest(increment: IntMilliseconds): Instant {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Instant.roundedToNearest(increment: IntMicroseconds): Instant {
+fun Instant.roundedToNearest(increment: Microseconds): Instant {
     checkRoundingIncrement(increment)
     return roundedToNearestUnchecked((increment.value * NANOSECONDS_PER_MICROSECOND).nanoseconds)
 }
@@ -471,7 +477,7 @@ fun Instant.roundedToNearest(increment: IntMicroseconds): Instant {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Instant.roundedToNearest(increment: IntNanoseconds): Instant {
+fun Instant.roundedToNearest(increment: Nanoseconds): Instant {
     checkRoundingIncrement(increment)
     return roundedToNearestUnchecked(increment)
 }
@@ -492,12 +498,7 @@ fun Instant.roundedTo(unit: TimeUnit): Instant {
     }
 }
 
-private fun Time.roundedToNearest(increment: LongNanoseconds): Time {
-    checkRoundingIncrement(increment)
-    return roundedToNearestUnchecked(increment)
-}
-
-private fun Time.roundedToNearestUnchecked(increment: LongNanoseconds): Time {
+private fun Time.roundedToNearestUnchecked(increment: Nanoseconds): Time {
     val remainder = nanosecondsSinceStartOfDay % increment.value
 
     return if (remainder.value > 0) {
@@ -511,12 +512,7 @@ private fun Time.roundedToNearestUnchecked(increment: LongNanoseconds): Time {
     }
 }
 
-private fun DateTime.roundedToNearest(increment: LongNanoseconds): DateTime {
-    checkRoundingIncrement(increment)
-    return roundedToNearestUnchecked(increment)
-}
-
-private fun DateTime.roundedToNearestUnchecked(increment: LongNanoseconds): DateTime {
+private fun DateTime.roundedToNearestUnchecked(increment: Nanoseconds): DateTime {
     val newTime = time.roundedToNearestUnchecked(increment)
 
     return when {
@@ -526,7 +522,7 @@ private fun DateTime.roundedToNearestUnchecked(increment: LongNanoseconds): Date
     }
 }
 
-private fun Instant.roundedToNearestUnchecked(increment: IntSeconds): Instant {
+private fun Instant.roundedToNearestUnchecked(increment: Seconds): Instant {
     val remainder = (secondOfUnixEpoch floorMod increment.value).seconds + additionalNanosecondsSinceUnixEpoch
 
     return if (remainder.value > 0) {
@@ -540,7 +536,7 @@ private fun Instant.roundedToNearestUnchecked(increment: IntSeconds): Instant {
     }
 }
 
-private fun Instant.roundedToNearestUnchecked(increment: IntNanoseconds): Instant {
+private fun Instant.roundedToNearestUnchecked(increment: Nanoseconds): Instant {
     val remainder = additionalNanosecondsSinceUnixEpoch % increment.value
 
     return if (remainder.value > 0) {

--- a/core/src/commonMain/kotlin/io/islandtime/operators/RoundDown.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/operators/RoundDown.kt
@@ -17,9 +17,9 @@ import kotlin.jvm.JvmName
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun Time.roundedDownToNearest(increment: IntHours): Time {
+fun Time.roundedDownToNearest(increment: Hours): Time {
     checkRoundingIncrement(increment)
-    return roundedDownToNearestUnchecked(increment.toLongHours().inNanosecondsUnchecked)
+    return roundedDownToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -27,9 +27,9 @@ fun Time.roundedDownToNearest(increment: IntHours): Time {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun Time.roundedDownToNearest(increment: IntMinutes): Time {
+fun Time.roundedDownToNearest(increment: Minutes): Time {
     checkRoundingIncrement(increment)
-    return roundedDownToNearestUnchecked(increment.toLongMinutes().inNanosecondsUnchecked)
+    return roundedDownToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -37,9 +37,9 @@ fun Time.roundedDownToNearest(increment: IntMinutes): Time {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun Time.roundedDownToNearest(increment: IntSeconds): Time {
+fun Time.roundedDownToNearest(increment: Seconds): Time {
     checkRoundingIncrement(increment)
-    return roundedDownToNearestUnchecked(increment.toLongSeconds().inNanosecondsUnchecked)
+    return roundedDownToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -47,8 +47,9 @@ fun Time.roundedDownToNearest(increment: IntSeconds): Time {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Time.roundedDownToNearest(increment: IntMilliseconds): Time {
-    return roundedDownToNearest(increment.inNanoseconds)
+fun Time.roundedDownToNearest(increment: Milliseconds): Time {
+    checkRoundingIncrement(increment)
+    return roundedDownToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -56,8 +57,9 @@ fun Time.roundedDownToNearest(increment: IntMilliseconds): Time {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Time.roundedDownToNearest(increment: IntMicroseconds): Time {
-    return roundedDownToNearest(increment.inNanoseconds)
+fun Time.roundedDownToNearest(increment: Microseconds): Time {
+    checkRoundingIncrement(increment)
+    return roundedDownToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -65,8 +67,9 @@ fun Time.roundedDownToNearest(increment: IntMicroseconds): Time {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Time.roundedDownToNearest(increment: IntNanoseconds): Time {
-    return roundedDownToNearest(increment.toLongNanoseconds())
+fun Time.roundedDownToNearest(increment: Nanoseconds): Time {
+    checkRoundingIncrement(increment)
+    return roundedDownToNearestUnchecked(increment)
 }
 
 /**
@@ -98,7 +101,7 @@ fun Time.truncatedTo(unit: TimeUnit): Time = roundedDownTo(unit)
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun OffsetTime.roundedDownToNearest(increment: IntHours): OffsetTime {
+fun OffsetTime.roundedDownToNearest(increment: Hours): OffsetTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -107,7 +110,7 @@ fun OffsetTime.roundedDownToNearest(increment: IntHours): OffsetTime {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun OffsetTime.roundedDownToNearest(increment: IntMinutes): OffsetTime {
+fun OffsetTime.roundedDownToNearest(increment: Minutes): OffsetTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -116,7 +119,7 @@ fun OffsetTime.roundedDownToNearest(increment: IntMinutes): OffsetTime {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun OffsetTime.roundedDownToNearest(increment: IntSeconds): OffsetTime {
+fun OffsetTime.roundedDownToNearest(increment: Seconds): OffsetTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -125,7 +128,7 @@ fun OffsetTime.roundedDownToNearest(increment: IntSeconds): OffsetTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetTime.roundedDownToNearest(increment: IntMilliseconds): OffsetTime {
+fun OffsetTime.roundedDownToNearest(increment: Milliseconds): OffsetTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -134,7 +137,7 @@ fun OffsetTime.roundedDownToNearest(increment: IntMilliseconds): OffsetTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetTime.roundedDownToNearest(increment: IntMicroseconds): OffsetTime {
+fun OffsetTime.roundedDownToNearest(increment: Microseconds): OffsetTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -143,7 +146,7 @@ fun OffsetTime.roundedDownToNearest(increment: IntMicroseconds): OffsetTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetTime.roundedDownToNearest(increment: IntNanoseconds): OffsetTime {
+fun OffsetTime.roundedDownToNearest(increment: Nanoseconds): OffsetTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -168,7 +171,7 @@ fun OffsetTime.truncatedTo(unit: TimeUnit): OffsetTime = roundedDownTo(unit)
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun DateTime.roundedDownToNearest(increment: IntHours): DateTime {
+fun DateTime.roundedDownToNearest(increment: Hours): DateTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -177,7 +180,7 @@ fun DateTime.roundedDownToNearest(increment: IntHours): DateTime {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun DateTime.roundedDownToNearest(increment: IntMinutes): DateTime {
+fun DateTime.roundedDownToNearest(increment: Minutes): DateTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -186,7 +189,7 @@ fun DateTime.roundedDownToNearest(increment: IntMinutes): DateTime {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun DateTime.roundedDownToNearest(increment: IntSeconds): DateTime {
+fun DateTime.roundedDownToNearest(increment: Seconds): DateTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -195,7 +198,7 @@ fun DateTime.roundedDownToNearest(increment: IntSeconds): DateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun DateTime.roundedDownToNearest(increment: IntMilliseconds): DateTime {
+fun DateTime.roundedDownToNearest(increment: Milliseconds): DateTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -204,7 +207,7 @@ fun DateTime.roundedDownToNearest(increment: IntMilliseconds): DateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun DateTime.roundedDownToNearest(increment: IntMicroseconds): DateTime {
+fun DateTime.roundedDownToNearest(increment: Microseconds): DateTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -213,7 +216,7 @@ fun DateTime.roundedDownToNearest(increment: IntMicroseconds): DateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun DateTime.roundedDownToNearest(increment: IntNanoseconds): DateTime {
+fun DateTime.roundedDownToNearest(increment: Nanoseconds): DateTime {
     return copyIfChanged(time = time.roundedDownToNearest(increment))
 }
 
@@ -246,7 +249,7 @@ fun DateTime.truncatedTo(unit: TimeUnit): DateTime = roundedDownTo(unit)
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun OffsetDateTime.roundedDownToNearest(increment: IntHours): OffsetDateTime {
+fun OffsetDateTime.roundedDownToNearest(increment: Hours): OffsetDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -255,7 +258,7 @@ fun OffsetDateTime.roundedDownToNearest(increment: IntHours): OffsetDateTime {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun OffsetDateTime.roundedDownToNearest(increment: IntMinutes): OffsetDateTime {
+fun OffsetDateTime.roundedDownToNearest(increment: Minutes): OffsetDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -264,7 +267,7 @@ fun OffsetDateTime.roundedDownToNearest(increment: IntMinutes): OffsetDateTime {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun OffsetDateTime.roundedDownToNearest(increment: IntSeconds): OffsetDateTime {
+fun OffsetDateTime.roundedDownToNearest(increment: Seconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -273,7 +276,7 @@ fun OffsetDateTime.roundedDownToNearest(increment: IntSeconds): OffsetDateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetDateTime.roundedDownToNearest(increment: IntMilliseconds): OffsetDateTime {
+fun OffsetDateTime.roundedDownToNearest(increment: Milliseconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -282,7 +285,7 @@ fun OffsetDateTime.roundedDownToNearest(increment: IntMilliseconds): OffsetDateT
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetDateTime.roundedDownToNearest(increment: IntMicroseconds): OffsetDateTime {
+fun OffsetDateTime.roundedDownToNearest(increment: Microseconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -291,7 +294,7 @@ fun OffsetDateTime.roundedDownToNearest(increment: IntMicroseconds): OffsetDateT
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetDateTime.roundedDownToNearest(increment: IntNanoseconds): OffsetDateTime {
+fun OffsetDateTime.roundedDownToNearest(increment: Nanoseconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -323,7 +326,7 @@ fun OffsetDateTime.truncatedTo(unit: TimeUnit): OffsetDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedDownToNearest(increment: IntHours): ZonedDateTime {
+fun ZonedDateTime.roundedDownToNearest(increment: Hours): ZonedDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -337,7 +340,7 @@ fun ZonedDateTime.roundedDownToNearest(increment: IntHours): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedDownToNearest(increment: IntMinutes): ZonedDateTime {
+fun ZonedDateTime.roundedDownToNearest(increment: Minutes): ZonedDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -351,7 +354,7 @@ fun ZonedDateTime.roundedDownToNearest(increment: IntMinutes): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedDownToNearest(increment: IntSeconds): ZonedDateTime {
+fun ZonedDateTime.roundedDownToNearest(increment: Seconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -365,7 +368,7 @@ fun ZonedDateTime.roundedDownToNearest(increment: IntSeconds): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedDownToNearest(increment: IntMilliseconds): ZonedDateTime {
+fun ZonedDateTime.roundedDownToNearest(increment: Milliseconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -379,7 +382,7 @@ fun ZonedDateTime.roundedDownToNearest(increment: IntMilliseconds): ZonedDateTim
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedDownToNearest(increment: IntMicroseconds): ZonedDateTime {
+fun ZonedDateTime.roundedDownToNearest(increment: Microseconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -393,7 +396,7 @@ fun ZonedDateTime.roundedDownToNearest(increment: IntMicroseconds): ZonedDateTim
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedDownToNearest(increment: IntNanoseconds): ZonedDateTime {
+fun ZonedDateTime.roundedDownToNearest(increment: Nanoseconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedDownToNearest(increment))
 }
 
@@ -425,7 +428,7 @@ fun ZonedDateTime.truncatedTo(unit: TimeUnit): ZonedDateTime {
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun Instant.roundedDownToNearest(increment: IntHours): Instant {
+fun Instant.roundedDownToNearest(increment: Hours): Instant {
     checkRoundingIncrement(increment)
     return roundedDownToNearestUnchecked(increment.inSecondsUnchecked)
 }
@@ -435,7 +438,7 @@ fun Instant.roundedDownToNearest(increment: IntHours): Instant {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun Instant.roundedDownToNearest(increment: IntMinutes): Instant {
+fun Instant.roundedDownToNearest(increment: Minutes): Instant {
     checkRoundingIncrement(increment)
     return roundedDownToNearestUnchecked(increment.inSecondsUnchecked)
 }
@@ -445,7 +448,7 @@ fun Instant.roundedDownToNearest(increment: IntMinutes): Instant {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun Instant.roundedDownToNearest(increment: IntSeconds): Instant {
+fun Instant.roundedDownToNearest(increment: Seconds): Instant {
     checkRoundingIncrement(increment)
     return roundedDownToNearestUnchecked(increment)
 }
@@ -455,7 +458,7 @@ fun Instant.roundedDownToNearest(increment: IntSeconds): Instant {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Instant.roundedDownToNearest(increment: IntMilliseconds): Instant {
+fun Instant.roundedDownToNearest(increment: Milliseconds): Instant {
     checkRoundingIncrement(increment)
     return roundedDownToNearestUnchecked((increment.value * NANOSECONDS_PER_MILLISECOND).nanoseconds)
 }
@@ -465,7 +468,7 @@ fun Instant.roundedDownToNearest(increment: IntMilliseconds): Instant {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Instant.roundedDownToNearest(increment: IntMicroseconds): Instant {
+fun Instant.roundedDownToNearest(increment: Microseconds): Instant {
     checkRoundingIncrement(increment)
     return roundedDownToNearestUnchecked((increment.value * NANOSECONDS_PER_MICROSECOND).nanoseconds)
 }
@@ -475,7 +478,7 @@ fun Instant.roundedDownToNearest(increment: IntMicroseconds): Instant {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Instant.roundedDownToNearest(increment: IntNanoseconds): Instant {
+fun Instant.roundedDownToNearest(increment: Nanoseconds): Instant {
     checkRoundingIncrement(increment)
     return roundedDownToNearestUnchecked(increment)
 }
@@ -504,17 +507,12 @@ fun Instant.roundedDownTo(unit: TimeUnit): Instant {
  */
 fun Instant.truncatedTo(unit: TimeUnit): Instant = roundedDownTo(unit)
 
-private fun Time.roundedDownToNearest(increment: LongNanoseconds): Time {
-    checkRoundingIncrement(increment)
-    return roundedDownToNearestUnchecked(increment)
-}
-
-private fun Time.roundedDownToNearestUnchecked(increment: LongNanoseconds): Time {
+private fun Time.roundedDownToNearestUnchecked(increment: Nanoseconds): Time {
     val remainder = nanosecondsSinceStartOfDay % increment.value
     return if (remainder.value > 0) this - remainder else this
 }
 
-private fun Instant.roundedDownToNearestUnchecked(increment: IntSeconds): Instant {
+private fun Instant.roundedDownToNearestUnchecked(increment: Seconds): Instant {
     val currentSecond = secondOfUnixEpoch
     val remainder = currentSecond floorMod increment.value
 
@@ -525,7 +523,7 @@ private fun Instant.roundedDownToNearestUnchecked(increment: IntSeconds): Instan
     }
 }
 
-private fun Instant.roundedDownToNearestUnchecked(increment: IntNanoseconds): Instant {
+private fun Instant.roundedDownToNearestUnchecked(increment: Nanoseconds): Instant {
     val remainder = additionalNanosecondsSinceUnixEpoch % increment.value
     return if (remainder.value > 0) this - remainder else this
 }

--- a/core/src/commonMain/kotlin/io/islandtime/operators/RoundUp.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/operators/RoundUp.kt
@@ -17,9 +17,9 @@ import kotlin.jvm.JvmName
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun Time.roundedUpToNearest(increment: IntHours): Time {
+fun Time.roundedUpToNearest(increment: Hours): Time {
     checkRoundingIncrement(increment)
-    return roundedUpToNearestUnchecked(increment.toLongHours().inNanosecondsUnchecked)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -27,9 +27,9 @@ fun Time.roundedUpToNearest(increment: IntHours): Time {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun Time.roundedUpToNearest(increment: IntMinutes): Time {
+fun Time.roundedUpToNearest(increment: Minutes): Time {
     checkRoundingIncrement(increment)
-    return roundedUpToNearestUnchecked(increment.toLongMinutes().inNanosecondsUnchecked)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -37,9 +37,9 @@ fun Time.roundedUpToNearest(increment: IntMinutes): Time {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun Time.roundedUpToNearest(increment: IntSeconds): Time {
+fun Time.roundedUpToNearest(increment: Seconds): Time {
     checkRoundingIncrement(increment)
-    return roundedUpToNearestUnchecked(increment.toLongSeconds().inNanosecondsUnchecked)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -47,8 +47,9 @@ fun Time.roundedUpToNearest(increment: IntSeconds): Time {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Time.roundedUpToNearest(increment: IntMilliseconds): Time {
-    return roundedUpToNearest(increment.inNanoseconds)
+fun Time.roundedUpToNearest(increment: Milliseconds): Time {
+    checkRoundingIncrement(increment)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -56,8 +57,9 @@ fun Time.roundedUpToNearest(increment: IntMilliseconds): Time {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Time.roundedUpToNearest(increment: IntMicroseconds): Time {
-    return roundedUpToNearest(increment.inNanoseconds)
+fun Time.roundedUpToNearest(increment: Microseconds): Time {
+    checkRoundingIncrement(increment)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -65,8 +67,9 @@ fun Time.roundedUpToNearest(increment: IntMicroseconds): Time {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Time.roundedUpToNearest(increment: IntNanoseconds): Time {
-    return roundedUpToNearest(increment.toLongNanoseconds())
+fun Time.roundedUpToNearest(increment: Nanoseconds): Time {
+    checkRoundingIncrement(increment)
+    return roundedUpToNearestUnchecked(increment)
 }
 
 /**
@@ -89,7 +92,7 @@ fun Time.roundedUpTo(unit: TimeUnit): Time {
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun OffsetTime.roundedUpToNearest(increment: IntHours): OffsetTime {
+fun OffsetTime.roundedUpToNearest(increment: Hours): OffsetTime {
     return copyIfChanged(time = time.roundedUpToNearest(increment))
 }
 
@@ -98,7 +101,7 @@ fun OffsetTime.roundedUpToNearest(increment: IntHours): OffsetTime {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun OffsetTime.roundedUpToNearest(increment: IntMinutes): OffsetTime {
+fun OffsetTime.roundedUpToNearest(increment: Minutes): OffsetTime {
     return copyIfChanged(time = time.roundedUpToNearest(increment))
 }
 
@@ -107,7 +110,7 @@ fun OffsetTime.roundedUpToNearest(increment: IntMinutes): OffsetTime {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun OffsetTime.roundedUpToNearest(increment: IntSeconds): OffsetTime {
+fun OffsetTime.roundedUpToNearest(increment: Seconds): OffsetTime {
     return copyIfChanged(time = time.roundedUpToNearest(increment))
 }
 
@@ -116,7 +119,7 @@ fun OffsetTime.roundedUpToNearest(increment: IntSeconds): OffsetTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetTime.roundedUpToNearest(increment: IntMilliseconds): OffsetTime {
+fun OffsetTime.roundedUpToNearest(increment: Milliseconds): OffsetTime {
     return copyIfChanged(time = time.roundedUpToNearest(increment))
 }
 
@@ -125,7 +128,7 @@ fun OffsetTime.roundedUpToNearest(increment: IntMilliseconds): OffsetTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetTime.roundedUpToNearest(increment: IntMicroseconds): OffsetTime {
+fun OffsetTime.roundedUpToNearest(increment: Microseconds): OffsetTime {
     return copyIfChanged(time = time.roundedUpToNearest(increment))
 }
 
@@ -134,7 +137,7 @@ fun OffsetTime.roundedUpToNearest(increment: IntMicroseconds): OffsetTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetTime.roundedUpToNearest(increment: IntNanoseconds): OffsetTime {
+fun OffsetTime.roundedUpToNearest(increment: Nanoseconds): OffsetTime {
     return copyIfChanged(time = time.roundedUpToNearest(increment))
 }
 
@@ -150,9 +153,9 @@ fun OffsetTime.roundedUpTo(unit: TimeUnit): OffsetTime {
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun DateTime.roundedUpToNearest(increment: IntHours): DateTime {
+fun DateTime.roundedUpToNearest(increment: Hours): DateTime {
     checkRoundingIncrement(increment)
-    return roundedUpToNearestUnchecked(increment.toLongHours().inNanosecondsUnchecked)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -160,9 +163,9 @@ fun DateTime.roundedUpToNearest(increment: IntHours): DateTime {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun DateTime.roundedUpToNearest(increment: IntMinutes): DateTime {
+fun DateTime.roundedUpToNearest(increment: Minutes): DateTime {
     checkRoundingIncrement(increment)
-    return roundedUpToNearestUnchecked(increment.toLongMinutes().inNanosecondsUnchecked)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -170,9 +173,9 @@ fun DateTime.roundedUpToNearest(increment: IntMinutes): DateTime {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun DateTime.roundedUpToNearest(increment: IntSeconds): DateTime {
+fun DateTime.roundedUpToNearest(increment: Seconds): DateTime {
     checkRoundingIncrement(increment)
-    return roundedUpToNearestUnchecked(increment.toLongSeconds().inNanosecondsUnchecked)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -180,8 +183,9 @@ fun DateTime.roundedUpToNearest(increment: IntSeconds): DateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun DateTime.roundedUpToNearest(increment: IntMilliseconds): DateTime {
-    return roundedUpToNearest(increment.inNanoseconds)
+fun DateTime.roundedUpToNearest(increment: Milliseconds): DateTime {
+    checkRoundingIncrement(increment)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -189,8 +193,9 @@ fun DateTime.roundedUpToNearest(increment: IntMilliseconds): DateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun DateTime.roundedUpToNearest(increment: IntMicroseconds): DateTime {
-    return roundedUpToNearest(increment.inNanoseconds)
+fun DateTime.roundedUpToNearest(increment: Microseconds): DateTime {
+    checkRoundingIncrement(increment)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -198,8 +203,9 @@ fun DateTime.roundedUpToNearest(increment: IntMicroseconds): DateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun DateTime.roundedUpToNearest(increment: IntNanoseconds): DateTime {
-    return roundedUpToNearest(increment.toLongNanoseconds())
+fun DateTime.roundedUpToNearest(increment: Nanoseconds): DateTime {
+    checkRoundingIncrement(increment)
+    return roundedUpToNearestUnchecked(increment)
 }
 
 /**
@@ -224,7 +230,7 @@ fun DateTime.roundedUpTo(unit: TimeUnit): DateTime {
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun OffsetDateTime.roundedUpToNearest(increment: IntHours): OffsetDateTime {
+fun OffsetDateTime.roundedUpToNearest(increment: Hours): OffsetDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -233,7 +239,7 @@ fun OffsetDateTime.roundedUpToNearest(increment: IntHours): OffsetDateTime {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun OffsetDateTime.roundedUpToNearest(increment: IntMinutes): OffsetDateTime {
+fun OffsetDateTime.roundedUpToNearest(increment: Minutes): OffsetDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -242,7 +248,7 @@ fun OffsetDateTime.roundedUpToNearest(increment: IntMinutes): OffsetDateTime {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun OffsetDateTime.roundedUpToNearest(increment: IntSeconds): OffsetDateTime {
+fun OffsetDateTime.roundedUpToNearest(increment: Seconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -251,7 +257,7 @@ fun OffsetDateTime.roundedUpToNearest(increment: IntSeconds): OffsetDateTime {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetDateTime.roundedUpToNearest(increment: IntMilliseconds): OffsetDateTime {
+fun OffsetDateTime.roundedUpToNearest(increment: Milliseconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -260,7 +266,7 @@ fun OffsetDateTime.roundedUpToNearest(increment: IntMilliseconds): OffsetDateTim
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetDateTime.roundedUpToNearest(increment: IntMicroseconds): OffsetDateTime {
+fun OffsetDateTime.roundedUpToNearest(increment: Microseconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -269,7 +275,7 @@ fun OffsetDateTime.roundedUpToNearest(increment: IntMicroseconds): OffsetDateTim
  *
  * The [increment] must multiply evenly into a second.
  */
-fun OffsetDateTime.roundedUpToNearest(increment: IntNanoseconds): OffsetDateTime {
+fun OffsetDateTime.roundedUpToNearest(increment: Nanoseconds): OffsetDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -292,7 +298,7 @@ fun OffsetDateTime.roundedUpTo(unit: TimeUnit): OffsetDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedUpToNearest(increment: IntHours): ZonedDateTime {
+fun ZonedDateTime.roundedUpToNearest(increment: Hours): ZonedDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -306,7 +312,7 @@ fun ZonedDateTime.roundedUpToNearest(increment: IntHours): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedUpToNearest(increment: IntMinutes): ZonedDateTime {
+fun ZonedDateTime.roundedUpToNearest(increment: Minutes): ZonedDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -320,7 +326,7 @@ fun ZonedDateTime.roundedUpToNearest(increment: IntMinutes): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedUpToNearest(increment: IntSeconds): ZonedDateTime {
+fun ZonedDateTime.roundedUpToNearest(increment: Seconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -334,7 +340,7 @@ fun ZonedDateTime.roundedUpToNearest(increment: IntSeconds): ZonedDateTime {
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedUpToNearest(increment: IntMilliseconds): ZonedDateTime {
+fun ZonedDateTime.roundedUpToNearest(increment: Milliseconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -348,7 +354,7 @@ fun ZonedDateTime.roundedUpToNearest(increment: IntMilliseconds): ZonedDateTime 
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedUpToNearest(increment: IntMicroseconds): ZonedDateTime {
+fun ZonedDateTime.roundedUpToNearest(increment: Microseconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -362,7 +368,7 @@ fun ZonedDateTime.roundedUpToNearest(increment: IntMicroseconds): ZonedDateTime 
  * (meaning the local time exists twice), the offset will be retained if possible. Otherwise, the earlier offset will be
  * used.
  */
-fun ZonedDateTime.roundedUpToNearest(increment: IntNanoseconds): ZonedDateTime {
+fun ZonedDateTime.roundedUpToNearest(increment: Nanoseconds): ZonedDateTime {
     return copyIfChanged(dateTime.roundedUpToNearest(increment))
 }
 
@@ -385,7 +391,7 @@ fun ZonedDateTime.roundedUpTo(unit: TimeUnit): ZonedDateTime {
  *
  * The [increment] must multiply evenly into a 24-hour day.
  */
-fun Instant.roundedUpToNearest(increment: IntHours): Instant {
+fun Instant.roundedUpToNearest(increment: Hours): Instant {
     checkRoundingIncrement(increment)
     return roundedUpToNearestUnchecked(increment.inSecondsUnchecked)
 }
@@ -395,7 +401,7 @@ fun Instant.roundedUpToNearest(increment: IntHours): Instant {
  *
  * The [increment] must multiply evenly into an hour.
  */
-fun Instant.roundedUpToNearest(increment: IntMinutes): Instant {
+fun Instant.roundedUpToNearest(increment: Minutes): Instant {
     checkRoundingIncrement(increment)
     return roundedUpToNearestUnchecked(increment.inSecondsUnchecked)
 }
@@ -405,7 +411,7 @@ fun Instant.roundedUpToNearest(increment: IntMinutes): Instant {
  *
  * The [increment] must multiply evenly into a minute.
  */
-fun Instant.roundedUpToNearest(increment: IntSeconds): Instant {
+fun Instant.roundedUpToNearest(increment: Seconds): Instant {
     checkRoundingIncrement(increment)
     return roundedUpToNearestUnchecked(increment)
 }
@@ -415,9 +421,9 @@ fun Instant.roundedUpToNearest(increment: IntSeconds): Instant {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Instant.roundedUpToNearest(increment: IntMilliseconds): Instant {
+fun Instant.roundedUpToNearest(increment: Milliseconds): Instant {
     checkRoundingIncrement(increment)
-    return roundedUpToNearestUnchecked((increment.value * NANOSECONDS_PER_MILLISECOND).nanoseconds)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -425,9 +431,9 @@ fun Instant.roundedUpToNearest(increment: IntMilliseconds): Instant {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Instant.roundedUpToNearest(increment: IntMicroseconds): Instant {
+fun Instant.roundedUpToNearest(increment: Microseconds): Instant {
     checkRoundingIncrement(increment)
-    return roundedUpToNearestUnchecked((increment.value * NANOSECONDS_PER_MICROSECOND).nanoseconds)
+    return roundedUpToNearestUnchecked(increment.inNanosecondsUnchecked)
 }
 
 /**
@@ -435,7 +441,7 @@ fun Instant.roundedUpToNearest(increment: IntMicroseconds): Instant {
  *
  * The [increment] must multiply evenly into a second.
  */
-fun Instant.roundedUpToNearest(increment: IntNanoseconds): Instant {
+fun Instant.roundedUpToNearest(increment: Nanoseconds): Instant {
     checkRoundingIncrement(increment)
     return roundedUpToNearestUnchecked(increment)
 }
@@ -455,22 +461,12 @@ fun Instant.roundedUpTo(unit: TimeUnit): Instant {
     }
 }
 
-private fun Time.roundedUpToNearest(increment: LongNanoseconds): Time {
-    checkRoundingIncrement(increment)
-    return roundedUpToNearestUnchecked(increment)
-}
-
-private fun Time.roundedUpToNearestUnchecked(increment: LongNanoseconds): Time {
+private fun Time.roundedUpToNearestUnchecked(increment: Nanoseconds): Time {
     val remainder = nanosecondsSinceStartOfDay % increment.value
     return if (remainder.value > 0) this + (increment - remainder) else this
 }
 
-private fun DateTime.roundedUpToNearest(increment: LongNanoseconds): DateTime {
-    checkRoundingIncrement(increment)
-    return roundedUpToNearestUnchecked(increment)
-}
-
-private fun DateTime.roundedUpToNearestUnchecked(increment: LongNanoseconds): DateTime {
+private fun DateTime.roundedUpToNearestUnchecked(increment: Nanoseconds): DateTime {
     val newTime = time.roundedUpToNearestUnchecked(increment)
 
     return when {
@@ -480,12 +476,12 @@ private fun DateTime.roundedUpToNearestUnchecked(increment: LongNanoseconds): Da
     }
 }
 
-private fun Instant.roundedUpToNearestUnchecked(increment: IntSeconds): Instant {
+private fun Instant.roundedUpToNearestUnchecked(increment: Seconds): Instant {
     val remainder = (secondOfUnixEpoch floorMod increment.value).seconds + additionalNanosecondsSinceUnixEpoch
     return if (remainder.value > 0) this + (increment - remainder) else this
 }
 
-private fun Instant.roundedUpToNearestUnchecked(increment: IntNanoseconds): Instant {
+private fun Instant.roundedUpToNearestUnchecked(increment: Nanoseconds): Instant {
     val remainder = additionalNanosecondsSinceUnixEpoch % increment.value
     return if (remainder.value > 0) this + (increment - remainder) else this
 }

--- a/core/src/commonMain/kotlin/io/islandtime/operators/Truncation.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/operators/Truncation.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package io.islandtime.operators
 
 import io.islandtime.*

--- a/core/src/commonMain/kotlin/io/islandtime/operators/Week.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/operators/Week.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED_PARAMETER")
+@file:Suppress("UNUSED_PARAMETER", "unused")
 
 package io.islandtime.operators
 

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/DateIterators.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/DateIterators.kt
@@ -1,13 +1,13 @@
 package io.islandtime.ranges
 
 import io.islandtime.Date
-import io.islandtime.measures.IntDays
-import io.islandtime.measures.IntMonths
+import io.islandtime.measures.Days
+import io.islandtime.measures.Months
 
 internal class DateDayProgressionIterator(
     first: Date,
     last: Date,
-    private val step: IntDays
+    private val step: Days
 ) : Iterator<Date> {
 
     private val finalElement = last
@@ -36,7 +36,7 @@ internal class DateDayProgressionIterator(
 internal class DateMonthProgressionIterator(
     first: Date,
     last: Date,
-    private val step: IntMonths
+    private val step: Months
 ) : Iterator<Date> {
 
     private val finalElement = last

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/DateRange.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/DateRange.kt
@@ -28,7 +28,7 @@ class DateRange(
 
     override val first: Date get() = start
     override val last: Date get() = endInclusive
-    override val step: IntDays get() = 1.days
+    override val step: Days get() = 1.days
 
     override fun isEmpty(): Boolean {
         return start > endInclusive || endInclusive == Date.MIN || start == Date.MAX
@@ -70,7 +70,7 @@ class DateRange(
      * The number of whole years in this range.
      * @throws UnsupportedOperationException if the range isn't bounded
      */
-    val lengthInYears: IntYears
+    val lengthInYears: Years
         get() = when {
             isEmpty() -> 0.years
             isBounded() -> yearsBetween(start, endInclusive + 1.days)
@@ -81,7 +81,7 @@ class DateRange(
      * The number of whole months in this range.
      * @throws UnsupportedOperationException if the range isn't bounded
      */
-    val lengthInMonths: IntMonths
+    val lengthInMonths: Months
         get() = when {
             isEmpty() -> 0.months
             isBounded() -> monthsBetween(start, endInclusive + 1.days)
@@ -92,9 +92,9 @@ class DateRange(
      * The number of whole weeks in this range.
      * @throws UnsupportedOperationException if the range isn't bounded
      */
-    val lengthInWeeks: LongWeeks
+    val lengthInWeeks: Weeks
         get() = when {
-            isEmpty() -> 0L.weeks
+            isEmpty() -> 0.weeks
             isBounded() -> weeksBetween(start, endInclusive + 1.days)
             else -> throwUnboundedIntervalException()
         }
@@ -104,9 +104,9 @@ class DateRange(
      * will be one day.
      * @throws UnsupportedOperationException if the range isn't bounded
      */
-    val lengthInDays: LongDays
+    val lengthInDays: Days
         get() = when {
-            isEmpty() -> 0L.days
+            isEmpty() -> 0.days
             isBounded() -> daysBetween(start, endInclusive + 1.days)
             else -> throwUnboundedIntervalException()
         }
@@ -179,29 +179,29 @@ fun String.toDateRange(
 /**
  * Creates a [DateRange] containing all of the days from this date up to, but not including [to].
  */
-infix fun Date.until(to: Date): DateRange = DateRange(this, to - 1L.days)
+infix fun Date.until(to: Date): DateRange = DateRange(this, to - 1.days)
 
 /**
  * Gets the [Period] between two dates.
  */
 fun periodBetween(start: Date, endExclusive: Date): Period {
     var totalMonths = endExclusive.monthsSinceYear0 - start.monthsSinceYear0
-    val dayDiff = (endExclusive.dayOfMonth - start.dayOfMonth).days
+    val dayDiff = endExclusive.dayOfMonth - start.dayOfMonth
 
     val days = when {
-        totalMonths > 0 && dayDiff.value < 0 -> {
+        totalMonths > 0 && dayDiff < 0 -> {
             totalMonths--
             val testDate = start + totalMonths.months
-            daysBetween(testDate, endExclusive).toIntDaysUnchecked()
+            daysBetween(testDate, endExclusive)
         }
-        totalMonths < 0 && dayDiff.value > 0 -> {
+        totalMonths < 0 && dayDiff > 0 -> {
             totalMonths++
-            (dayDiff.value - endExclusive.lengthOfMonth.value).days
+            (dayDiff - endExclusive.lengthOfMonth.value).days
         }
-        else -> dayDiff
+        else -> dayDiff.days
     }
-    val years = (totalMonths / MONTHS_PER_YEAR).toInt().years
-    val months = (totalMonths % MONTHS_PER_YEAR).toInt().months
+    val years = (totalMonths / MONTHS_PER_YEAR).years
+    val months = (totalMonths % MONTHS_PER_YEAR).months
 
     return periodOf(years, months, days)
 }
@@ -209,29 +209,29 @@ fun periodBetween(start: Date, endExclusive: Date): Period {
 /**
  * Gets the number of whole years between two dates.
  */
-fun yearsBetween(start: Date, endExclusive: Date): IntYears {
-    return monthsBetween(start, endExclusive).inYears
+fun yearsBetween(start: Date, endExclusive: Date): Years {
+    return monthsBetween(start, endExclusive).inWholeYears
 }
 
 /**
  * Gets the number of whole months between two dates.
  */
-fun monthsBetween(start: Date, endExclusive: Date): IntMonths {
+fun monthsBetween(start: Date, endExclusive: Date): Months {
     val startDays = start.monthsSinceYear0 * 32L + start.dayOfMonth
     val endDays = endExclusive.monthsSinceYear0 * 32L + endExclusive.dayOfMonth
-    return ((endDays - startDays) / 32).toInt().months
+    return ((endDays - startDays) / 32).months
 }
 
 /**
  * Gets the number of whole weeks between two dates.
  */
-fun weeksBetween(start: Date, endExclusive: Date): LongWeeks {
-    return daysBetween(start, endExclusive).inWeeks
+fun weeksBetween(start: Date, endExclusive: Date): Weeks {
+    return daysBetween(start, endExclusive).inWholeWeeks
 }
 
 /**
  * Gets the number of days between two dates.
  */
-fun daysBetween(start: Date, endExclusive: Date): LongDays {
+fun daysBetween(start: Date, endExclusive: Date): Days {
     return endExclusive.daysSinceUnixEpoch - start.daysSinceUnixEpoch
 }

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/DateTimeInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/DateTimeInterval.kt
@@ -3,7 +3,6 @@ package io.islandtime.ranges
 import io.islandtime.*
 import io.islandtime.base.DateTimeField
 import io.islandtime.measures.*
-import io.islandtime.measures.internal.minusWithOverflow
 import io.islandtime.parser.*
 import io.islandtime.ranges.internal.*
 
@@ -84,7 +83,7 @@ class DateTimeInterval(
      * The number of whole years in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInYears: IntYears
+    val lengthInYears: Years
         get() = when {
             isEmpty() -> 0.years
             isBounded() -> yearsBetween(start, endExclusive)
@@ -95,7 +94,7 @@ class DateTimeInterval(
      * The number of whole months in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInMonths: IntMonths
+    val lengthInMonths: Months
         get() = when {
             isEmpty() -> 0.months
             isBounded() -> monthsBetween(start, endExclusive)
@@ -106,7 +105,7 @@ class DateTimeInterval(
      * The number of whole weeks in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInWeeks: LongWeeks
+    val lengthInWeeks: Weeks
         get() = when {
             isEmpty() -> 0L.weeks
             isBounded() -> weeksBetween(start, endExclusive)
@@ -117,7 +116,7 @@ class DateTimeInterval(
      * The number of whole days in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInDays: LongDays
+    val lengthInDays: Days
         get() = when {
             isEmpty() -> 0L.days
             isBounded() -> daysBetween(start, endExclusive)
@@ -128,7 +127,7 @@ class DateTimeInterval(
      * The number of whole hours in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInHours: LongHours
+    val lengthInHours: Hours
         get() = when {
             isEmpty() -> 0L.hours
             isBounded() -> hoursBetween(start, endExclusive)
@@ -139,7 +138,7 @@ class DateTimeInterval(
      * The number of whole minutes in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInMinutes: LongMinutes
+    val lengthInMinutes: Minutes
         get() = when {
             isEmpty() -> 0L.minutes
             isBounded() -> minutesBetween(start, endExclusive)
@@ -150,7 +149,7 @@ class DateTimeInterval(
      * The number of whole seconds in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInSeconds: LongSeconds
+    val lengthInSeconds: Seconds
         get() = when {
             isEmpty() -> 0L.seconds
             isBounded() -> secondsBetween(start, endExclusive)
@@ -161,7 +160,7 @@ class DateTimeInterval(
      * The number of whole milliseconds in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInMilliseconds: LongMilliseconds
+    val lengthInMilliseconds: Milliseconds
         get() = when {
             isEmpty() -> 0L.milliseconds
             isBounded() -> millisecondsBetween(start, endExclusive)
@@ -172,7 +171,7 @@ class DateTimeInterval(
      * The number of whole microseconds in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInMicroseconds: LongMicroseconds
+    val lengthInMicroseconds: Microseconds
         get() = when {
             isEmpty() -> 0L.microseconds
             isBounded() -> microsecondsBetween(start, endExclusive)
@@ -183,7 +182,7 @@ class DateTimeInterval(
      * The number of nanoseconds in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInNanoseconds: LongNanoseconds
+    val lengthInNanoseconds: Nanoseconds
         get() = when {
             isEmpty() -> 0L.nanoseconds
             isBounded() -> nanosecondsBetween(start, endExclusive)
@@ -283,29 +282,29 @@ fun periodBetween(start: DateTime, endExclusive: DateTime): Period {
 /**
  * Gets the number of whole years between two date-times, assuming they're in the same time zone.
  */
-fun yearsBetween(start: DateTime, endExclusive: DateTime): IntYears {
+fun yearsBetween(start: DateTime, endExclusive: DateTime): Years {
     return yearsBetween(start.date, adjustedEndDate(start, endExclusive))
 }
 
 /**
  * Gets the number of whole months between two date-times, assuming they're in the same time zone.
  */
-fun monthsBetween(start: DateTime, endExclusive: DateTime): IntMonths {
+fun monthsBetween(start: DateTime, endExclusive: DateTime): Months {
     return monthsBetween(start.date, adjustedEndDate(start, endExclusive))
 }
 
 /**
  * Gets the number whole weeks between two date-times, assuming they're in the same time zone.
  */
-fun weeksBetween(start: DateTime, endExclusive: DateTime): LongWeeks {
-    return daysBetween(start, endExclusive).inWeeks
+fun weeksBetween(start: DateTime, endExclusive: DateTime): Weeks {
+    return daysBetween(start, endExclusive).inWholeWeeks
 }
 
 /**
  * Gets the number whole days between two date-times, assuming they're in the same time zone.
  */
-fun daysBetween(start: DateTime, endExclusive: DateTime): LongDays {
-    return secondsBetween(start, endExclusive).inDays
+fun daysBetween(start: DateTime, endExclusive: DateTime): Days {
+    return secondsBetween(start, endExclusive).inWholeDays
 }
 
 /**
@@ -314,13 +313,9 @@ fun daysBetween(start: DateTime, endExclusive: DateTime): LongDays {
  * when working with [DateTime] directly.
  */
 fun durationBetween(start: DateTime, endExclusive: DateTime): Duration {
-    val secondDiff =
-        endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO) - start.secondsSinceUnixEpochAt(UtcOffset.ZERO)
-
-    val nanoDiff =
-        endExclusive.additionalNanosecondsSinceUnixEpoch minusWithOverflow start.additionalNanosecondsSinceUnixEpoch
-
-    return durationOf(secondDiff, nanoDiff)
+    val secondDiff = endExclusive.secondOfUnixEpochAt(UtcOffset.ZERO) - start.secondOfUnixEpochAt(UtcOffset.ZERO)
+    val nanoDiff = endExclusive.nanosecond - start.nanosecond
+    return durationOf(secondDiff.seconds, nanoDiff.nanoseconds)
 }
 
 /**
@@ -328,8 +323,8 @@ fun durationBetween(start: DateTime, endExclusive: DateTime): Duration {
  * appropriate to calculate duration using [Instant] or [ZonedDateTime] as any daylight savings rules won't be taken
  * into account when working with [DateTime] directly.
  */
-fun hoursBetween(start: DateTime, endExclusive: DateTime): LongHours {
-    return secondsBetween(start, endExclusive).inHours
+fun hoursBetween(start: DateTime, endExclusive: DateTime): Hours {
+    return secondsBetween(start, endExclusive).inWholeHours
 }
 
 /**
@@ -337,8 +332,8 @@ fun hoursBetween(start: DateTime, endExclusive: DateTime): LongHours {
  * more appropriate to calculate duration using [Instant] or [ZonedDateTime] as any daylight savings rules won't be
  * taken into account when working with [DateTime] directly.
  */
-fun minutesBetween(start: DateTime, endExclusive: DateTime): LongMinutes {
-    return secondsBetween(start, endExclusive).inMinutes
+fun minutesBetween(start: DateTime, endExclusive: DateTime): Minutes {
+    return secondsBetween(start, endExclusive).inWholeMinutes
 }
 
 /**
@@ -348,12 +343,12 @@ fun minutesBetween(start: DateTime, endExclusive: DateTime): LongMinutes {
  *
  * @throws ArithmeticException if the result overflows
  */
-fun secondsBetween(start: DateTime, endExclusive: DateTime): LongSeconds {
+fun secondsBetween(start: DateTime, endExclusive: DateTime): Seconds {
     return secondsBetween(
-        start.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        start.additionalNanosecondsSinceUnixEpoch,
-        endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        endExclusive.additionalNanosecondsSinceUnixEpoch
+        start.secondOfUnixEpochAt(UtcOffset.ZERO),
+        start.nanosecond,
+        endExclusive.secondOfUnixEpochAt(UtcOffset.ZERO),
+        endExclusive.nanosecond
     )
 }
 
@@ -364,12 +359,12 @@ fun secondsBetween(start: DateTime, endExclusive: DateTime): LongSeconds {
  *
  * @throws ArithmeticException if the result overflows
  */
-fun millisecondsBetween(start: DateTime, endExclusive: DateTime): LongMilliseconds {
+fun millisecondsBetween(start: DateTime, endExclusive: DateTime): Milliseconds {
     return millisecondsBetween(
-        start.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        start.additionalNanosecondsSinceUnixEpoch,
-        endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        endExclusive.additionalNanosecondsSinceUnixEpoch
+        start.secondOfUnixEpochAt(UtcOffset.ZERO),
+        start.nanosecond,
+        endExclusive.secondOfUnixEpochAt(UtcOffset.ZERO),
+        endExclusive.nanosecond
     )
 }
 
@@ -380,12 +375,12 @@ fun millisecondsBetween(start: DateTime, endExclusive: DateTime): LongMillisecon
  *
  *  @throws ArithmeticException if the result overflows
  */
-fun microsecondsBetween(start: DateTime, endExclusive: DateTime): LongMicroseconds {
+fun microsecondsBetween(start: DateTime, endExclusive: DateTime): Microseconds {
     return microsecondsBetween(
-        start.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        start.additionalNanosecondsSinceUnixEpoch,
-        endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        endExclusive.additionalNanosecondsSinceUnixEpoch
+        start.secondOfUnixEpochAt(UtcOffset.ZERO),
+        start.nanosecond,
+        endExclusive.secondOfUnixEpochAt(UtcOffset.ZERO),
+        endExclusive.nanosecond
     )
 }
 
@@ -396,12 +391,12 @@ fun microsecondsBetween(start: DateTime, endExclusive: DateTime): LongMicrosecon
  *
  * @throws ArithmeticException if the result overflows
  */
-fun nanosecondsBetween(start: DateTime, endExclusive: DateTime): LongNanoseconds {
+fun nanosecondsBetween(start: DateTime, endExclusive: DateTime): Nanoseconds {
     return nanosecondsBetween(
-        start.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        start.additionalNanosecondsSinceUnixEpoch,
-        endExclusive.secondsSinceUnixEpochAt(UtcOffset.ZERO),
-        endExclusive.additionalNanosecondsSinceUnixEpoch
+        start.secondOfUnixEpochAt(UtcOffset.ZERO),
+        start.nanosecond,
+        endExclusive.secondOfUnixEpochAt(UtcOffset.ZERO),
+        endExclusive.nanosecond
     )
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/InstantInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/InstantInterval.kt
@@ -2,6 +2,7 @@ package io.islandtime.ranges
 
 import io.islandtime.*
 import io.islandtime.base.DateTimeField
+import io.islandtime.internal.deprecatedToError
 import io.islandtime.measures.nanoseconds
 import io.islandtime.parser.*
 import io.islandtime.ranges.internal.buildIsoString
@@ -122,11 +123,13 @@ infix fun Instant.until(to: Instant): InstantInterval = InstantInterval(this, to
     ReplaceWith("this.toInstantInterval()"),
     DeprecationLevel.ERROR
 )
-fun OffsetDateTimeInterval.asInstantInterval(): InstantInterval = toInstantInterval()
+@Suppress("unused")
+fun OffsetDateTimeInterval.asInstantInterval(): InstantInterval = deprecatedToError()
 
 @Deprecated(
     "Use toInstantInterval() instead.",
     ReplaceWith("this.toInstantInterval()"),
     DeprecationLevel.ERROR
 )
-fun ZonedDateTimeInterval.asInstantInterval(): InstantInterval = toInstantInterval()
+@Suppress("unused")
+fun ZonedDateTimeInterval.asInstantInterval(): InstantInterval = deprecatedToError()

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/OffsetDateTimeInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/OffsetDateTimeInterval.kt
@@ -47,7 +47,7 @@ class OffsetDateTimeInterval(
      * The number of whole years in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInYears: IntYears
+    val lengthInYears: Years
         get() = when {
             isEmpty() -> 0.years
             isBounded() -> yearsBetween(start, endExclusive)
@@ -58,7 +58,7 @@ class OffsetDateTimeInterval(
      * The number of whole months in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInMonths: IntMonths
+    val lengthInMonths: Months
         get() = when {
             isEmpty() -> 0.months
             isBounded() -> monthsBetween(start, endExclusive)
@@ -69,7 +69,7 @@ class OffsetDateTimeInterval(
      * The number of whole weeks in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInWeeks: LongWeeks
+    val lengthInWeeks: Weeks
         get() = when {
             isEmpty() -> 0L.weeks
             isBounded() -> weeksBetween(start, endExclusive)
@@ -180,7 +180,7 @@ fun periodBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): Period {
  * Gets the number of whole years between two date-times, adjusting the offset of [endExclusive] if necessary to match
  * the starting date-time.
  */
-fun yearsBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): IntYears {
+fun yearsBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): Years {
     return yearsBetween(start.dateTime, adjustedEndDateTime(start, endExclusive))
 }
 
@@ -188,7 +188,7 @@ fun yearsBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): IntYears 
  * Gets the number of whole months between two date-times, adjusting the offset of [endExclusive] if necessary to match
  * the starting date-time.
  */
-fun monthsBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): IntMonths {
+fun monthsBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): Months {
     return monthsBetween(start.dateTime, adjustedEndDateTime(start, endExclusive))
 }
 
@@ -196,7 +196,7 @@ fun monthsBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): IntMonth
  * Gets the number whole weeks between two date-times, adjusting the offset of [endExclusive] if necessary to match the
  * starting date-time.
  */
-fun weeksBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): LongWeeks {
+fun weeksBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): Weeks {
     return weeksBetween(start.dateTime, adjustedEndDateTime(start, endExclusive))
 }
 
@@ -204,7 +204,7 @@ fun weeksBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): LongWeeks
  * Gets the number whole days between two date-times, adjusting the offset of [endExclusive] if necessary to match the
  * starting date-time.
  */
-fun daysBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): LongDays {
+fun daysBetween(start: OffsetDateTime, endExclusive: OffsetDateTime): Days {
     return daysBetween(start.dateTime, adjustedEndDateTime(start, endExclusive))
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/TimePointIterators.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/TimePointIterators.kt
@@ -1,12 +1,13 @@
 package io.islandtime.ranges
 
 import io.islandtime.base.TimePoint
-import io.islandtime.measures.*
+import io.islandtime.measures.Nanoseconds
+import io.islandtime.measures.Seconds
 
 internal class TimePointSecondProgressionIterator<T : TimePoint<T>>(
     first: T,
     last: T,
-    private val step: LongSeconds
+    private val step: Seconds
 ) : Iterator<T> {
 
     private val finalElement = last
@@ -35,7 +36,7 @@ internal class TimePointSecondProgressionIterator<T : TimePoint<T>>(
 internal class TimePointNanosecondProgressionIterator<T : TimePoint<T>>(
     first: T,
     last: T,
-    private val step: LongNanoseconds
+    private val step: Nanoseconds
 ) : Iterator<T> {
 
     private val finalElement = last

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/TimePointProgressions.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/TimePointProgressions.kt
@@ -25,7 +25,7 @@ private class DefaultTimePointProgressionBuilder<T : TimePoint<T>>(
 class TimePointSecondProgression<T : TimePoint<T>> private constructor(
     start: T,
     endInclusive: T,
-    val step: LongSeconds
+    val step: Seconds
 ) : TimePointProgressionBuilder<T>,
     Iterable<T> {
 
@@ -75,7 +75,7 @@ class TimePointSecondProgression<T : TimePoint<T>> private constructor(
         fun <T : TimePoint<T>> fromClosedRange(
             rangeStart: T,
             rangeEnd: T,
-            step: LongSeconds
+            step: Seconds
         ): TimePointSecondProgression<T> = TimePointSecondProgression(rangeStart, rangeEnd, step)
     }
 }
@@ -83,7 +83,7 @@ class TimePointSecondProgression<T : TimePoint<T>> private constructor(
 class TimePointNanosecondProgression<T : TimePoint<T>> private constructor(
     start: T,
     endInclusive: T,
-    val step: LongNanoseconds
+    val step: Nanoseconds
 ) : TimePointProgressionBuilder<T>,
     Iterable<T> {
 
@@ -133,7 +133,7 @@ class TimePointNanosecondProgression<T : TimePoint<T>> private constructor(
         fun <T : TimePoint<T>> fromClosedRange(
             rangeStart: T,
             rangeEnd: T,
-            step: LongNanoseconds
+            step: Nanoseconds
         ): TimePointNanosecondProgression<T> = TimePointNanosecondProgression(rangeStart, rangeEnd, step)
     }
 }
@@ -145,45 +145,32 @@ infix fun <T : TimePoint<T>> T.downTo(to: T): TimePointProgressionBuilder<T> {
     return DefaultTimePointProgressionBuilder(this, to)
 }
 
-infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(step: IntDays): TimePointSecondProgression<T> {
+infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(step: Days): TimePointSecondProgression<T> {
     require(step.value > 0) { "step must be positive" }
-    val longStep = step.toLongDays()
-    val secondStep = (if (last > first) longStep else longStep.negateUnchecked()).inSecondsUnchecked
+    val secondStep = (if (last > first) step else -step).inSeconds
     return TimePointSecondProgression.fromClosedRange(first, last, secondStep)
 }
 
-infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(step: IntHours): TimePointSecondProgression<T> {
+infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(step: Hours): TimePointSecondProgression<T> {
     require(step.value > 0) { "step must be positive" }
-    val longStep = step.toLongHours()
-    val secondStep = (if (last > first) longStep else longStep.negateUnchecked()).inSecondsUnchecked
+    val secondStep = (if (last > first) step else -step).inSeconds
     return TimePointSecondProgression.fromClosedRange(first, last, secondStep)
 }
 
-infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(step: IntMinutes): TimePointSecondProgression<T> {
+infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(step: Minutes): TimePointSecondProgression<T> {
     require(step.value > 0) { "step must be positive" }
-    val longStep = step.toLongMinutes()
-    val secondStep = (if (last > first) longStep else longStep.negateUnchecked()).inSecondsUnchecked
+    val secondStep = (if (last > first) step else -step).inSeconds
     return TimePointSecondProgression.fromClosedRange(first, last, secondStep)
 }
 
-infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(step: IntSeconds): TimePointSecondProgression<T> {
+infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(step: Seconds): TimePointSecondProgression<T> {
     require(step.value > 0) { "step must be positive" }
-    val longStep = step.toLongSeconds()
-    val secondStep = (if (last > first) longStep else longStep.negateUnchecked())
+    val secondStep = (if (last > first) step else -step)
     return TimePointSecondProgression.fromClosedRange(first, last, secondStep)
 }
 
 infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(
-    step: IntMilliseconds
-): TimePointNanosecondProgression<T> {
-    require(step.value > 0) { "step must be positive" }
-    val longStep = step.toLongMilliseconds()
-    val nanoStep = (if (last > first) longStep else longStep.negateUnchecked()).inNanosecondsUnchecked
-    return TimePointNanosecondProgression.fromClosedRange(first, last, nanoStep)
-}
-
-infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(
-    step: LongMilliseconds
+    step: Milliseconds
 ): TimePointNanosecondProgression<T> {
     require(step.value > 0) { "step must be positive" }
     val nanoStep = (if (last > first) step else -step).inNanoseconds
@@ -191,16 +178,7 @@ infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(
 }
 
 infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(
-    step: IntMicroseconds
-): TimePointNanosecondProgression<T> {
-    require(step.value > 0) { "step must be positive" }
-    val longStep = step.toLongMicroseconds()
-    val nanoStep = (if (last > first) longStep else longStep.negateUnchecked()).inNanosecondsUnchecked
-    return TimePointNanosecondProgression.fromClosedRange(first, last, nanoStep)
-}
-
-infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(
-    step: LongMicroseconds
+    step: Microseconds
 ): TimePointNanosecondProgression<T> {
     require(step.value > 0) { "step must be positive" }
     val nanoStep = (if (last > first) step else -step).inNanoseconds
@@ -208,16 +186,7 @@ infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(
 }
 
 infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(
-    step: IntNanoseconds
-): TimePointNanosecondProgression<T> {
-    require(step.value > 0) { "step must be positive" }
-    val longStep = step.toLongNanoseconds()
-    val nanoStep = if (last > first) longStep else longStep.negateUnchecked()
-    return TimePointNanosecondProgression.fromClosedRange(first, last, nanoStep)
-}
-
-infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(
-    step: LongNanoseconds
+    step: Nanoseconds
 ): TimePointNanosecondProgression<T> {
     require(step.value > 0) { "step must be positive" }
     val nanoStep = if (last > first) step else -step
@@ -227,7 +196,7 @@ infix fun <T : TimePoint<T>> TimePointProgressionBuilder<T>.step(
 /**
  * Assumes step is non-zero
  */
-private fun <T : TimePoint<T>> getLastTimePointInProgression(start: T, end: T, step: LongSeconds): T {
+private fun <T : TimePoint<T>> getLastTimePointInProgression(start: T, end: T, step: Seconds): T {
     return if ((step.value > 0 && start >= end) || (step.value < 0 && start <= end)) {
         end
     } else {
@@ -240,7 +209,7 @@ private fun <T : TimePoint<T>> getLastTimePointInProgression(start: T, end: T, s
 /**
  * Assumes step is non-zero
  */
-private fun <T : TimePoint<T>> getLastTimePointInProgression(start: T, end: T, step: LongNanoseconds): T {
+private fun <T : TimePoint<T>> getLastTimePointInProgression(start: T, end: T, step: Nanoseconds): T {
     return if ((step.value > 0 && start >= end) || (step.value < 0 && start <= end)) {
         end
     } else {

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/TimePointProgressions.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/TimePointProgressions.kt
@@ -30,7 +30,7 @@ class TimePointSecondProgression<T : TimePoint<T>> private constructor(
     Iterable<T> {
 
     init {
-        require(!step.isZero()) { "Step must be non-zero" }
+        require(step != 0L.seconds) { "Step must be non-zero" }
     }
 
     override val first: T = start
@@ -76,7 +76,7 @@ class TimePointSecondProgression<T : TimePoint<T>> private constructor(
             rangeStart: T,
             rangeEnd: T,
             step: LongSeconds
-        ) = TimePointSecondProgression(rangeStart, rangeEnd, step)
+        ): TimePointSecondProgression<T> = TimePointSecondProgression(rangeStart, rangeEnd, step)
     }
 }
 
@@ -88,7 +88,7 @@ class TimePointNanosecondProgression<T : TimePoint<T>> private constructor(
     Iterable<T> {
 
     init {
-        require(!step.isZero()) { "Step must be non-zero" }
+        require(step != 0L.nanoseconds) { "Step must be non-zero" }
     }
 
     override val first: T = start
@@ -134,7 +134,7 @@ class TimePointNanosecondProgression<T : TimePoint<T>> private constructor(
             rangeStart: T,
             rangeEnd: T,
             step: LongNanoseconds
-        ) = TimePointNanosecondProgression(rangeStart, rangeEnd, step)
+        ): TimePointNanosecondProgression<T> = TimePointNanosecondProgression(rangeStart, rangeEnd, step)
     }
 }
 

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/ZonedDateTimeInterval.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/ZonedDateTimeInterval.kt
@@ -2,6 +2,7 @@ package io.islandtime.ranges
 
 import io.islandtime.*
 import io.islandtime.base.DateTimeField
+import io.islandtime.internal.deprecatedToError
 import io.islandtime.measures.*
 import io.islandtime.parser.*
 import io.islandtime.ranges.internal.MAX_INCLUSIVE_END_DATE_TIME
@@ -48,7 +49,7 @@ class ZonedDateTimeInterval(
      * The number of whole years in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInYears: IntYears
+    val lengthInYears: Years
         get() = when {
             isEmpty() -> 0.years
             isBounded() -> yearsBetween(start, endExclusive)
@@ -59,7 +60,7 @@ class ZonedDateTimeInterval(
      * The number of whole months is this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInMonths: IntMonths
+    val lengthInMonths: Months
         get() = when {
             isEmpty() -> 0.months
             isBounded() -> monthsBetween(start, endExclusive)
@@ -70,9 +71,9 @@ class ZonedDateTimeInterval(
      * The number of whole weeks in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    val lengthInWeeks: LongWeeks
+    val lengthInWeeks: Weeks
         get() = when {
-            isEmpty() -> 0L.weeks
+            isEmpty() -> 0.weeks
             isBounded() -> weeksBetween(start, endExclusive)
             else -> throwUnboundedIntervalException()
         }
@@ -81,9 +82,9 @@ class ZonedDateTimeInterval(
      * The number of whole days in this interval.
      * @throws UnsupportedOperationException if the interval isn't bounded
      */
-    override val lengthInDays: LongDays
+    override val lengthInDays: Days
         get() = when {
-            isEmpty() -> 0L.days
+            isEmpty() -> 0.days
             isBounded() -> daysBetween(start, endExclusive)
             else -> throwUnboundedIntervalException()
         }
@@ -186,7 +187,8 @@ infix fun ZonedDateTime.until(to: ZonedDateTime): ZonedDateTimeInterval = ZonedD
     ReplaceWith("this at zone"),
     DeprecationLevel.ERROR
 )
-fun DateRange.toZonedDateTimeInterval(zone: TimeZone): ZonedDateTimeInterval = this at zone
+@Suppress("UNUSED_PARAMETER", "unused")
+fun DateRange.toZonedDateTimeInterval(zone: TimeZone): ZonedDateTimeInterval = deprecatedToError()
 
 /**
  * Gets the [Period] between two zoned date-times, adjusting the time zone of [endExclusive] if necessary to match the
@@ -200,7 +202,7 @@ fun periodBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): Period {
  * Gets the number of whole years between two zoned date-times, adjusting the time zone of [endExclusive] if necessary
  * to match the starting date-time.
  */
-fun yearsBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): IntYears {
+fun yearsBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): Years {
     return yearsBetween(start.dateTime, endExclusive.adjustedTo(start.zone).dateTime)
 }
 
@@ -208,7 +210,7 @@ fun yearsBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): IntYears {
  * Gets the number of whole months between two zoned date-times, adjusting the time zone of [endExclusive] if necessary
  * to match the starting date-time.
  */
-fun monthsBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): IntMonths {
+fun monthsBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): Months {
     return monthsBetween(start.dateTime, endExclusive.adjustedTo(start.zone).dateTime)
 }
 
@@ -216,7 +218,7 @@ fun monthsBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): IntMonths 
  * Gets the number of whole weeks between two zoned date-times, adjusting the time zone of [endExclusive] if necessary
  * to match the starting date-time.
  */
-fun weeksBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): LongWeeks {
+fun weeksBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): Weeks {
     return weeksBetween(start.dateTime, endExclusive.adjustedTo(start.zone).dateTime)
 }
 
@@ -224,6 +226,6 @@ fun weeksBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): LongWeeks {
  * Gets the number of whole days between two zoned date-times, adjusting the time zone of [endExclusive] if necessary to
  * match the starting date-time.
  */
-fun daysBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): LongDays {
+fun daysBetween(start: ZonedDateTime, endExclusive: ZonedDateTime): Days {
     return daysBetween(start.dateTime, endExclusive.adjustedTo(start.zone).dateTime)
 }

--- a/core/src/commonMain/kotlin/io/islandtime/ranges/internal/Common.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ranges/internal/Common.kt
@@ -2,55 +2,53 @@ package io.islandtime.ranges.internal
 
 import io.islandtime.DateTime
 import io.islandtime.measures.*
-import io.islandtime.measures.internal.minusWithOverflow
 import io.islandtime.ranges.Interval
 
-internal val MAX_INCLUSIVE_END_DATE_TIME = DateTime.MAX - 2.nanoseconds
+internal val MAX_INCLUSIVE_END_DATE_TIME: DateTime = DateTime.MAX - 2.nanoseconds
 
 internal fun secondsBetween(
-    startSeconds: LongSeconds,
-    startNanoseconds: IntNanoseconds,
-    endExclusiveSeconds: LongSeconds,
-    endExclusiveNanoseconds: IntNanoseconds
-): LongSeconds {
-    val secondDiff = endExclusiveSeconds - startSeconds
-    val nanoDiff = endExclusiveNanoseconds minusWithOverflow startNanoseconds
+    startSecond: Long,
+    startNanosecond: Int,
+    endExclusiveSecond: Long,
+    endExclusiveNanosecond: Int
+): Seconds {
+    val secondDiff = endExclusiveSecond - startSecond
+    val nanoDiff = endExclusiveNanosecond - startNanosecond
 
     return when {
-        secondDiff.value > 0 && nanoDiff.value < 0 -> secondDiff - 1.seconds
-        secondDiff.value < 0 && nanoDiff.value > 0 -> secondDiff + 1.seconds
+        secondDiff > 0 && nanoDiff < 0 -> secondDiff - 1
+        secondDiff < 0 && nanoDiff > 0 -> secondDiff + 1
         else -> secondDiff
-    }
+    }.seconds
 }
 
 internal fun millisecondsBetween(
-    startSeconds: LongSeconds,
-    startNanoseconds: IntNanoseconds,
-    endExclusiveSeconds: LongSeconds,
-    endExclusiveNanoseconds: IntNanoseconds
-): LongMilliseconds {
-    return (endExclusiveSeconds - startSeconds).inMilliseconds +
-        (endExclusiveNanoseconds - startNanoseconds).inMilliseconds
+    startSecond: Long,
+    startNanosecond: Int,
+    endExclusiveSecond: Long,
+    endExclusiveNanosecond: Int
+): Milliseconds {
+    return (endExclusiveSecond - startSecond).seconds +
+        (endExclusiveNanosecond - startNanosecond).nanoseconds.inWholeMilliseconds
 }
 
 internal fun microsecondsBetween(
-    startSeconds: LongSeconds,
-    startNanoseconds: IntNanoseconds,
-    endExclusiveSeconds: LongSeconds,
-    endExclusiveNanoseconds: IntNanoseconds
-): LongMicroseconds {
-    return (endExclusiveSeconds - startSeconds).inMicroseconds +
-        (endExclusiveNanoseconds - startNanoseconds).inMicroseconds
+    startSecond: Long,
+    startNanosecond: Int,
+    endExclusiveSecond: Long,
+    endExclusiveNanosecond: Int
+): Microseconds {
+    return (endExclusiveSecond - startSecond).seconds +
+        (endExclusiveNanosecond - startNanosecond).nanoseconds.inWholeMicroseconds
 }
 
 internal fun nanosecondsBetween(
-    startSeconds: LongSeconds,
-    startNanoseconds: IntNanoseconds,
-    endExclusiveSeconds: LongSeconds,
-    endExclusiveNanoseconds: IntNanoseconds
-): LongNanoseconds {
-    return (endExclusiveSeconds - startSeconds).inNanoseconds +
-        (endExclusiveNanoseconds - startNanoseconds)
+    startSecond: Long,
+    startNanosecond: Int,
+    endExclusiveSecond: Long,
+    endExclusiveNanosecond: Int
+): Nanoseconds {
+    return (endExclusiveSecond - startSecond).seconds + (endExclusiveNanosecond - startNanosecond).nanoseconds
 }
 
 internal inline fun <T> Interval<T>.buildIsoString(

--- a/core/src/commonMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
@@ -1,7 +1,10 @@
 package io.islandtime.zone
 
 import io.islandtime.*
-import io.islandtime.measures.*
+import io.islandtime.measures.Milliseconds
+import io.islandtime.measures.Nanoseconds
+import io.islandtime.measures.Seconds
+import io.islandtime.measures.seconds
 
 class TimeZoneRulesException(
     message: String? = null,
@@ -94,7 +97,7 @@ interface TimeZoneOffsetTransition {
     /**
      * The duration of the transition period in seconds.
      */
-    val duration: IntSeconds
+    val duration: Seconds
 
     /**
      * Gets a list of the valid offsets during this transition. If this is gap, the list will be empty. If this is an
@@ -116,12 +119,12 @@ interface TimeZoneRules {
     /**
      * Gets the offset in effect at a certain number of milliseconds since the Unix epoch.
      */
-    fun offsetAt(millisecondsSinceUnixEpoch: LongMilliseconds): UtcOffset
+    fun offsetAt(millisecondsSinceUnixEpoch: Milliseconds): UtcOffset
 
     /**
      * Gets the offset in effect at a certain number of seconds since the Unix epoch.
      */
-    fun offsetAt(secondsSinceUnixEpoch: LongSeconds, nanoOfSeconds: IntNanoseconds): UtcOffset
+    fun offsetAt(secondsSinceUnixEpoch: Seconds, nanoOfSeconds: Nanoseconds): UtcOffset
 
     /**
      * Gets the offset in effect at a particular instant.
@@ -162,7 +165,7 @@ interface TimeZoneRules {
      * Gets the amount of daylight savings time in effect at a particular instant. This is the amount of time added to
      * the standard offset.
      */
-    fun daylightSavingsAt(instant: Instant): IntSeconds
+    fun daylightSavingsAt(instant: Instant): Seconds
 }
 
 /**
@@ -171,9 +174,9 @@ interface TimeZoneRules {
 internal class FixedTimeZoneRules(private val offset: UtcOffset) : TimeZoneRules {
     override val hasFixedOffset: Boolean get() = true
 
-    override fun offsetAt(millisecondsSinceUnixEpoch: LongMilliseconds) = offset
+    override fun offsetAt(millisecondsSinceUnixEpoch: Milliseconds) = offset
 
-    override fun offsetAt(secondsSinceUnixEpoch: LongSeconds, nanoOfSeconds: IntNanoseconds): UtcOffset {
+    override fun offsetAt(secondsSinceUnixEpoch: Seconds, nanoOfSeconds: Nanoseconds): UtcOffset {
         return offset
     }
 

--- a/core/src/commonTest/kotlin/io/islandtime/MonthTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/MonthTest.kt
@@ -52,12 +52,12 @@ class MonthTest : AbstractIslandTimeTest() {
 
     @Test
     fun `first day in common year`() {
-        assertEquals(60, Month.MARCH.firstDayOfCommonYear)
+        assertEquals(60, Month.MARCH.firstDayOfYearInCommonYear)
     }
 
     @Test
     fun `first day in leap year`() {
-        assertEquals(61, Month.MARCH.firstDayOfLeapYear)
+        assertEquals(61, Month.MARCH.firstDayOfYearInLeapYear)
     }
 
     @Test

--- a/core/src/commonTest/kotlin/io/islandtime/UtcOffsetTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/UtcOffsetTest.kt
@@ -43,27 +43,27 @@ class UtcOffsetTest : AbstractIslandTimeTest() {
     }
 
     @Test
-    fun `IntHours_asUtcOffset() creates a UtcOffset from a duration of hours`() {
+    fun `Hours_asUtcOffset() creates a UtcOffset from a duration of hours`() {
         assertEquals((-3600).seconds, (-1).hours.asUtcOffset().totalSeconds)
     }
 
     @Test
-    fun `IntHours_asUtcOffset() throws an exception on overflow`() {
-        assertFailsWith<ArithmeticException> { Int.MAX_VALUE.hours.asUtcOffset() }
+    fun `Hours_asUtcOffset() throws an exception on overflow`() {
+        assertFailsWith<DateTimeException> { Int.MAX_VALUE.hours.asUtcOffset() }
     }
 
     @Test
-    fun `IntMinutes_asUtcOffset() creates a UtcOffset from a duration of minutes`() {
+    fun `Minutes_asUtcOffset() creates a UtcOffset from a duration of minutes`() {
         assertEquals((-12_000).seconds, (-200).minutes.asUtcOffset().totalSeconds)
     }
 
     @Test
-    fun `IntMinutes_asUtcOffset() throws an exception on overflow`() {
-        assertFailsWith<ArithmeticException> { Int.MAX_VALUE.minutes.asUtcOffset() }
+    fun `Minutes_asUtcOffset() throws an exception on overflow`() {
+        assertFailsWith<DateTimeException> { Int.MAX_VALUE.minutes.asUtcOffset() }
     }
 
     @Test
-    fun `IntSeconds_asUtcOffset() creates a UtcOffset from a duration of seconds`() {
+    fun `Seconds_asUtcOffset() creates a UtcOffset from a duration of seconds`() {
         assertEquals(1.seconds, 1.seconds.asUtcOffset().totalSeconds)
     }
 

--- a/core/src/commonTest/kotlin/io/islandtime/measures/DaysTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/measures/DaysTest.kt
@@ -8,49 +8,21 @@ import kotlin.time.Duration as KotlinDuration
 
 class DaysTest {
     @Test
-    fun `IntDays can be compared to other IntDays`() {
+    fun `Days can be compared to other Days`() {
         assertTrue { 0.days < 1.days }
         assertTrue { 0.days == 0.days }
         assertTrue { 5.days > (-1).days }
     }
 
     @Test
-    fun `LongDays can be compared to other LongDays`() {
-        assertTrue { 0L.days < 1L.days }
-        assertTrue { 0L.days == 0L.days }
-        assertTrue { 5L.days > (-1L).days }
-    }
-
-    @Test
-    fun `toLongDays() converts IntDays to LongDays`() {
-        assertEquals(2L.days, 2.days.toLongDays())
-    }
-
-    @Test
-    fun `toIntDays() converts LongDays to IntDays`() {
-        assertEquals(2.days, 2L.days.toIntDays())
-    }
-
-    @Test
-    fun `IntDays_toString() converts zero days to 'P0D'`() {
+    fun `toString() converts zero days to 'P0D'`() {
         assertEquals("P0D", 0.days.toString())
     }
 
     @Test
-    fun `IntDays_toString() converts to ISO-8601 period representation`() {
+    fun `toString() converts to ISO-8601 period representation`() {
         assertEquals("P1D", 1.days.toString())
         assertEquals("-P1D", (-1).days.toString())
-    }
-
-    @Test
-    fun `LongDays_toString() converts zero days to 'P0D'`() {
-        assertEquals("P0D", 0L.days.toString())
-    }
-
-    @Test
-    fun `LongDays_toString() converts to ISO-8601 period representation`() {
-        assertEquals("P1D", 1L.days.toString())
-        assertEquals("-P1D", (-1L).days.toString())
     }
 
     @ExperimentalTime
@@ -65,9 +37,9 @@ class DaysTest {
     @ExperimentalTime
     @Test
     fun `conversion from Kotlin Duration`() {
-        assertEquals(0L.days, KotlinDuration.days(0).toIslandDays())
-        assertEquals(1L.days, KotlinDuration.days(1).toIslandDays())
-        assertEquals((-1L).days, KotlinDuration.days(-1L).toIslandDays())
+        assertEquals(0.days, KotlinDuration.days(0).toIslandDays())
+        assertEquals(1.days, KotlinDuration.days(1).toIslandDays())
+        assertEquals((-1).days, KotlinDuration.days(-1L).toIslandDays())
         assertEquals(Long.MIN_VALUE.days, KotlinDuration.days(Long.MIN_VALUE).toIslandDays())
     }
 }

--- a/core/src/commonTest/kotlin/io/islandtime/measures/HoursTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/measures/HoursTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 
 class HoursTest {
     @Test
-    fun `IntHours_toComponents() breaks the hours up into days and hours`() {
+    fun `toComponents() breaks the hours up into days and hours`() {
         36.hours.toComponents { days, hours ->
             assertEquals(1.days, days)
             assertEquals(12.hours, hours)
@@ -13,32 +13,21 @@ class HoursTest {
     }
 
     @Test
-    fun `LongHours_toComponents() breaks the hours up into days and hours`() {
-        36L.hours.toComponents { days, hours ->
-            assertEquals(1L.days, days)
-            assertEquals(12.hours, hours)
+    fun `toComponentValues() breaks the hours up into days and hours`() {
+        36.hours.toComponentValues { days, hours ->
+            assertEquals(1L, days)
+            assertEquals(12, hours)
         }
     }
 
     @Test
-    fun `IntHours_toString() converts zero hours to 'PT0H'`() {
+    fun `toString() converts zero hours to 'PT0H'`() {
         assertEquals("PT0H", 0.hours.toString())
     }
 
     @Test
-    fun `IntHours_toString() converts to ISO-8601 period representation`() {
+    fun `toString() converts to ISO-8601 period representation`() {
         assertEquals("PT1H", 1.hours.toString())
         assertEquals("-PT1H", (-1).hours.toString())
-    }
-
-    @Test
-    fun `LongHours_toString() converts zero hours to 'PT0H'`() {
-        assertEquals("PT0H", 0L.hours.toString())
-    }
-
-    @Test
-    fun `LongHours_toString() converts to ISO-8601 period representation`() {
-        assertEquals("PT1H", 1L.hours.toString())
-        assertEquals("-PT1H", (-1L).hours.toString())
     }
 }

--- a/core/src/commonTest/kotlin/io/islandtime/measures/MinutesTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/measures/MinutesTest.kt
@@ -11,13 +11,13 @@ class MinutesTest {
     }
 
     @Test
-    fun `inMilliseconds always converts to LongMilliseconds`() {
+    fun `inMilliseconds converts to Milliseconds`() {
         assertEquals((-300_000L).milliseconds, (-5).minutes.inMilliseconds)
         assertEquals(60_000L.milliseconds, 1L.minutes.inMilliseconds)
     }
 
     @Test
-    fun `IntHours_toComponents() breaks the minutes up into days, hours, and minutes`() {
+    fun `toComponents() breaks the minutes up into days, hours, and minutes`() {
         (1.days + 1.hours + 1.minutes).toComponents { days, hours, minutes ->
             assertEquals(1.days, days)
             assertEquals(1.hours, hours)
@@ -26,7 +26,16 @@ class MinutesTest {
     }
 
     @Test
-    fun `IntHours_toComponents() breaks the minutes up into hours, and minutes`() {
+    fun `toComponentValues() breaks the minutes up into days, hours, and minutes`() {
+        (1.days + 1.hours + 1.minutes).toComponentValues { days, hours, minutes ->
+            assertEquals(1L, days)
+            assertEquals(1, hours)
+            assertEquals(1, minutes)
+        }
+    }
+
+    @Test
+    fun `toComponents() breaks the minutes up into hours, and minutes`() {
         (1.days + 1.hours + 1.minutes).toComponents { hours, minutes ->
             assertEquals(25.hours, hours)
             assertEquals(1.minutes, minutes)
@@ -34,41 +43,21 @@ class MinutesTest {
     }
 
     @Test
-    fun `LongHours_toComponents() breaks the minutes up into days, hours, and minutes`() {
-        (1L.days + 1.hours + 1.minutes).toComponents { days, hours, minutes ->
-            assertEquals(1L.days, days)
-            assertEquals(1.hours, hours)
-            assertEquals(1.minutes, minutes)
+    fun `toComponentValues() breaks the minutes up into hours, and minutes`() {
+        (1.days + 1.hours + 1.minutes).toComponentValues { hours, minutes ->
+            assertEquals(25L, hours)
+            assertEquals(1, minutes)
         }
     }
 
     @Test
-    fun `LongHours_toComponents() breaks the minutes up into hours, and minutes`() {
-        (1L.days + 1.hours + 1.minutes).toComponents { hours, minutes ->
-            assertEquals(25L.hours, hours)
-            assertEquals(1.minutes, minutes)
-        }
-    }
-
-    @Test
-    fun `IntMinutes_toString() converts zero minutes to 'PT0M'`() {
+    fun `Minutes_toString() converts zero minutes to 'PT0M'`() {
         assertEquals("PT0M", 0.minutes.toString())
     }
 
     @Test
-    fun `IntMinutes_toString() converts to ISO-8601 period representation`() {
+    fun `Minutes_toString() converts to ISO-8601 period representation`() {
         assertEquals("PT1M", 1.minutes.toString())
         assertEquals("-PT1M", (-1).minutes.toString())
-    }
-
-    @Test
-    fun `LongMinutes_toString() converts zero minutes to 'PT0M'`() {
-        assertEquals("PT0M", 0L.minutes.toString())
-    }
-
-    @Test
-    fun `LongMinutes_toString() converts to ISO-8601 period representation`() {
-        assertEquals("PT1M", 1L.minutes.toString())
-        assertEquals("-PT1M", (-1L).minutes.toString())
     }
 }

--- a/core/src/commonTest/kotlin/io/islandtime/measures/MonthsTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/measures/MonthsTest.kt
@@ -6,44 +6,24 @@ import kotlin.test.assertTrue
 
 class MonthsTest {
     @Test
-    fun `IntMonths can be compared to other IntMonths`() {
+    fun `Months can be compared to other Months`() {
         assertTrue { 0.months < 1.months }
         assertTrue { 0.months == 0.months }
         assertTrue { 5.months > (-1).months }
     }
 
     @Test
-    fun `LongMonths can be compared to other LongMonths`() {
-        assertTrue { 0L.months < 1L.months }
-        assertTrue { 0L.months == 0L.months }
-        assertTrue { 5L.months > (-1L).months }
-    }
-
-    @Test
     fun `adding years to months produces months`() {
         assertEquals(13.months, 1.months + 1.years)
-        assertEquals(13L.months, 1L.months + 1L.years)
     }
 
     @Test
     fun `subtracting years from months produces months`() {
         assertEquals(0.months, 12.months - 1.years)
-        assertEquals(0L.months, 12L.months - 1L.years)
     }
 
     @Test
-    fun `inYears converts months to an equivalent number of full years`() {
-        assertEquals(1.years, 13.months.inYears)
-        assertEquals(1L.years, 13L.months.inYears)
-    }
-
-    @Test
-    fun `toLongMonths() converts IntMonths to LongMonths`() {
-        assertEquals(2L.months, 2.months.toLongMonths())
-    }
-
-    @Test
-    fun `toIntMonths() converts LongMonths to IntMonths`() {
-        assertEquals(2.months, 2L.months.toIntMonths())
+    fun `inWholeYears converts months to an equivalent number of full years`() {
+        assertEquals(1.years, 13.months.inWholeYears)
     }
 }

--- a/core/src/commonTest/kotlin/io/islandtime/measures/NanosecondsTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/measures/NanosecondsTest.kt
@@ -9,59 +9,43 @@ import kotlin.time.Duration as KotlinDuration
 
 class NanosecondsTest {
     @Test
-    fun `IntNanoseconds can be compared to other IntNanoseconds`() {
+    fun `Nanoseconds can be compared to other Nanoseconds`() {
         assertTrue { 0.nanoseconds < 1.nanoseconds }
         assertTrue { 0.nanoseconds == 0.nanoseconds }
         assertTrue { 5.nanoseconds > (-1).nanoseconds }
     }
 
     @Test
-    fun `LongNanoseconds can be compared to other LongNanoseconds`() {
-        assertTrue { 0L.nanoseconds < 1L.nanoseconds }
-        assertTrue { 0L.nanoseconds == 0L.nanoseconds }
-        assertTrue { 5L.nanoseconds > (-1L).nanoseconds }
-    }
-
-    @Test
     fun `absoluteValue returns the same value for 0 or positive values`() {
-        listOf(0, 1, Int.MAX_VALUE).forEach {
+        listOf(0, 1, Long.MAX_VALUE).forEach {
             assertEquals(it.nanoseconds, it.nanoseconds.absoluteValue)
-            assertEquals(it.toLong().nanoseconds, it.toLong().nanoseconds.absoluteValue)
         }
-
-        assertEquals(Long.MAX_VALUE.nanoseconds, Long.MAX_VALUE.nanoseconds.absoluteValue)
     }
 
     @Test
     fun `absoluteValue returns a positive value for negatives values`() {
         assertEquals(1.nanoseconds, (-1).nanoseconds.absoluteValue)
-        assertEquals(1L.nanoseconds, (-1L).nanoseconds.absoluteValue)
     }
 
     @Test
     fun `absoluteValue throws an exception when value is MIN_VALUE`() {
-        assertFailsWith<ArithmeticException> { Int.MIN_VALUE.nanoseconds.absoluteValue }
         assertFailsWith<ArithmeticException> { Long.MIN_VALUE.nanoseconds.absoluteValue }
     }
 
     @Test
     fun `unary minus negates the value`() {
         listOf(
-            0 to 0,
-            1 to -1,
-            -1 to 1,
-            Int.MAX_VALUE to -Int.MAX_VALUE
+            0L to 0L,
+            1L to -1L,
+            -1L to 1L,
+            Long.MAX_VALUE to -Long.MAX_VALUE
         ).forEach {
             assertEquals(it.second.nanoseconds, -it.first.nanoseconds)
-            assertEquals(it.second.toLong().nanoseconds, -it.first.toLong().nanoseconds)
         }
-
-        assertEquals((-Long.MAX_VALUE).nanoseconds, -Long.MAX_VALUE.nanoseconds)
     }
 
     @Test
     fun `unary minus throws an exception when value in MIN_VALUE`() {
-        assertFailsWith<ArithmeticException> { -Int.MIN_VALUE.nanoseconds }
         assertFailsWith<ArithmeticException> { -Long.MIN_VALUE.nanoseconds }
     }
 
@@ -81,33 +65,24 @@ class NanosecondsTest {
     @Test
     fun `division by a scalar value`() {
         assertEquals(3.nanoseconds, 9.nanoseconds / 3)
-        assertEquals(3L.nanoseconds, 9.nanoseconds / 3L)
-        assertEquals((-3L).nanoseconds, 9L.nanoseconds / -3)
-        assertEquals((-3L).nanoseconds, 9L.nanoseconds / -3L)
+        assertEquals(3.nanoseconds, 9.nanoseconds / 3L)
+        assertEquals((-3).nanoseconds, 9.nanoseconds / -3)
+        assertEquals((-3).nanoseconds, 9.nanoseconds / -3L)
     }
 
     @Test
     fun `dividing by -1 throws an exception when value is MIN_VALUE`() {
-        assertFailsWith<ArithmeticException> { Int.MIN_VALUE.nanoseconds / -1 }
         assertFailsWith<ArithmeticException> { Long.MIN_VALUE.nanoseconds / -1 }
-    }
-
-    @Test
-    fun `adding or subtracting IntNanoseconds forces lengthening to Long`() {
-        assertEquals(1L.nanoseconds, 0.nanoseconds + 1.nanoseconds)
-        assertEquals((-1L).nanoseconds, 0.nanoseconds - 1.nanoseconds)
     }
 
     @Test
     fun `rem operator works`() {
         assertEquals(1.nanoseconds, 5.nanoseconds % 2)
-        assertEquals(1L.nanoseconds, 5.nanoseconds % 2L)
-        assertEquals(1L.nanoseconds, 5L.nanoseconds % 2)
-        assertEquals(1L.nanoseconds, 5L.nanoseconds % 2L)
+        assertEquals(1.nanoseconds, 5.nanoseconds % 2L)
     }
 
     @Test
-    fun `inSeconds converts nanoseconds to seconds`() {
+    fun `inWholeSeconds converts Nanoseconds to Seconds`() {
         listOf(
             0 to 0,
             999_999_999 to 0,
@@ -115,13 +90,12 @@ class NanosecondsTest {
             1_000_000_000 to 1,
             -1_000_000_000 to -1
         ).forEach {
-            assertEquals(it.second.seconds, it.first.nanoseconds.inSeconds)
-            assertEquals(it.second.toLong().seconds, it.first.toLong().nanoseconds.inSeconds)
+            assertEquals(it.second.seconds, it.first.nanoseconds.inWholeSeconds)
         }
     }
 
     @Test
-    fun `inMicroseconds converts nanoseconds to Microseconds`() {
+    fun `inWholeMicroseconds converts Nanoseconds to Microseconds`() {
         listOf(
             0 to 0,
             999 to 0,
@@ -129,32 +103,28 @@ class NanosecondsTest {
             1_000 to 1,
             -1_000 to -1
         ).forEach {
-            assertEquals(it.second.microseconds, it.first.nanoseconds.inMicroseconds)
-            assertEquals(it.second.toLong().microseconds, it.first.toLong().nanoseconds.inMicroseconds)
+            assertEquals(it.second.microseconds, it.first.nanoseconds.inWholeMicroseconds)
         }
     }
 
     @Test
-    fun `toLong() and toLongNanoseconds() convert to Long`() {
-        listOf(0, -1, 1, Int.MIN_VALUE, Int.MAX_VALUE).forEach {
-            assertEquals(it.toLong(), it.nanoseconds.toLong())
-            assertEquals(it.toLong().nanoseconds, it.nanoseconds.toLongNanoseconds())
+    fun `toLong() converts to Long`() {
+        listOf(0, -1, 1, Long.MIN_VALUE, Long.MAX_VALUE).forEach {
+            assertEquals(it, it.nanoseconds.toLong())
         }
     }
 
     @Test
-    fun `toInt() and toIntNanoseconds() throw an exception if overflow occurs during conversion`() {
+    fun `toInt() throws an exception if overflow occurs during conversion`() {
         listOf(Int.MAX_VALUE + 1L, Int.MIN_VALUE - 1L).forEach {
             assertFailsWith<ArithmeticException> { it.nanoseconds.toInt() }
-            assertFailsWith<ArithmeticException> { it.nanoseconds.toIntNanoseconds() }
         }
     }
 
     @Test
-    fun `toInt() and toIntNanoseconds() convert to Int`() {
+    fun `toInt() converts to Int`() {
         listOf(0, -1, 1, Int.MAX_VALUE, Int.MIN_VALUE).forEach {
-            assertEquals(it.nanoseconds, it.toLong().nanoseconds.toIntNanoseconds())
-            assertEquals(it, it.toLong().nanoseconds.toInt())
+            assertEquals(it, it.nanoseconds.toInt())
         }
     }
 
@@ -170,10 +140,9 @@ class NanosecondsTest {
             -1_000_000_000 to "-PT1S",
             Int.MAX_VALUE to "PT2.147483647S",
             Int.MIN_VALUE + 1 to "-PT2.147483647S",
-            Int.MIN_VALUE to "-PT2.147483648S"
+            Int.MIN_VALUE to "-PT2.147483648S",
         ).forEach {
             assertEquals(it.second, it.first.nanoseconds.toString())
-            assertEquals(it.second, it.first.toLong().nanoseconds.toString())
         }
 
         listOf(
@@ -185,7 +154,7 @@ class NanosecondsTest {
     }
 
     @Test
-    fun `toComponents() with days, hours, minutes, seconds, milliseconds, and microseconds`() {
+    fun `toComponents() and toComponentValues() with days, hours, minutes, seconds, milliseconds, and microseconds`() {
         listOf(
             0 to listOf(0, 0, 0, 0, 0, 0, 0),
             1 to listOf(0, 0, 0, 0, 0, 0, 1),
@@ -202,21 +171,21 @@ class NanosecondsTest {
                     assertEquals(it.second[6].nanoseconds, nanoseconds)
                 }
 
-            it.first.toLong().nanoseconds
-                .toComponents { days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds ->
-                    assertEquals(it.second[0].toLong().days, days)
-                    assertEquals(it.second[1].hours, hours)
-                    assertEquals(it.second[2].minutes, minutes)
-                    assertEquals(it.second[3].seconds, seconds)
-                    assertEquals(it.second[4].milliseconds, milliseconds)
-                    assertEquals(it.second[5].microseconds, microseconds)
-                    assertEquals(it.second[6].nanoseconds, nanoseconds)
+            it.first.nanoseconds
+                .toComponentValues { days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds ->
+                    assertEquals(it.second[0].toLong(), days)
+                    assertEquals(it.second[1], hours)
+                    assertEquals(it.second[2], minutes)
+                    assertEquals(it.second[3], seconds)
+                    assertEquals(it.second[4], milliseconds)
+                    assertEquals(it.second[5], microseconds)
+                    assertEquals(it.second[6], nanoseconds)
                 }
         }
     }
 
     @Test
-    fun `toComponents() with microseconds`() {
+    fun `toComponents() and toComponentValues() with microseconds`() {
         listOf(
             0 to listOf(0, 0),
             1 to listOf(0, 1),
@@ -229,9 +198,9 @@ class NanosecondsTest {
                 assertEquals(it.second[1].nanoseconds, nanoseconds)
             }
 
-            it.first.toLong().nanoseconds.toComponents { microseconds, nanoseconds ->
-                assertEquals(it.second[0].toLong().microseconds, microseconds)
-                assertEquals(it.second[1].nanoseconds, nanoseconds)
+            it.first.nanoseconds.toComponentValues { microseconds, nanoseconds ->
+                assertEquals(it.second[0].toLong(), microseconds)
+                assertEquals(it.second[1], nanoseconds)
             }
         }
     }
@@ -241,19 +210,19 @@ class NanosecondsTest {
     fun `conversion to Kotlin Duration`() {
         assertEquals(KotlinDuration.nanoseconds(0), 0.nanoseconds.toKotlinDuration())
         assertEquals(KotlinDuration.nanoseconds(1), 1.nanoseconds.toKotlinDuration())
-        assertEquals(KotlinDuration.nanoseconds(-1), (-1L).nanoseconds.toKotlinDuration())
+        assertEquals(KotlinDuration.nanoseconds(-1), (-1).nanoseconds.toKotlinDuration())
         assertEquals(KotlinDuration.nanoseconds(Long.MIN_VALUE), Long.MIN_VALUE.nanoseconds.toKotlinDuration())
     }
 
     @ExperimentalTime
     @Test
     fun `conversion from Kotlin Duration`() {
-        assertEquals(0L.nanoseconds, KotlinDuration.nanoseconds(0).toIslandNanoseconds())
-        assertEquals(1L.nanoseconds, KotlinDuration.nanoseconds(1).toIslandNanoseconds())
-        assertEquals((-1L).nanoseconds, KotlinDuration.nanoseconds(-1L).toIslandNanoseconds())
+        assertEquals(0.nanoseconds, KotlinDuration.nanoseconds(0).toIslandNanoseconds())
+        assertEquals(1.nanoseconds, KotlinDuration.nanoseconds(1).toIslandNanoseconds())
+        assertEquals((-1).nanoseconds, KotlinDuration.nanoseconds(-1).toIslandNanoseconds())
 
         assertEquals(
-            Long.MIN_VALUE.nanoseconds.inMilliseconds.inNanoseconds,
+            Long.MIN_VALUE.nanoseconds.inWholeMilliseconds.inNanoseconds,
             KotlinDuration.nanoseconds(Long.MIN_VALUE).toIslandNanoseconds()
         )
     }

--- a/core/src/commonTest/kotlin/io/islandtime/measures/PeriodTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/measures/PeriodTest.kt
@@ -251,8 +251,8 @@ class PeriodTest {
 
     @Test
     fun `normalized() throws an exception when overflow occurs`() {
-        assertFailsWith<ArithmeticException> { periodOf(Int.MAX_VALUE.years, Int.MAX_VALUE.months).normalized() }
-        assertFailsWith<ArithmeticException> { periodOf(Int.MIN_VALUE.years, Int.MIN_VALUE.months).normalized() }
+        assertFailsWith<ArithmeticException> { periodOf(Long.MAX_VALUE.years, Long.MAX_VALUE.months).normalized() }
+        assertFailsWith<ArithmeticException> { periodOf(Long.MIN_VALUE.years, Long.MIN_VALUE.months).normalized() }
     }
 
     @Test
@@ -263,12 +263,12 @@ class PeriodTest {
     @Test
     fun `unary minus throws an exception when overflow occurs`() {
         listOf(
-            periodOf(Int.MIN_VALUE.years),
-            periodOf(Int.MIN_VALUE.months),
-            periodOf(Int.MIN_VALUE.days),
-            periodOf(Int.MIN_VALUE.years, Int.MIN_VALUE.months),
-            periodOf(Int.MIN_VALUE.years, Int.MIN_VALUE.days),
-            periodOf(Int.MIN_VALUE.years, Int.MIN_VALUE.months, Int.MIN_VALUE.days)
+            periodOf(Long.MIN_VALUE.years),
+            periodOf(Long.MIN_VALUE.months),
+            periodOf(Long.MIN_VALUE.days),
+            periodOf(Long.MIN_VALUE.years, Long.MIN_VALUE.months),
+            periodOf(Long.MIN_VALUE.years, Long.MIN_VALUE.days),
+            periodOf(Long.MIN_VALUE.years, Long.MIN_VALUE.months, Long.MIN_VALUE.days)
         ).forEach {
             assertFailsWith<ArithmeticException> { -it }
         }
@@ -356,34 +356,34 @@ class PeriodTest {
     
     @Test
     fun `adding or subtracting years causes an exception on overflow`() {
-        assertFailsWith<ArithmeticException> { periodOf(Int.MAX_VALUE.years) + 1.years }
-        assertFailsWith<ArithmeticException> { periodOf(Int.MIN_VALUE.years) - 1.years }
-        assertFailsWith<ArithmeticException> { periodOf(1.years) + Int.MAX_VALUE.years }
-        assertFailsWith<ArithmeticException> { periodOf((-1).years) + Int.MIN_VALUE.years }
+        assertFailsWith<ArithmeticException> { periodOf(Long.MAX_VALUE.years) + 1.years }
+        assertFailsWith<ArithmeticException> { periodOf(Long.MIN_VALUE.years) - 1.years }
+        assertFailsWith<ArithmeticException> { periodOf(1.years) + Long.MAX_VALUE.years }
+        assertFailsWith<ArithmeticException> { periodOf((-1).years) + Long.MIN_VALUE.years }
     }
 
     @Test
     fun `adding or subtracting months causes an exception on overflow`() {
-        assertFailsWith<ArithmeticException> { periodOf(Int.MAX_VALUE.months) + 1.months }
-        assertFailsWith<ArithmeticException> { periodOf(Int.MIN_VALUE.months) - 1.months }
-        assertFailsWith<ArithmeticException> { periodOf(1.months) + Int.MAX_VALUE.months }
-        assertFailsWith<ArithmeticException> { periodOf((-1).months) + Int.MIN_VALUE.months }
+        assertFailsWith<ArithmeticException> { periodOf(Long.MAX_VALUE.months) + 1.months }
+        assertFailsWith<ArithmeticException> { periodOf(Long.MIN_VALUE.months) - 1.months }
+        assertFailsWith<ArithmeticException> { periodOf(1.months) + Long.MAX_VALUE.months }
+        assertFailsWith<ArithmeticException> { periodOf((-1).months) + Long.MIN_VALUE.months }
     }
 
     @Test
     fun `adding or subtracting weeks causes an exception on overflow`() {
-        assertFailsWith<ArithmeticException> { periodOf(Int.MAX_VALUE.days) + 1.weeks }
-        assertFailsWith<ArithmeticException> { periodOf(Int.MIN_VALUE.days) - 1.weeks }
-        assertFailsWith<ArithmeticException> { periodOf(1.days) + Int.MAX_VALUE.weeks }
-        assertFailsWith<ArithmeticException> { periodOf((-1).days) + Int.MIN_VALUE.weeks }
+        assertFailsWith<ArithmeticException> { periodOf(Long.MAX_VALUE.days) + 1.weeks }
+        assertFailsWith<ArithmeticException> { periodOf(Long.MIN_VALUE.days) - 1.weeks }
+        assertFailsWith<ArithmeticException> { periodOf(1.days) + Long.MAX_VALUE.weeks }
+        assertFailsWith<ArithmeticException> { periodOf((-1).days) + Long.MIN_VALUE.weeks }
     }
 
     @Test
     fun `adding or subtracting days causes an exception on overflow`() {
-        assertFailsWith<ArithmeticException> { periodOf(Int.MAX_VALUE.days) + 1.days }
-        assertFailsWith<ArithmeticException> { periodOf(Int.MIN_VALUE.days) - 1.days }
-        assertFailsWith<ArithmeticException> { periodOf(1.days) + Int.MAX_VALUE.days }
-        assertFailsWith<ArithmeticException> { periodOf((-1).days) + Int.MIN_VALUE.days }
+        assertFailsWith<ArithmeticException> { periodOf(Long.MAX_VALUE.days) + 1.days }
+        assertFailsWith<ArithmeticException> { periodOf(Long.MIN_VALUE.days) - 1.days }
+        assertFailsWith<ArithmeticException> { periodOf(1.days) + Long.MAX_VALUE.days }
+        assertFailsWith<ArithmeticException> { periodOf((-1).days) + Long.MIN_VALUE.days }
     }
 
     @Test
@@ -407,18 +407,18 @@ class PeriodTest {
     @Test
     fun `multiplication causes an exception when overflow occurs`() {
         listOf(
-            periodOf(Int.MIN_VALUE.years),
-            periodOf(Int.MIN_VALUE.months),
-            periodOf(Int.MIN_VALUE.days),
-            periodOf(Int.MIN_VALUE.years, Int.MIN_VALUE.months),
-            periodOf(Int.MIN_VALUE.years, Int.MIN_VALUE.days),
-            periodOf(Int.MIN_VALUE.years, Int.MIN_VALUE.months, Int.MIN_VALUE.days)
+            periodOf(Long.MIN_VALUE.years),
+            periodOf(Long.MIN_VALUE.months),
+            periodOf(Long.MIN_VALUE.days),
+            periodOf(Long.MIN_VALUE.years, Long.MIN_VALUE.months),
+            periodOf(Long.MIN_VALUE.years, Long.MIN_VALUE.days),
+            periodOf(Long.MIN_VALUE.years, Long.MIN_VALUE.months, Long.MIN_VALUE.days)
         ).forEach {
             assertFailsWith<ArithmeticException> { it * -1 }
         }
 
-        assertFailsWith<ArithmeticException> { periodOf(1.weeks) * Int.MAX_VALUE }
-        assertFailsWith<ArithmeticException> { Int.MAX_VALUE * periodOf(2.days) }
+        assertFailsWith<ArithmeticException> { periodOf(1.weeks) * Long.MAX_VALUE }
+        assertFailsWith<ArithmeticException> { Long.MAX_VALUE * periodOf(2.days) }
     }
 
     @Test

--- a/core/src/commonTest/kotlin/io/islandtime/measures/YearsTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/measures/YearsTest.kt
@@ -8,127 +8,95 @@ import kotlin.test.assertTrue
 
 class YearsTest {
     @Test
-    fun `IntYears can be compared to other IntYears`() {
+    fun `Years can be compared to other Years`() {
         assertTrue { 0.years < 1.years }
         assertTrue { 0.years == 0.years }
         assertTrue { 5.years > (-1).years }
     }
-
-    @Test
-    fun `LongYears can be compared to other LongYears`() {
-        assertTrue { 0L.years < 1L.years }
-        assertTrue { 0L.years == 0L.years }
-        assertTrue { 5L.years > (-1L).years }
-    }
-
+    
     @Test
     fun `absoluteValue returns the same value for 0 or positive values`() {
-        listOf(0, 1, Int.MAX_VALUE).forEach {
+        listOf(0, 1, Long.MAX_VALUE).forEach {
             assertEquals(it.years, it.years.absoluteValue)
-            assertEquals(it.toLong().years, it.toLong().years.absoluteValue)
         }
-
-        assertEquals(Long.MAX_VALUE.years, Long.MAX_VALUE.years.absoluteValue)
     }
 
     @Test
-    fun `absoluteValue returns a positive value for negatives values`() {
+    fun `absoluteValue returns a positive value for negative values`() {
         assertEquals(1.years, (-1).years.absoluteValue)
-        assertEquals(1L.years, (-1L).years.absoluteValue)
     }
 
     @Test
     fun `absoluteValue throws an exception when value is MIN_VALUE`() {
-        assertFailsWith<ArithmeticException> { Int.MIN_VALUE.years.absoluteValue }
         assertFailsWith<ArithmeticException> { Long.MIN_VALUE.years.absoluteValue }
     }
 
     @Test
     fun `unary minus negates the value`() {
         listOf(
-            0 to 0,
-            1 to -1,
-            -1 to 1,
-            Int.MAX_VALUE to -Int.MAX_VALUE
+            0L to 0L,
+            1L to -1L,
+            -1L to 1L,
+            Long.MAX_VALUE to -Long.MAX_VALUE
         ).forEach {
             assertEquals(it.second.years, -it.first.years)
-            assertEquals(it.second.toLong().years, -it.first.toLong().years)
         }
-
-        assertEquals((-Long.MAX_VALUE).years, -Long.MAX_VALUE.years)
     }
 
     @Test
     fun `unary minus throws an exception when value in MIN_VALUE`() {
-        assertFailsWith<ArithmeticException> { -Int.MIN_VALUE.years }
         assertFailsWith<ArithmeticException> { -Long.MIN_VALUE.years }
     }
 
     @Test
     fun `multiplying by a scalar value throws an exception when overflow occurs`() {
-        assertFailsWith<ArithmeticException> { Int.MAX_VALUE.years * 2 }
-        assertFailsWith<ArithmeticException> { Int.MIN_VALUE.years * -1 }
-
         assertFailsWith<ArithmeticException> { Long.MAX_VALUE.years * 2 }
         assertFailsWith<ArithmeticException> { Long.MAX_VALUE.years * 2L }
         assertFailsWith<ArithmeticException> { Long.MIN_VALUE.years * -1 }
+        assertFailsWith<ArithmeticException> { Long.MIN_VALUE.years * -1L }
     }
 
     @Test
     fun `division by a scalar value`() {
         assertEquals(3.years, 9.years / 3)
-        assertEquals(3L.years, 9.years / 3L)
-        assertEquals((-3L).years, 9L.years / -3)
-        assertEquals((-3L).years, 9L.years / -3L)
+        assertEquals(3.years, 9.years / 3L)
+        assertEquals((-3).years, 9.years / -3)
+        assertEquals((-3).years, 9.years / -3L)
     }
 
     @Test
     fun `dividing by -1 throws an exception when value is MIN_VALUE`() {
-        assertFailsWith<ArithmeticException> { Int.MIN_VALUE.years / -1 }
         assertFailsWith<ArithmeticException> { Long.MIN_VALUE.years / -1  }
     }
 
     @Test
     fun `adding months to years produces months`() {
         assertEquals(15.months, 1.years + 3.months)
-        assertEquals(Int.MAX_VALUE.months, 1.years + (Int.MAX_VALUE - 12).months)
-        assertEquals(Int.MAX_VALUE.toLong().months, 1.years + (Int.MAX_VALUE - 12L).months)
-        assertEquals(Int.MIN_VALUE.months, (-1).years + (Int.MIN_VALUE + 12).months)
-        assertEquals(Int.MIN_VALUE.toLong().months, (-1).years + (Int.MIN_VALUE + 12L).months)
-
-        assertEquals(15L.months, 1L.years + 3L.months)
-        assertEquals(Long.MAX_VALUE.months, 1L.years + (Long.MAX_VALUE - 12L).months)
-        assertEquals(Long.MAX_VALUE.months, 1L.years + (Long.MAX_VALUE - 12).months)
-        assertEquals(Long.MIN_VALUE.months, (-1L).years + (Long.MIN_VALUE + 12L).months)
-        assertEquals(Long.MIN_VALUE.months, (-1L).years + (Long.MIN_VALUE + 12).months)
+        assertEquals(Long.MAX_VALUE.months, 1.years + (Long.MAX_VALUE - 12).months)
+        assertEquals(Long.MIN_VALUE.months, (-1).years + (Long.MIN_VALUE + 12).months)
     }
 
     @Test
     fun `throws an exception when adding months to years causes overflow`() {
-        assertFailsWith<ArithmeticException> { 1.years + (Int.MAX_VALUE - 11).months }
-        assertFailsWith<ArithmeticException> { Int.MAX_VALUE.years + 1.months }
-        assertFailsWith<ArithmeticException> { (-1).years + (Int.MIN_VALUE + 11).months }
-        assertFailsWith<ArithmeticException> { Int.MIN_VALUE.years + (-1).months }
+        assertFailsWith<ArithmeticException> { 1.years + (Long.MAX_VALUE - 11).months }
+        assertFailsWith<ArithmeticException> { Long.MAX_VALUE.years + 1.months }
+        assertFailsWith<ArithmeticException> { (-1).years + (Long.MIN_VALUE + 11).months }
+        assertFailsWith<ArithmeticException> { Long.MIN_VALUE.years + (-1).months }
     }
 
     @Test
     fun `subtracting months from years produces months`() {
         assertEquals(21.months, 2.years - 3.months)
-        assertEquals(21L.months, 2.years - 3L.months)
-        assertEquals(21L.months, 2L.years - 3.months)
-        assertEquals(21L.months, 2L.years - 3L.months)
     }
 
     @Test
     fun `rem operator works`() {
         assertEquals(1.years, 5.years % 2)
-        assertEquals(1L.years, 5.years % 2L)
-        assertEquals(1L.years, 5L.years % 2)
-        assertEquals(1L.years, 5L.years % 2L)
+        assertEquals(1.years, 5.years % 2L)
     }
 
     @Test
-    fun `inCenturies converts years to centuries`() {
+    fun `inWholeCenturies converts years to centuries`() {
         listOf(
             0 to 0,
             99 to 0,
@@ -136,13 +104,12 @@ class YearsTest {
             100 to 1,
             -100 to -1
         ).forEach {
-            assertEquals(it.second.centuries, it.first.years.inCenturies)
-            assertEquals(it.second.toLong().centuries, it.first.toLong().years.inCenturies)
+            assertEquals(it.second.centuries, it.first.years.inWholeCenturies)
         }
     }
 
     @Test
-    fun `inDecades converts years to decades`() {
+    fun `inWholeDecades converts years to decades`() {
         listOf(
             0 to 0,
             9 to 0,
@@ -150,8 +117,7 @@ class YearsTest {
             10 to 1,
             -10 to -1
         ).forEach {
-            assertEquals(it.second.decades, it.first.years.inDecades)
-            assertEquals(it.second.toLong().decades, it.first.toLong().years.inDecades)
+            assertEquals(it.second.decades, it.first.years.inWholeDecades)
         }
     }
 
@@ -166,66 +132,42 @@ class YearsTest {
         ).forEach {
             assertEquals(it.second, it.first.inMonths)
         }
-
-        listOf(
-            0L.years to 0L.months,
-            (-1L).years to (-12L).months,
-            1L.years to 12L.months
-        ).forEach {
-            assertEquals(it.second, it.first.inMonths)
-        }
     }
 
     @Test
     fun `inMonths throws an exception when overflow occurs`() {
-        listOf(Int.MAX_VALUE, Int.MIN_VALUE, 178956971, -178956971).forEach {
-            assertFailsWith<ArithmeticException> { it.years.inMonths }
-        }
-
         listOf(Long.MAX_VALUE, Long.MIN_VALUE).forEach {
             assertFailsWith<ArithmeticException> { it.years.inMonths }
         }
     }
 
     @Test
-    fun `toLong() and toLongYears() convert to Long`() {
-        listOf(0, -1, 1, Int.MIN_VALUE, Int.MAX_VALUE).forEach {
-            assertEquals(it.toLong(), it.years.toLong())
-            assertEquals(it.toLong().years, it.years.toLongYears())
+    fun `toLong() converts to Long`() {
+        listOf(0, -1, 1, Long.MIN_VALUE, Long.MAX_VALUE).forEach {
+            assertEquals(it, it.years.toLong())
         }
     }
 
     @Test
-    fun `toInt() and toIntYears() throw an exception if overflow occurs during conversion`() {
+    fun `toInt() throws an exception if overflow occurs during conversion`() {
         listOf(Int.MAX_VALUE + 1L, Int.MIN_VALUE - 1L).forEach {
             assertFailsWith<ArithmeticException> { it.years.toInt() }
-            assertFailsWith<ArithmeticException> { it.years.toIntYears() }
         }
     }
 
     @Test
-    fun `toInt() and toIntYears() convert to Int`() {
+    fun `toInt() converts to Int`() {
         listOf(0, -1, 1, Int.MAX_VALUE, Int.MIN_VALUE).forEach {
-            assertEquals(it.years, it.toLong().years.toIntYears())
-            assertEquals(it, it.toLong().years.toInt())
+            assertEquals(it, it.years.toInt())
         }
     }
 
     @Test
     fun `toString() returns an ISO duration string`() {
         listOf(
-            0 to "P0Y",
-            1 to "P1Y",
-            -1 to "-P1Y",
-            Int.MAX_VALUE to "P${Int.MAX_VALUE}Y",
-            Int.MIN_VALUE + 1 to "-P${(Int.MIN_VALUE + 1L).absoluteValue}Y",
-            Int.MIN_VALUE to "-P${Int.MIN_VALUE.toLong().absoluteValue}Y"
-        ).forEach {
-            assertEquals(it.second, it.first.years.toString())
-            assertEquals(it.second, it.first.toLong().years.toString())
-        }
-
-        listOf(
+            0L to "P0Y",
+            1L to "P1Y",
+            -1L to "-P1Y",
             Long.MAX_VALUE to "P${Long.MAX_VALUE}Y",
             Long.MIN_VALUE to "-P9223372036854775808Y"
         ).forEach {
@@ -234,7 +176,7 @@ class YearsTest {
     }
 
     @Test
-    fun `toComponents() with centuries and decades`() {
+    fun `toComponents() and toComponentValues() with centuries and decades`() {
         listOf(
             0 to listOf(0, 0, 0),
             1 to listOf(0, 0, 1),
@@ -250,16 +192,16 @@ class YearsTest {
                 assertEquals(it.second[2].years, years)
             }
 
-            it.first.toLong().years.toComponents { centuries, decades, years ->
-                assertEquals(it.second[0].toLong().centuries, centuries)
-                assertEquals(it.second[1].decades, decades)
-                assertEquals(it.second[2].years, years)
+            it.first.years.toComponentValues { centuries, decades, years ->
+                assertEquals(it.second[0].toLong(), centuries)
+                assertEquals(it.second[1], decades)
+                assertEquals(it.second[2], years)
             }
         }
     }
 
     @Test
-    fun `toComponents() with decades`() {
+    fun `toComponents() and toComponentValues() with decades`() {
         listOf(
             0 to listOf(0, 0),
             1 to listOf(0, 1),
@@ -272,9 +214,9 @@ class YearsTest {
                 assertEquals(it.second[1].years, years)
             }
 
-            it.first.toLong().years.toComponents { decades, years ->
-                assertEquals(it.second[0].toLong().decades, decades)
-                assertEquals(it.second[1].years, years)
+            it.first.years.toComponentValues { decades, years ->
+                assertEquals(it.second[0].toLong(), decades)
+                assertEquals(it.second[1], years)
             }
         }
     }

--- a/core/src/commonTest/kotlin/io/islandtime/operators/RoundDownTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/operators/RoundDownTest.kt
@@ -21,8 +21,8 @@ class RoundDownTest {
                 0.hours,
                 25.hours,
                 48.hours,
-                Int.MIN_VALUE.hours,
-                Int.MAX_VALUE.hours
+                Long.MIN_VALUE.hours,
+                Long.MAX_VALUE.hours
             )
         )
     }
@@ -58,8 +58,8 @@ class RoundDownTest {
                 (-1).minutes,
                 0.minutes,
                 61.minutes,
-                Int.MIN_VALUE.minutes,
-                Int.MAX_VALUE.minutes
+                Long.MIN_VALUE.minutes,
+                Long.MAX_VALUE.minutes
             )
         )
     }
@@ -105,8 +105,8 @@ class RoundDownTest {
                 (-1).seconds,
                 0.seconds,
                 61.seconds,
-                Int.MIN_VALUE.seconds,
-                Int.MAX_VALUE.seconds
+                Long.MIN_VALUE.seconds,
+                Long.MAX_VALUE.seconds
             )
         )
     }
@@ -133,9 +133,9 @@ class RoundDownTest {
             listOf(
                 (-1).milliseconds,
                 0.milliseconds,
-                (1.seconds + 1.milliseconds).toIntMilliseconds(),
-                Int.MIN_VALUE.milliseconds,
-                Int.MAX_VALUE.milliseconds
+                (1.seconds + 1.milliseconds),
+                Long.MIN_VALUE.milliseconds,
+                Long.MAX_VALUE.milliseconds
             )
         )
     }
@@ -192,8 +192,8 @@ class RoundDownTest {
                 (-1).microseconds,
                 0.microseconds,
                 1_000_001.microseconds,
-                Int.MIN_VALUE.microseconds,
-                Int.MAX_VALUE.microseconds
+                Long.MIN_VALUE.microseconds,
+                Long.MAX_VALUE.microseconds
             )
         )
     }
@@ -227,8 +227,8 @@ class RoundDownTest {
                 (-1).nanoseconds,
                 0.nanoseconds,
                 1_000_000_001.nanoseconds,
-                Int.MIN_VALUE.nanoseconds,
-                Int.MAX_VALUE.nanoseconds
+                Long.MIN_VALUE.nanoseconds,
+                Long.MAX_VALUE.nanoseconds
             )
         )
     }
@@ -319,7 +319,7 @@ class RoundDownTest {
     }
 
     @JvmName("testExceptionHours")
-    private fun testException(invalidIncrements: List<IntHours>) {
+    private fun testException(invalidIncrements: List<Hours>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedDownToNearest(it)
@@ -343,7 +343,7 @@ class RoundDownTest {
     }
 
     @JvmName("testExceptionMinutes")
-    private fun testException(invalidIncrements: List<IntMinutes>) {
+    private fun testException(invalidIncrements: List<Minutes>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedDownToNearest(it)
@@ -367,7 +367,7 @@ class RoundDownTest {
     }
 
     @JvmName("testExceptionSeconds")
-    private fun testException(invalidIncrements: List<IntSeconds>) {
+    private fun testException(invalidIncrements: List<Seconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedDownToNearest(it)
@@ -391,7 +391,7 @@ class RoundDownTest {
     }
 
     @JvmName("testExceptionMilliseconds")
-    private fun testException(invalidIncrements: List<IntMilliseconds>) {
+    private fun testException(invalidIncrements: List<Milliseconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedDownToNearest(it)
@@ -415,7 +415,7 @@ class RoundDownTest {
     }
 
     @JvmName("testExceptionMicroseconds")
-    private fun testException(invalidIncrements: List<IntMicroseconds>) {
+    private fun testException(invalidIncrements: List<Microseconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedDownToNearest(it)
@@ -439,7 +439,7 @@ class RoundDownTest {
     }
 
     @JvmName("testExceptionNanoseconds")
-    private fun testException(invalidIncrements: List<IntNanoseconds>) {
+    private fun testException(invalidIncrements: List<Nanoseconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedDownToNearest(it)
@@ -506,7 +506,7 @@ class RoundDownTest {
             }
     }
 
-    private fun testRoundedDownToNearest(increment: IntHours, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedDownToNearest(increment: Hours, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedDownToNearest(increment))
@@ -526,7 +526,7 @@ class RoundDownTest {
             }
     }
 
-    private fun testRoundedDownToNearest(increment: IntMinutes, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedDownToNearest(increment: Minutes, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedDownToNearest(increment))
@@ -546,7 +546,7 @@ class RoundDownTest {
             }
     }
 
-    private fun testRoundedDownToNearest(increment: IntSeconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedDownToNearest(increment: Seconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedDownToNearest(increment))
@@ -566,7 +566,7 @@ class RoundDownTest {
             }
     }
 
-    private fun testRoundedDownToNearest(increment: IntMilliseconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedDownToNearest(increment: Milliseconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedDownToNearest(increment))
@@ -586,7 +586,7 @@ class RoundDownTest {
             }
     }
 
-    private fun testRoundedDownToNearest(increment: IntMicroseconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedDownToNearest(increment: Microseconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedDownToNearest(increment))
@@ -606,7 +606,7 @@ class RoundDownTest {
             }
     }
 
-    private fun testRoundedDownToNearest(increment: IntNanoseconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedDownToNearest(increment: Nanoseconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedDownToNearest(increment))

--- a/core/src/commonTest/kotlin/io/islandtime/operators/RoundTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/operators/RoundTest.kt
@@ -21,8 +21,8 @@ class RoundTest {
                 0.hours,
                 25.hours,
                 48.hours,
-                Int.MIN_VALUE.hours,
-                Int.MAX_VALUE.hours
+                Long.MIN_VALUE.hours,
+                Long.MAX_VALUE.hours
             )
         )
     }
@@ -59,8 +59,8 @@ class RoundTest {
                 (-1).minutes,
                 0.minutes,
                 61.minutes,
-                Int.MIN_VALUE.minutes,
-                Int.MAX_VALUE.minutes
+                Long.MIN_VALUE.minutes,
+                Long.MAX_VALUE.minutes
             )
         )
     }
@@ -111,8 +111,8 @@ class RoundTest {
                 (-1).seconds,
                 0.seconds,
                 61.seconds,
-                Int.MIN_VALUE.seconds,
-                Int.MAX_VALUE.seconds
+                Long.MIN_VALUE.seconds,
+                Long.MAX_VALUE.seconds
             )
         )
     }
@@ -142,9 +142,9 @@ class RoundTest {
             listOf(
                 (-1).milliseconds,
                 0.milliseconds,
-                (1.seconds + 1.milliseconds).toIntMilliseconds(),
-                Int.MIN_VALUE.milliseconds,
-                Int.MAX_VALUE.milliseconds
+                1.seconds + 1.milliseconds,
+                Long.MIN_VALUE.milliseconds,
+                Long.MAX_VALUE.milliseconds
             )
         )
     }
@@ -207,8 +207,8 @@ class RoundTest {
                 (-1).microseconds,
                 0.microseconds,
                 1_000_001.microseconds,
-                Int.MIN_VALUE.microseconds,
-                Int.MAX_VALUE.microseconds
+                Long.MIN_VALUE.microseconds,
+                Long.MAX_VALUE.microseconds
             )
         )
     }
@@ -245,8 +245,8 @@ class RoundTest {
                 (-1).nanoseconds,
                 0.nanoseconds,
                 1_000_000_001.nanoseconds,
-                Int.MIN_VALUE.nanoseconds,
-                Int.MAX_VALUE.nanoseconds
+                Long.MIN_VALUE.nanoseconds,
+                Long.MAX_VALUE.nanoseconds
             )
         )
     }
@@ -343,7 +343,7 @@ class RoundTest {
     }
 
     @JvmName("testExceptionHours")
-    private fun testException(invalidIncrements: List<IntHours>) {
+    private fun testException(invalidIncrements: List<Hours>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedToNearest(it)
@@ -367,7 +367,7 @@ class RoundTest {
     }
 
     @JvmName("testExceptionMinutes")
-    private fun testException(invalidIncrements: List<IntMinutes>) {
+    private fun testException(invalidIncrements: List<Minutes>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedToNearest(it)
@@ -391,7 +391,7 @@ class RoundTest {
     }
 
     @JvmName("testExceptionSeconds")
-    private fun testException(invalidIncrements: List<IntSeconds>) {
+    private fun testException(invalidIncrements: List<Seconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedToNearest(it)
@@ -415,7 +415,7 @@ class RoundTest {
     }
 
     @JvmName("testExceptionMilliseconds")
-    private fun testException(invalidIncrements: List<IntMilliseconds>) {
+    private fun testException(invalidIncrements: List<Milliseconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedToNearest(it)
@@ -439,7 +439,7 @@ class RoundTest {
     }
 
     @JvmName("testExceptionMicroseconds")
-    private fun testException(invalidIncrements: List<IntMicroseconds>) {
+    private fun testException(invalidIncrements: List<Microseconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedToNearest(it)
@@ -463,7 +463,7 @@ class RoundTest {
     }
 
     @JvmName("testExceptionNanoseconds")
-    private fun testException(invalidIncrements: List<IntNanoseconds>) {
+    private fun testException(invalidIncrements: List<Nanoseconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedToNearest(it)
@@ -530,7 +530,7 @@ class RoundTest {
             }
     }
 
-    private fun testRoundedToNearest(increment: IntHours, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedToNearest(increment: Hours, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedToNearest(increment))
@@ -550,7 +550,7 @@ class RoundTest {
             }
     }
 
-    private fun testRoundedToNearest(increment: IntMinutes, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedToNearest(increment: Minutes, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedToNearest(increment))
@@ -570,7 +570,7 @@ class RoundTest {
             }
     }
 
-    private fun testRoundedToNearest(increment: IntSeconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedToNearest(increment: Seconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedToNearest(increment))
@@ -590,7 +590,7 @@ class RoundTest {
             }
     }
 
-    private fun testRoundedToNearest(increment: IntMilliseconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedToNearest(increment: Milliseconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedToNearest(increment))
@@ -610,7 +610,7 @@ class RoundTest {
             }
     }
 
-    private fun testRoundedToNearest(increment: IntMicroseconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedToNearest(increment: Microseconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedToNearest(increment))
@@ -630,7 +630,7 @@ class RoundTest {
             }
     }
 
-    private fun testRoundedToNearest(increment: IntNanoseconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedToNearest(increment: Nanoseconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedToNearest(increment))

--- a/core/src/commonTest/kotlin/io/islandtime/operators/RoundUpTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/operators/RoundUpTest.kt
@@ -21,8 +21,8 @@ class RoundUpTest {
                 0.hours,
                 25.hours,
                 48.hours,
-                Int.MIN_VALUE.hours,
-                Int.MAX_VALUE.hours
+                Long.MIN_VALUE.hours,
+                Long.MAX_VALUE.hours
             )
         )
     }
@@ -59,8 +59,8 @@ class RoundUpTest {
                 (-1).minutes,
                 0.minutes,
                 61.minutes,
-                Int.MIN_VALUE.minutes,
-                Int.MAX_VALUE.minutes
+                Long.MIN_VALUE.minutes,
+                Long.MAX_VALUE.minutes
             )
         )
     }
@@ -109,8 +109,8 @@ class RoundUpTest {
                 (-1).seconds,
                 0.seconds,
                 61.seconds,
-                Int.MIN_VALUE.seconds,
-                Int.MAX_VALUE.seconds
+                Long.MIN_VALUE.seconds,
+                Long.MAX_VALUE.seconds
             )
         )
     }
@@ -139,9 +139,9 @@ class RoundUpTest {
             listOf(
                 (-1).milliseconds,
                 0.milliseconds,
-                (1.seconds + 1.milliseconds).toIntMilliseconds(),
-                Int.MIN_VALUE.milliseconds,
-                Int.MAX_VALUE.milliseconds
+                1.seconds + 1.milliseconds,
+                Long.MIN_VALUE.milliseconds,
+                Long.MAX_VALUE.milliseconds
             )
         )
     }
@@ -199,8 +199,8 @@ class RoundUpTest {
                 (-1).microseconds,
                 0.microseconds,
                 1_000_001.microseconds,
-                Int.MIN_VALUE.microseconds,
-                Int.MAX_VALUE.microseconds
+                Long.MIN_VALUE.microseconds,
+                Long.MAX_VALUE.microseconds
             )
         )
     }
@@ -236,8 +236,8 @@ class RoundUpTest {
                 (-1).nanoseconds,
                 0.nanoseconds,
                 1_000_000_001.nanoseconds,
-                Int.MIN_VALUE.nanoseconds,
-                Int.MAX_VALUE.nanoseconds
+                Long.MIN_VALUE.nanoseconds,
+                Long.MAX_VALUE.nanoseconds
             )
         )
     }
@@ -334,7 +334,7 @@ class RoundUpTest {
     }
 
     @JvmName("testExceptionHours")
-    private fun testException(invalidIncrements: List<IntHours>) {
+    private fun testException(invalidIncrements: List<Hours>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedUpToNearest(it)
@@ -358,7 +358,7 @@ class RoundUpTest {
     }
 
     @JvmName("testExceptionMinutes")
-    private fun testException(invalidIncrements: List<IntMinutes>) {
+    private fun testException(invalidIncrements: List<Minutes>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedUpToNearest(it)
@@ -382,7 +382,7 @@ class RoundUpTest {
     }
 
     @JvmName("testExceptionSeconds")
-    private fun testException(invalidIncrements: List<IntSeconds>) {
+    private fun testException(invalidIncrements: List<Seconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedUpToNearest(it)
@@ -406,7 +406,7 @@ class RoundUpTest {
     }
 
     @JvmName("testExceptionMilliseconds")
-    private fun testException(invalidIncrements: List<IntMilliseconds>) {
+    private fun testException(invalidIncrements: List<Milliseconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedUpToNearest(it)
@@ -430,7 +430,7 @@ class RoundUpTest {
     }
 
     @JvmName("testExceptionMicroseconds")
-    private fun testException(invalidIncrements: List<IntMicroseconds>) {
+    private fun testException(invalidIncrements: List<Microseconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedUpToNearest(it)
@@ -454,7 +454,7 @@ class RoundUpTest {
     }
 
     @JvmName("testExceptionNanoseconds")
-    private fun testException(invalidIncrements: List<IntNanoseconds>) {
+    private fun testException(invalidIncrements: List<Nanoseconds>) {
         invalidIncrements.forEach {
             assertFailsWith<IllegalArgumentException>("Failed at '$it'") {
                 Time.MIDNIGHT.roundedUpToNearest(it)
@@ -521,7 +521,7 @@ class RoundUpTest {
             }
     }
 
-    private fun testRoundedUpToNearest(increment: IntHours, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedUpToNearest(increment: Hours, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedUpToNearest(increment))
@@ -541,7 +541,7 @@ class RoundUpTest {
             }
     }
 
-    private fun testRoundedUpToNearest(increment: IntMinutes, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedUpToNearest(increment: Minutes, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedUpToNearest(increment))
@@ -561,7 +561,7 @@ class RoundUpTest {
             }
     }
 
-    private fun testRoundedUpToNearest(increment: IntSeconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedUpToNearest(increment: Seconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedUpToNearest(increment))
@@ -581,7 +581,7 @@ class RoundUpTest {
             }
     }
 
-    private fun testRoundedUpToNearest(increment: IntMilliseconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedUpToNearest(increment: Milliseconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedUpToNearest(increment))
@@ -601,7 +601,7 @@ class RoundUpTest {
             }
     }
 
-    private fun testRoundedUpToNearest(increment: IntMicroseconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedUpToNearest(increment: Microseconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedUpToNearest(increment))
@@ -621,7 +621,7 @@ class RoundUpTest {
             }
     }
 
-    private fun testRoundedUpToNearest(increment: IntNanoseconds, vararg dateTimeValues: Pair<String, String>) {
+    private fun testRoundedUpToNearest(increment: Nanoseconds, vararg dateTimeValues: Pair<String, String>) {
         dateTimeValues.map { (input, output) -> input.toDateTime() to output.toDateTime() }
             .forEach { (inDateTime, outDateTime) ->
                 assertEquals(outDateTime, inDateTime.roundedUpToNearest(increment))

--- a/core/src/darwinMain/kotlin/io/islandtime/clock/internal/SystemClockImpl.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/clock/internal/SystemClockImpl.kt
@@ -17,8 +17,8 @@ internal actual fun createSystemClock(zone: TimeZone): SystemClock {
     return object : SystemClock() {
         override val zone: TimeZone = zone
 
-        override fun readMilliseconds(): LongMilliseconds {
-            return readSystemTime { seconds, microseconds -> seconds + microseconds.inMilliseconds }
+        override fun readMilliseconds(): Milliseconds {
+            return readSystemTime { seconds, microseconds -> seconds + microseconds.inWholeMilliseconds }
         }
 
         override fun readInstant(): Instant {
@@ -29,7 +29,7 @@ internal actual fun createSystemClock(zone: TimeZone): SystemClock {
     }
 }
 
-private inline fun <T> readSystemTime(action: (seconds: LongSeconds, microseconds: IntMicroseconds) -> T): T {
+private inline fun <T> readSystemTime(action: (seconds: Seconds, microseconds: Microseconds) -> T): T {
     return memScoped {
         val posixTime = alloc<timeval>()
         gettimeofday(posixTime.ptr, null)

--- a/core/src/darwinMain/kotlin/io/islandtime/darwin/Conversions.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/darwin/Conversions.kt
@@ -146,7 +146,7 @@ fun NSDateComponents.toIslandOffsetDateTime() = toIslandOffsetDateTimeOrNull()
  * absent.
  */
 fun NSDateComponents.toIslandOffsetDateTimeOrNull(): OffsetDateTime? {
-    return timeZone?.let {
+    return timeZone.let {
         val dateTime = toIslandDateTime()
         OffsetDateTime(dateTime, it.toIslandTimeZone().rules.offsetAt(dateTime))
     }
@@ -164,7 +164,7 @@ fun NSDateComponents.toIslandZonedDateTime() = toIslandZonedDateTimeOrNull()
  * absent.
  */
 fun NSDateComponents.toIslandZonedDateTimeOrNull(): ZonedDateTime? {
-    return timeZone?.let { ZonedDateTime(toIslandDateTime(), it.toIslandTimeZone()) }
+    return timeZone.let { ZonedDateTime(toIslandDateTime(), it.toIslandTimeZone()) }
 }
 
 /**
@@ -278,89 +278,48 @@ fun TimeZone.toNSTimeZoneOrNull(): NSTimeZone? {
  * Converts this duration to an equivalent `NSTimeInterval`.
  */
 fun Duration.toNSTimeInterval(): NSTimeInterval = toComponents { seconds, nanoseconds ->
-    seconds.value.toDouble() + nanoseconds.value.toDouble() / NANOSECONDS_PER_SECOND
+    seconds.toDouble() + nanoseconds.toDouble() / NANOSECONDS_PER_SECOND
 }
 
 /**
  * Converts this duration to an equivalent `NSTimeInterval`.
  */
-fun IntDays.toNSTimeInterval(): NSTimeInterval = this.toLongDays().inSecondsUnchecked.value.toDouble()
+fun Days.toNSTimeInterval(): NSTimeInterval = this.inSeconds.toDouble()
 
 /**
  * Converts this duration to an equivalent `NSTimeInterval`.
  */
-fun LongDays.toNSTimeInterval(): NSTimeInterval = this.inSeconds.value.toDouble()
+fun Hours.toNSTimeInterval(): NSTimeInterval = this.inSeconds.toDouble()
 
 /**
  * Converts this duration to an equivalent `NSTimeInterval`.
  */
-fun IntHours.toNSTimeInterval(): NSTimeInterval = this.toLongHours().inSecondsUnchecked.value.toDouble()
+fun Minutes.toNSTimeInterval(): NSTimeInterval = this.inSeconds.toDouble()
 
 /**
  * Converts this duration to an equivalent `NSTimeInterval`.
  */
-fun LongHours.toNSTimeInterval(): NSTimeInterval = this.inSeconds.value.toDouble()
+fun Seconds.toNSTimeInterval(): NSTimeInterval = this.toDouble()
 
 /**
  * Converts this duration to an equivalent `NSTimeInterval`.
  */
-fun IntMinutes.toNSTimeInterval(): NSTimeInterval = this.toLongMinutes().inSecondsUnchecked.value.toDouble()
-
-/**
- * Converts this duration to an equivalent `NSTimeInterval`.
- */
-fun LongMinutes.toNSTimeInterval(): NSTimeInterval = this.inSeconds.value.toDouble()
-
-/**
- * Converts this duration to an equivalent `NSTimeInterval`.
- */
-fun IntSeconds.toNSTimeInterval(): NSTimeInterval = value.toDouble()
-
-/**
- * Converts this duration to an equivalent `NSTimeInterval`.
- */
-fun LongSeconds.toNSTimeInterval(): NSTimeInterval = value.toDouble()
-
-/**
- * Converts this duration to an equivalent `NSTimeInterval`.
- */
-fun IntMilliseconds.toNSTimeInterval(): NSTimeInterval = toComponents { seconds, milliseconds ->
-    seconds.value.toDouble() + milliseconds.value.toDouble() / MILLISECONDS_PER_SECOND
+fun Milliseconds.toNSTimeInterval(): NSTimeInterval = toComponents { seconds, milliseconds ->
+    seconds.toDouble() + milliseconds.toDouble() / MILLISECONDS_PER_SECOND
 }
 
 /**
  * Converts this duration to an equivalent `NSTimeInterval`.
  */
-fun LongMilliseconds.toNSTimeInterval(): NSTimeInterval = toComponents { seconds, milliseconds ->
-    seconds.value.toDouble() + milliseconds.value.toDouble() / MILLISECONDS_PER_SECOND
+fun Microseconds.toNSTimeInterval(): NSTimeInterval = toComponents { seconds, microseconds ->
+    seconds.toDouble() + microseconds.toDouble() / MICROSECONDS_PER_SECOND
 }
 
 /**
  * Converts this duration to an equivalent `NSTimeInterval`.
  */
-fun IntMicroseconds.toNSTimeInterval(): NSTimeInterval = toComponents { seconds, microseconds ->
-    seconds.value.toDouble() + microseconds.value.toDouble() / MICROSECONDS_PER_SECOND
-}
-
-/**
- * Converts this duration to an equivalent `NSTimeInterval`.
- */
-fun LongMicroseconds.toNSTimeInterval(): NSTimeInterval = toComponents { seconds, microseconds ->
-    seconds.value.toDouble() + microseconds.value.toDouble() / MICROSECONDS_PER_SECOND
-}
-
-/**
- * Converts this duration to an equivalent `NSTimeInterval`.
- */
-fun IntNanoseconds.toNSTimeInterval(): NSTimeInterval = toComponents { seconds, nanoseconds ->
-    seconds.value.toDouble() + nanoseconds.value.toDouble() / NANOSECONDS_PER_SECOND
-}
-
-/**
- * Converts this duration to an equivalent `NSTimeInterval`.
- */
-fun LongNanoseconds.toNSTimeInterval(): NSTimeInterval = toComponents { seconds, nanoseconds ->
-    seconds.value.toDouble() + nanoseconds.value.toDouble() / NANOSECONDS_PER_SECOND
+fun Nanoseconds.toNSTimeInterval(): NSTimeInterval = toComponents { seconds, nanoseconds ->
+    seconds.toDouble() + nanoseconds.toDouble() / NANOSECONDS_PER_SECOND
 }
 
 /**

--- a/core/src/darwinMain/kotlin/io/islandtime/darwin/Conversions.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/darwin/Conversions.kt
@@ -146,7 +146,7 @@ fun NSDateComponents.toIslandOffsetDateTime() = toIslandOffsetDateTimeOrNull()
  * absent.
  */
 fun NSDateComponents.toIslandOffsetDateTimeOrNull(): OffsetDateTime? {
-    return timeZone.let {
+    return timeZone?.let {
         val dateTime = toIslandDateTime()
         OffsetDateTime(dateTime, it.toIslandTimeZone().rules.offsetAt(dateTime))
     }
@@ -164,7 +164,7 @@ fun NSDateComponents.toIslandZonedDateTime() = toIslandZonedDateTimeOrNull()
  * absent.
  */
 fun NSDateComponents.toIslandZonedDateTimeOrNull(): ZonedDateTime? {
-    return timeZone.let { ZonedDateTime(toIslandDateTime(), it.toIslandTimeZone()) }
+    return timeZone?.let { ZonedDateTime(toIslandDateTime(), it.toIslandTimeZone()) }
 }
 
 /**
@@ -241,6 +241,7 @@ fun UtcOffset.toNSTimeZone(): NSTimeZone = NSTimeZone.timeZoneForSecondsFromGMT(
     replaceWith = ReplaceWith("this.toIslandUtcOffsetAt()"),
     level = DeprecationLevel.ERROR
 )
+@Suppress("unused")
 fun NSTimeZone.toIslandUtcOffset(): UtcOffset = throw UnsupportedOperationException("Should not be called")
 
 /**

--- a/core/src/darwinMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
@@ -127,7 +127,7 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
                 TextStyle.SHORT_STANDALONE -> shortStandaloneWeekdaySymbols
                 TextStyle.NARROW -> veryShortWeekdaySymbols
                 TextStyle.NARROW_STANDALONE -> veryShortStandaloneWeekdaySymbols
-            }
+            } as List<String>
         }
     }
 
@@ -141,7 +141,7 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
                 TextStyle.SHORT_STANDALONE -> shortStandaloneMonthSymbols
                 TextStyle.NARROW -> veryShortMonthSymbols
                 TextStyle.NARROW_STANDALONE -> veryShortStandaloneMonthSymbols
-            }
+            } as List<String>
         }
     }
 
@@ -159,7 +159,7 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
                 when (style) {
                     TextStyle.FULL, TextStyle.FULL_STANDALONE -> longEraSymbols
                     else -> eraSymbols
-                }
+                } as List<String>
             }
         }
     }
@@ -167,6 +167,6 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
     private inline fun <T> withCalendarIn(locale: Locale, block: NSCalendar.() -> T): T? {
         return NSCalendar.calendarWithIdentifier(NSCalendarIdentifierISO8601)?.also {
             it.locale = locale
-        }.block()
+        }?.block()
     }
 }

--- a/core/src/darwinMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/format/DateTimeTextProvider.kt
@@ -127,7 +127,7 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
                 TextStyle.SHORT_STANDALONE -> shortStandaloneWeekdaySymbols
                 TextStyle.NARROW -> veryShortWeekdaySymbols
                 TextStyle.NARROW_STANDALONE -> veryShortStandaloneWeekdaySymbols
-            } as List<String>
+            }
         }
     }
 
@@ -141,7 +141,7 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
                 TextStyle.SHORT_STANDALONE -> shortStandaloneMonthSymbols
                 TextStyle.NARROW -> veryShortMonthSymbols
                 TextStyle.NARROW_STANDALONE -> veryShortStandaloneMonthSymbols
-            } as List<String>
+            }
         }
     }
 
@@ -159,7 +159,7 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
                 when (style) {
                     TextStyle.FULL, TextStyle.FULL_STANDALONE -> longEraSymbols
                     else -> eraSymbols
-                } as List<String>
+                }
             }
         }
     }
@@ -167,6 +167,6 @@ actual object PlatformDateTimeTextProvider : DateTimeTextProvider {
     private inline fun <T> withCalendarIn(locale: Locale, block: NSCalendar.() -> T): T? {
         return NSCalendar.calendarWithIdentifier(NSCalendarIdentifierISO8601)?.also {
             it.locale = locale
-        }?.block()
+        }.block()
     }
 }

--- a/core/src/darwinMain/kotlin/io/islandtime/format/NumberStyle.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/format/NumberStyle.kt
@@ -10,7 +10,7 @@ actual val Locale.numberStyle: NumberStyle
         val formatter = NSNumberFormatter().also { it.locale = this }
 
         return NumberStyle(
-            zeroDigit = formatter.stringFromNumber(NSNumber(int = 0)).singleOrNull() ?: '0',
+            zeroDigit = formatter.stringFromNumber(NSNumber(int = 0))?.singleOrNull() ?: '0',
             plusSign = listOf(formatter.plusSign.singleOrElse { '+' }),
             minusSign = listOf(formatter.minusSign.singleOrElse { '-' }),
             decimalSeparator = listOf(decimalSeparator.singleOrElse { '.' })

--- a/core/src/darwinMain/kotlin/io/islandtime/format/NumberStyle.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/format/NumberStyle.kt
@@ -10,7 +10,7 @@ actual val Locale.numberStyle: NumberStyle
         val formatter = NSNumberFormatter().also { it.locale = this }
 
         return NumberStyle(
-            zeroDigit = formatter.stringFromNumber(NSNumber(int = 0))?.singleOrNull() ?: '0',
+            zeroDigit = formatter.stringFromNumber(NSNumber(int = 0)).singleOrNull() ?: '0',
             plusSign = listOf(formatter.plusSign.singleOrElse { '+' }),
             minusSign = listOf(formatter.minusSign.singleOrElse { '-' }),
             decimalSeparator = listOf(decimalSeparator.singleOrElse { '.' })

--- a/core/src/darwinMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
@@ -7,7 +7,7 @@ import platform.Foundation.*
 actual object PlatformTimeZoneTextProvider : TimeZoneTextProvider {
     override fun timeZoneTextFor(zone: TimeZone, style: TimeZoneTextStyle, locale: Locale): String? {
         return if (zone is TimeZone.Region) {
-            NSTimeZone.timeZoneWithName(zone.id)?.run {
+            NSTimeZone.timeZoneWithName(zone.id).run {
                 val darwinStyle = when (style) {
                     TimeZoneTextStyle.STANDARD -> NSTimeZoneNameStyle.NSTimeZoneNameStyleStandard
                     TimeZoneTextStyle.SHORT_STANDARD -> NSTimeZoneNameStyle.NSTimeZoneNameStyleShortStandard

--- a/core/src/darwinMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/format/TimeZoneTextProvider.kt
@@ -7,7 +7,7 @@ import platform.Foundation.*
 actual object PlatformTimeZoneTextProvider : TimeZoneTextProvider {
     override fun timeZoneTextFor(zone: TimeZone, style: TimeZoneTextStyle, locale: Locale): String? {
         return if (zone is TimeZone.Region) {
-            NSTimeZone.timeZoneWithName(zone.id).run {
+            NSTimeZone.timeZoneWithName(zone.id)?.run {
                 val darwinStyle = when (style) {
                     TimeZoneTextStyle.STANDARD -> NSTimeZoneNameStyle.NSTimeZoneNameStyleStandard
                     TimeZoneTextStyle.SHORT_STANDARD -> NSTimeZoneNameStyle.NSTimeZoneNameStyleShortStandard

--- a/core/src/darwinMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
@@ -53,14 +53,14 @@ private class DarwinTimeZoneRules(timeZone: NSTimeZone) : TimeZoneRules {
         return offsetAt(date)
     }
 
-    override fun offsetAt(secondsSinceUnixEpoch: LongSeconds, nanoOfSeconds: IntNanoseconds): UtcOffset {
+    override fun offsetAt(secondsSinceUnixEpoch: Seconds, nanoOfSeconds: Nanoseconds): UtcOffset {
         val date = NSDate.dateWithTimeIntervalSince1970(
-            secondsSinceUnixEpoch.value.toDouble() + nanoOfSeconds.value.toDouble() / NANOSECONDS_PER_SECOND
+            secondsSinceUnixEpoch.toDouble() + nanoOfSeconds.toDouble() / NANOSECONDS_PER_SECOND
         )
         return offsetAt(date)
     }
 
-    override fun offsetAt(millisecondsSinceUnixEpoch: LongMilliseconds): UtcOffset {
+    override fun offsetAt(millisecondsSinceUnixEpoch: Milliseconds): UtcOffset {
         return offsetAt(NSDate.fromMillisecondsSinceUnixEpoch(millisecondsSinceUnixEpoch))
     }
 
@@ -92,8 +92,8 @@ private class DarwinTimeZoneRules(timeZone: NSTimeZone) : TimeZoneRules {
         return timeZone.isDaylightSavingTimeForDate(instant.toNSDate())
     }
 
-    override fun daylightSavingsAt(instant: Instant): IntSeconds {
-        return timeZone.daylightSavingTimeOffsetForDate(instant.toNSDate()).toInt().seconds
+    override fun daylightSavingsAt(instant: Instant): Seconds {
+        return timeZone.daylightSavingTimeOffsetForDate(instant.toNSDate()).seconds
     }
 
     override val hasFixedOffset: Boolean
@@ -145,7 +145,7 @@ private class DarwinTimeZoneOffsetTransition(
     }
 
     override val dateTimeAfter: DateTime get() = dateTimeBefore + duration
-    override val duration: IntSeconds get() = offsetAfter.totalSeconds - offsetBefore.totalSeconds
+    override val duration: Seconds get() = offsetAfter.totalSeconds - offsetBefore.totalSeconds
     override val isGap: Boolean get() = offsetAfter > offsetBefore
     override val isOverlap: Boolean get() = offsetAfter < offsetBefore
 
@@ -164,8 +164,8 @@ private class DarwinTimeZoneOffsetTransition(
     }
 }
 
-private fun NSDate.Companion.fromMillisecondsSinceUnixEpoch(milliseconds: LongMilliseconds): NSDate {
-    return NSDate.dateWithTimeIntervalSince1970(milliseconds.value.toDouble() / MILLISECONDS_PER_SECOND)
+private fun NSDate.Companion.fromMillisecondsSinceUnixEpoch(milliseconds: Milliseconds): NSDate {
+    return NSDate.dateWithTimeIntervalSince1970(milliseconds.toDouble() / MILLISECONDS_PER_SECOND)
 }
 
 private fun DateTime.toNSDateOrNull(calendar: NSCalendar) = calendar.dateFromComponents(toNSDateComponents())

--- a/core/src/darwinMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
+++ b/core/src/darwinMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
@@ -93,7 +93,7 @@ private class DarwinTimeZoneRules(timeZone: NSTimeZone) : TimeZoneRules {
     }
 
     override fun daylightSavingsAt(instant: Instant): Seconds {
-        return timeZone.daylightSavingTimeOffsetForDate(instant.toNSDate()).seconds
+        return timeZone.daylightSavingTimeOffsetForDate(instant.toNSDate()).toInt().seconds
     }
 
     override val hasFixedOffset: Boolean

--- a/core/src/darwinTest/kotlin/io/islandtime/darwin/ConversionsTest.kt
+++ b/core/src/darwinTest/kotlin/io/islandtime/darwin/ConversionsTest.kt
@@ -101,7 +101,7 @@ class ConversionsTest : AbstractIslandTimeTest() {
             nanosecond = 0
         )
 
-        assertEquals(-14400, components.timeZone?.secondsFromGMT)
+        assertEquals(-14400, components.timeZone.secondsFromGMT)
 
         val componentsWithCalendar = offsetDateTime.toNSDateComponents(includeCalendar = true)
 
@@ -118,7 +118,7 @@ class ConversionsTest : AbstractIslandTimeTest() {
             nanosecond = 0
         )
 
-        assertEquals(-14400, componentsWithCalendar.timeZone?.secondsFromGMT)
+        assertEquals(-14400, componentsWithCalendar.timeZone.secondsFromGMT)
     }
 
     @Test
@@ -139,7 +139,7 @@ class ConversionsTest : AbstractIslandTimeTest() {
             nanosecond = 0
         )
 
-        assertEquals("America/New_York", components.timeZone?.name)
+        assertEquals("America/New_York", components.timeZone.name)
 
         val componentsWithCalendar = zonedDateTime.toNSDateComponents(includeCalendar = true)
 
@@ -156,7 +156,7 @@ class ConversionsTest : AbstractIslandTimeTest() {
             nanosecond = 0
         )
 
-        assertEquals("America/New_York", componentsWithCalendar.timeZone?.name)
+        assertEquals("America/New_York", componentsWithCalendar.timeZone.name)
     }
 
     @Test
@@ -248,7 +248,6 @@ class ConversionsTest : AbstractIslandTimeTest() {
             -1 to -86_400.0
         ).forEach { (value, expected) ->
             assertEquals(expected, value.days.toNSTimeInterval())
-            assertEquals(expected, value.toLong().days.toNSTimeInterval())
         }
     }
 
@@ -260,7 +259,6 @@ class ConversionsTest : AbstractIslandTimeTest() {
             -1 to -3600.0
         ).forEach { (value, expected) ->
             assertEquals(expected, value.hours.toNSTimeInterval())
-            assertEquals(expected, value.toLong().hours.toNSTimeInterval())
         }
     }
 
@@ -272,7 +270,6 @@ class ConversionsTest : AbstractIslandTimeTest() {
             -1 to -60.0
         ).forEach { (value, expected) ->
             assertEquals(expected, value.minutes.toNSTimeInterval())
-            assertEquals(expected, value.toLong().minutes.toNSTimeInterval())
         }
     }
 
@@ -284,7 +281,6 @@ class ConversionsTest : AbstractIslandTimeTest() {
             -1 to -1.0
         ).forEach { (value, expected) ->
             assertEquals(expected, value.seconds.toNSTimeInterval())
-            assertEquals(expected, value.toLong().seconds.toNSTimeInterval())
         }
     }
 
@@ -296,7 +292,6 @@ class ConversionsTest : AbstractIslandTimeTest() {
             -1 to -0.001
         ).forEach { (value, expected) ->
             assertEquals(expected, value.milliseconds.toNSTimeInterval())
-            assertEquals(expected, value.toLong().milliseconds.toNSTimeInterval())
         }
     }
 
@@ -308,7 +303,6 @@ class ConversionsTest : AbstractIslandTimeTest() {
             -1 to -0.000001
         ).forEach { (value, expected) ->
             assertEquals(expected, value.microseconds.toNSTimeInterval())
-            assertEquals(expected, value.toLong().microseconds.toNSTimeInterval())
         }
     }
 
@@ -320,7 +314,6 @@ class ConversionsTest : AbstractIslandTimeTest() {
             -1 to -0.000000001
         ).forEach { (value, expected) ->
             assertEquals(expected, value.nanoseconds.toNSTimeInterval())
-            assertEquals(expected, value.toLong().nanoseconds.toNSTimeInterval())
         }
     }
 

--- a/core/src/darwinTest/kotlin/io/islandtime/darwin/ConversionsTest.kt
+++ b/core/src/darwinTest/kotlin/io/islandtime/darwin/ConversionsTest.kt
@@ -101,7 +101,7 @@ class ConversionsTest : AbstractIslandTimeTest() {
             nanosecond = 0
         )
 
-        assertEquals(-14400, components.timeZone.secondsFromGMT)
+        assertEquals(-14400, components.timeZone?.secondsFromGMT)
 
         val componentsWithCalendar = offsetDateTime.toNSDateComponents(includeCalendar = true)
 
@@ -118,7 +118,7 @@ class ConversionsTest : AbstractIslandTimeTest() {
             nanosecond = 0
         )
 
-        assertEquals(-14400, componentsWithCalendar.timeZone.secondsFromGMT)
+        assertEquals(-14400, componentsWithCalendar.timeZone?.secondsFromGMT)
     }
 
     @Test
@@ -139,7 +139,7 @@ class ConversionsTest : AbstractIslandTimeTest() {
             nanosecond = 0
         )
 
-        assertEquals("America/New_York", components.timeZone.name)
+        assertEquals("America/New_York", components.timeZone?.name)
 
         val componentsWithCalendar = zonedDateTime.toNSDateComponents(includeCalendar = true)
 
@@ -156,7 +156,7 @@ class ConversionsTest : AbstractIslandTimeTest() {
             nanosecond = 0
         )
 
-        assertEquals("America/New_York", componentsWithCalendar.timeZone.name)
+        assertEquals("America/New_York", componentsWithCalendar.timeZone?.name)
     }
 
     @Test

--- a/core/src/jvmMain/kotlin/io/islandtime/calendar/WeekSettings.kt
+++ b/core/src/jvmMain/kotlin/io/islandtime/calendar/WeekSettings.kt
@@ -18,5 +18,5 @@ internal actual val Locale.firstDayOfWeek: DayOfWeek
 
 private fun Locale.withoutVariant() = Locale(language, country)
 
-private val Calendar.firstIslandDayOfWeek
+private val Calendar.firstIslandDayOfWeek: DayOfWeek
     get() = DayOfWeek.SUNDAY + (firstDayOfWeek - 1).days

--- a/core/src/jvmMain/kotlin/io/islandtime/clock/internal/SystemClockImpl.kt
+++ b/core/src/jvmMain/kotlin/io/islandtime/clock/internal/SystemClockImpl.kt
@@ -5,7 +5,7 @@ import io.islandtime.PlatformInstant
 import io.islandtime.TimeZone
 import io.islandtime.clock.SystemClock
 import io.islandtime.jvm.toIslandInstant
-import io.islandtime.measures.LongMilliseconds
+import io.islandtime.measures.Milliseconds
 import io.islandtime.measures.milliseconds
 import java.time.Clock as JavaClock
 
@@ -14,7 +14,7 @@ private val javaClock = JavaClock.systemUTC()
 internal actual fun createSystemClock(zone: TimeZone): SystemClock {
     return object : SystemClock() {
         override val zone: TimeZone = zone
-        override fun readMilliseconds(): LongMilliseconds = System.currentTimeMillis().milliseconds
+        override fun readMilliseconds(): Milliseconds = System.currentTimeMillis().milliseconds
         override fun readInstant(): Instant = readPlatformInstant().toIslandInstant()
         override fun readPlatformInstant(): PlatformInstant = javaClock.instant()
     }

--- a/core/src/jvmMain/kotlin/io/islandtime/jvm/Conversions.kt
+++ b/core/src/jvmMain/kotlin/io/islandtime/jvm/Conversions.kt
@@ -73,7 +73,7 @@ fun DateTime.toJavaLocalDateTime(): java.time.LocalDateTime {
 fun java.time.OffsetTime.toIslandOffsetTime(): OffsetTime {
     return OffsetTime(
         Time(hour, minute, second, nano),
-        UtcOffset(offset.totalSeconds.seconds)
+        UtcOffset.fromTotalSeconds(offset.totalSeconds)
     )
 }
 
@@ -83,7 +83,7 @@ fun java.time.OffsetTime.toIslandOffsetTime(): OffsetTime {
 fun OffsetTime.toJavaOffsetTime(): java.time.OffsetTime {
     return java.time.OffsetTime.of(
         java.time.LocalTime.of(hour, minute, second, nanosecond),
-        java.time.ZoneOffset.ofTotalSeconds(offset.totalSeconds.value)
+        java.time.ZoneOffset.ofTotalSeconds(offset.totalSecondsValue)
     )
 }
 
@@ -96,7 +96,7 @@ fun java.time.OffsetDateTime.toIslandOffsetDateTime(): OffsetDateTime {
             Date(year, monthValue, dayOfMonth),
             Time(hour, minute, second, nano)
         ),
-        UtcOffset(offset.totalSeconds.seconds)
+        UtcOffset.fromTotalSeconds(offset.totalSeconds)
     )
 }
 
@@ -106,7 +106,7 @@ fun java.time.OffsetDateTime.toIslandOffsetDateTime(): OffsetDateTime {
 fun OffsetDateTime.toJavaOffsetDateTime(): java.time.OffsetDateTime {
     return java.time.OffsetDateTime.of(
         java.time.LocalDateTime.of(year, monthNumber, dayOfMonth, hour, minute, second, nanosecond),
-        java.time.ZoneOffset.ofTotalSeconds(offset.totalSeconds.value)
+        java.time.ZoneOffset.ofTotalSeconds(offset.totalSecondsValue)
     )
 }
 
@@ -120,7 +120,7 @@ fun java.time.ZonedDateTime.toIslandZonedDateTime(): ZonedDateTime {
             Time(hour, minute, second, nano)
         ),
         zone.toIslandTimeZone(),
-        UtcOffset(offset.totalSeconds.seconds)
+        UtcOffset.fromTotalSeconds(offset.totalSeconds)
     )
 }
 
@@ -131,7 +131,7 @@ fun ZonedDateTime.toJavaZonedDateTime(): java.time.ZonedDateTime {
     return java.time.ZonedDateTime.ofLocal(
         java.time.LocalDateTime.of(year, monthNumber, dayOfMonth, hour, minute, second, nanosecond),
         java.time.ZoneId.of(zone.id),
-        java.time.ZoneOffset.ofTotalSeconds(offset.totalSeconds.value)
+        java.time.ZoneOffset.ofTotalSeconds(offset.totalSecondsValue)
     )
 }
 
@@ -139,14 +139,14 @@ fun ZonedDateTime.toJavaZonedDateTime(): java.time.ZonedDateTime {
  * Converts this UTC offset to an equivalent Island Time [UtcOffset].
  */
 fun java.time.ZoneOffset.toIslandUtcOffset(): UtcOffset {
-    return UtcOffset(totalSeconds.seconds)
+    return UtcOffset.fromTotalSeconds(totalSeconds)
 }
 
 /**
  * Converts this UTC offset to an equivalent Java `ZoneOffset`.
  */
 fun UtcOffset.toJavaZoneOffset(): java.time.ZoneOffset {
-    return java.time.ZoneOffset.ofTotalSeconds(totalSeconds.value)
+    return java.time.ZoneOffset.ofTotalSeconds(totalSecondsValue)
 }
 
 /**
@@ -174,7 +174,7 @@ fun java.time.Duration.toIslandDuration(): Duration {
  * Converts this duration to an equivalent Java `Duration`.
  */
 fun Duration.toJavaDuration(): java.time.Duration {
-    return java.time.Duration.ofSeconds(seconds.value, nanosecondAdjustment.value.toLong())
+    return java.time.Duration.ofSeconds(seconds.value, nanosecondAdjustment.value)
 }
 
 /**
@@ -188,7 +188,7 @@ fun java.time.Period.toIslandPeriod(): Period {
  * Converts this period to an equivalent Java `Period`.
  */
 fun Period.toJavaPeriod(): java.time.Period {
-    return java.time.Period.of(years.value, months.value, days.value)
+    return java.time.Period.of(years.toInt(), months.toInt(), days.toInt())
 }
 
 /**
@@ -222,123 +222,63 @@ fun Year.toJavaYear(): java.time.Year {
 /**
  * Converts this duration to an equivalent Java `Period`.
  */
-fun IntCenturies.toJavaPeriod(): java.time.Period = this.inYears.toJavaPeriod()
+fun Centuries.toJavaPeriod(): java.time.Period = this.inYears.toJavaPeriod()
 
 /**
  * Converts this duration to an equivalent Java `Period`.
  */
-fun LongCenturies.toJavaPeriod(): java.time.Period = this.inYears.toJavaPeriod()
+fun Decades.toJavaPeriod(): java.time.Period = this.inYears.toJavaPeriod()
 
 /**
  * Converts this duration to an equivalent Java `Period`.
  */
-fun IntDecades.toJavaPeriod(): java.time.Period = this.inYears.toJavaPeriod()
+fun Years.toJavaPeriod(): java.time.Period = java.time.Period.ofYears(this.toInt())
 
 /**
  * Converts this duration to an equivalent Java `Period`.
  */
-fun LongDecades.toJavaPeriod(): java.time.Period = this.inYears.toJavaPeriod()
+fun Months.toJavaPeriod(): java.time.Period = java.time.Period.ofMonths(this.toInt())
 
 /**
  * Converts this duration to an equivalent Java `Period`.
  */
-fun IntYears.toJavaPeriod(): java.time.Period = java.time.Period.ofYears(value)
+fun Weeks.toJavaPeriod(): java.time.Period = java.time.Period.ofWeeks(this.toInt())
 
 /**
  * Converts this duration to an equivalent Java `Period`.
  */
-fun LongYears.toJavaPeriod(): java.time.Period = this.toIntYears().toJavaPeriod()
-
-/**
- * Converts this duration to an equivalent Java `Period`.
- */
-fun IntMonths.toJavaPeriod(): java.time.Period = java.time.Period.ofMonths(value)
-
-/**
- * Converts this duration to an equivalent Java `Period`.
- */
-fun LongMonths.toJavaPeriod(): java.time.Period = this.toIntMonths().toJavaPeriod()
-
-/**
- * Converts this duration to an equivalent Java `Period`.
- */
-fun IntWeeks.toJavaPeriod(): java.time.Period = java.time.Period.ofWeeks(value)
-
-/**
- * Converts this duration to an equivalent Java `Period`.
- */
-fun LongWeeks.toJavaPeriod(): java.time.Period = this.toIntWeeks().toJavaPeriod()
-
-/**
- * Converts this duration to an equivalent Java `Period`.
- */
-fun IntDays.toJavaPeriod(): java.time.Period = java.time.Period.ofDays(value)
-
-/**
- * Converts this duration to an equivalent Java `Period`.
- */
-fun LongDays.toJavaPeriod(): java.time.Period = this.toIntDays().toJavaPeriod()
+fun Days.toJavaPeriod(): java.time.Period = java.time.Period.ofDays(this.toInt())
 
 /**
  * Converts this duration to an equivalent Java `Duration`.
  */
-fun IntDays.toJavaDuration(): java.time.Duration = java.time.Duration.ofDays(value.toLong())
+fun Days.toJavaDuration(): java.time.Duration = java.time.Duration.ofDays(value)
 
 /**
  * Converts this duration to an equivalent Java `Duration`.
  */
-fun LongDays.toJavaDuration(): java.time.Duration = java.time.Duration.ofDays(value)
+fun Hours.toJavaDuration(): java.time.Duration = java.time.Duration.ofHours(value)
 
 /**
  * Converts this duration to an equivalent Java `Duration`.
  */
-fun IntHours.toJavaDuration(): java.time.Duration = java.time.Duration.ofHours(value.toLong())
+fun Minutes.toJavaDuration(): java.time.Duration = java.time.Duration.ofMinutes(value)
 
 /**
  * Converts this duration to an equivalent Java `Duration`.
  */
-fun LongHours.toJavaDuration(): java.time.Duration = java.time.Duration.ofHours(value)
+fun Seconds.toJavaDuration(): java.time.Duration = java.time.Duration.ofSeconds(value)
 
 /**
  * Converts this duration to an equivalent Java `Duration`.
  */
-fun IntMinutes.toJavaDuration(): java.time.Duration = java.time.Duration.ofMinutes(value.toLong())
+fun Milliseconds.toJavaDuration(): java.time.Duration = java.time.Duration.ofMillis(value)
 
 /**
  * Converts this duration to an equivalent Java `Duration`.
  */
-fun LongMinutes.toJavaDuration(): java.time.Duration = java.time.Duration.ofMinutes(value)
-
-/**
- * Converts this duration to an equivalent Java `Duration`.
- */
-fun IntSeconds.toJavaDuration(): java.time.Duration = java.time.Duration.ofSeconds(value.toLong())
-
-/**
- * Converts this duration to an equivalent Java `Duration`.
- */
-fun LongSeconds.toJavaDuration(): java.time.Duration = java.time.Duration.ofSeconds(value)
-
-/**
- * Converts this duration to an equivalent Java `Duration`.
- */
-fun IntMilliseconds.toJavaDuration(): java.time.Duration = java.time.Duration.ofMillis(value.toLong())
-
-/**
- * Converts this duration to an equivalent Java `Duration`.
- */
-fun LongMilliseconds.toJavaDuration(): java.time.Duration = java.time.Duration.ofMillis(value)
-
-/**
- * Converts this duration to an equivalent Java `Duration`.
- */
-fun IntMicroseconds.toJavaDuration(): java.time.Duration = this.toLongMicroseconds().toJavaDuration()
-
-/**
- * Converts this duration to an equivalent Java `Duration`.
- */
-fun LongMicroseconds.toJavaDuration(): java.time.Duration {
-    val seconds = this.inSeconds
+fun Microseconds.toJavaDuration(): java.time.Duration {
+    val seconds = this.inWholeSeconds
     val nanoOfSeconds = (this % MICROSECONDS_PER_SECOND).inNanoseconds
     return java.time.Duration.ofSeconds(seconds.value, nanoOfSeconds.value)
 }
@@ -346,12 +286,7 @@ fun LongMicroseconds.toJavaDuration(): java.time.Duration {
 /**
  * Converts this duration to an equivalent Java `Duration`.
  */
-fun IntNanoseconds.toJavaDuration(): java.time.Duration = java.time.Duration.ofNanos(value.toLong())
-
-/**
- * Converts this duration to an equivalent Java `Duration`.
- */
-fun LongNanoseconds.toJavaDuration(): java.time.Duration = java.time.Duration.ofNanos(value)
+fun Nanoseconds.toJavaDuration(): java.time.Duration = java.time.Duration.ofNanos(value)
 
 /**
  * Makes this clock compatible with Island Time's [Clock] interface.
@@ -369,5 +304,5 @@ private class WrappedJavaClock(private val clock: java.time.Clock) : Clock {
     override val zone: TimeZone get() = clock.zone.toIslandTimeZone()
     override fun readPlatformInstant(): PlatformInstant = clock.instant()
     override fun readInstant(): Instant = readPlatformInstant().toIslandInstant()
-    override fun readMilliseconds(): LongMilliseconds = clock.millis().milliseconds
+    override fun readMilliseconds(): Milliseconds = clock.millis().milliseconds
 }

--- a/core/src/jvmMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
+++ b/core/src/jvmMain/kotlin/io/islandtime/zone/TimeZoneRules.kt
@@ -5,7 +5,10 @@ import io.islandtime.Instant
 import io.islandtime.PlatformInstant
 import io.islandtime.UtcOffset
 import io.islandtime.jvm.*
-import io.islandtime.measures.*
+import io.islandtime.measures.Milliseconds
+import io.islandtime.measures.Nanoseconds
+import io.islandtime.measures.Seconds
+import io.islandtime.measures.seconds
 import java.time.ZoneId
 import java.time.zone.ZoneOffsetTransition
 import java.time.zone.ZoneRules
@@ -45,13 +48,13 @@ private class JavaTimeZoneRules(private val javaZoneRules: ZoneRules) : TimeZone
 
     override val hasFixedOffset: Boolean get() = javaZoneRules.isFixedOffset
 
-    override fun offsetAt(millisecondsSinceUnixEpoch: LongMilliseconds): UtcOffset {
+    override fun offsetAt(millisecondsSinceUnixEpoch: Milliseconds): UtcOffset {
         val javaInstant = JavaInstant.ofEpochMilli(millisecondsSinceUnixEpoch.value)
         return offsetAt(javaInstant)
     }
 
-    override fun offsetAt(secondsSinceUnixEpoch: LongSeconds, nanoOfSeconds: IntNanoseconds): UtcOffset {
-        val javaInstant = JavaInstant.ofEpochSecond(secondsSinceUnixEpoch.value, nanoOfSeconds.value.toLong())
+    override fun offsetAt(secondsSinceUnixEpoch: Seconds, nanoOfSeconds: Nanoseconds): UtcOffset {
+        val javaInstant = JavaInstant.ofEpochSecond(secondsSinceUnixEpoch.value, nanoOfSeconds.value)
         return offsetAt(javaInstant)
     }
 
@@ -94,8 +97,8 @@ private class JavaTimeZoneRules(private val javaZoneRules: ZoneRules) : TimeZone
         return javaZoneRules.isDaylightSavings(instant.toJavaInstant())
     }
 
-    override fun daylightSavingsAt(instant: Instant): IntSeconds {
-        return javaZoneRules.getDaylightSavings(instant.toJavaInstant()).seconds.toInt().seconds
+    override fun daylightSavingsAt(instant: Instant): Seconds {
+        return javaZoneRules.getDaylightSavings(instant.toJavaInstant()).seconds.seconds
     }
 }
 
@@ -115,7 +118,7 @@ private class JavaTimeZoneOffsetTransition(
     override val offsetAfter: UtcOffset
         get() = javaZoneOffsetTransition.offsetAfter.toIslandUtcOffset()
 
-    override val duration: IntSeconds
+    override val duration: Seconds
         get() = offsetAfter.totalSeconds - offsetBefore.totalSeconds
 
     override val isGap: Boolean

--- a/core/src/jvmMain/resources/META-INF/proguard/islandtime.pro
+++ b/core/src/jvmMain/resources/META-INF/proguard/islandtime.pro
@@ -1,3 +1,3 @@
--keepclassmembernames class io.islandtime.** {
+-keepclassmembers class io.islandtime.** {
     volatile <fields>;
 }

--- a/docs/basics/durations.md
+++ b/docs/basics/durations.md
@@ -4,22 +4,19 @@ In Island Time, durations are fully type-safe. The use of durations in terms of 
 
 ## Single Unit Durations
 
-Island Time provides [value classes](https://kotlinlang.org/docs/reference/inline-classes.html) representing each individual duration unit, backed by either a `Long` or `Int` &mdash; such as `IntYears`, `IntHours`, or `LongNanoseconds`. This allows the precision of each quantity to be maintained, avoids ambiguitity regarding the meaning of a day (ie. conceptual vs. 24 hours), and is quite efficient as well. When adding or subtracting quantities in mixed units, precision is increased automatically as needed. For example:
+Island Time provides [value classes](https://kotlinlang.org/docs/reference/inline-classes.html) representing each individual duration unit backed by a `Long` value &mdash; such as `Years`, `Hours`, or `Nanoseconds`. This allows the precision of each quantity to be maintained, avoids ambiguitity regarding the meaning of a day (ie. conceptual vs. 24 hours), and is quite efficient as well. When adding or subtracting quantities in mixed units, precision is increased automatically as needed. For example:
 
 ```kotlin
 // The minimum necessary unit granularity is preserved when
 // combining different units
-val totalSeconds: IntSeconds = 5.hours + 30.minutes + 1.seconds
-
-// Math with Int values on sub-second units forces a lengthing
-// to Long due to overflow potential
-val nanoseconds: LongNanoseconds = 5.seconds + 1.nanoseconds
+val totalSeconds: Seconds = 5.hours + 30.minutes + 1.seconds
+val nanoseconds: Nanoseconds = totalSeconds + 1.nanoseconds
 ```
 
 A quantity in one unit can be broken down into parts in terms of "bigger" units using the `toComponents()` method.
 
 ```kotlin
-61.minutes.toComponents { hours: IntHours, minutes: IntMinutes ->
+61.minutes.toComponents { hours: Hours, minutes: Minutes ->
    println(hours) // PT1H
    println(minutes) // PT1M
 }
@@ -28,7 +25,7 @@ A quantity in one unit can be broken down into parts in terms of "bigger" units 
 Or converted to another unit.
 
 ```kotlin
-val hours: IntHours = 60.minutes.inHours
+val hours: Hours = 60.minutes.inWholeHours
 ```
 
 You can also get the duration between two date-times in terms of any given unit, using functions like `hoursBetween()` or `daysBetween()`.

--- a/docs/basics/interop.md
+++ b/docs/basics/interop.md
@@ -42,7 +42,7 @@ You can find the full set of conversions in the [io.islandtime.jvm](../api/core/
 
 ## Apple Foundation Classes
 
-We can map between some of the Island Time types and the date-time types provided in Apple's [Foundation API](https://developer.apple.com/documentation/foundation/dates_and_times?language=objc), such as `NSDate`, `NSDateComponents`, and `NSTimeZone`. Keep in mind that `NSDate` and `NSTimeInterval` are based around floating-point numbers, so conversion may result in lost precision.
+We can map between some Island Time types and the date-time types provided in Apple's [Foundation API](https://developer.apple.com/documentation/foundation/dates_and_times?language=objc), such as `NSDate`, `NSDateComponents`, and `NSTimeZone`. Keep in mind that `NSDate` and `NSTimeInterval` are based around floating-point numbers, so conversion may result in lost precision.
 
 ```kotlin
 // NSDate is a timestamp, just like Instant
@@ -64,7 +64,7 @@ The full set of conversions can be found in the [io.islandtime.darwin](../api/co
 
 ## kotlin.time
 
-The Kotlin Standard Library has an experimental [`Duration`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.time/-duration/) type of its own, which you can convert to and from Island Time durations. Kotlin's `Duration` is based on a floating-point number, so keep in mind that conversion may result in lost precision.
+The Kotlin Standard Library has an experimental [`Duration`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.time/-duration/) type of its own, which you can convert to and from Island Time durations.
 
 ```kotlin
 import kotlin.time.seconds as kotlinSeconds
@@ -73,5 +73,5 @@ import kotlin.time.seconds as kotlinSeconds
 val kotlinDuration: kotlin.time.Duration = 30.minutes.toKotlinDuration()
 
 // Convert from Kotlin Duration to Island Time Duration
-val islandDuration: Duration = 30.kotlinSeconds.toIslandDuration() 
+val islandDuration: Duration = kotlin.time.Duration.seconds(30).toIslandDuration() 
 ```

--- a/extensions/parcelize/src/main/kotlin/Duration.kt
+++ b/extensions/parcelize/src/main/kotlin/Duration.kt
@@ -14,7 +14,7 @@ object DurationParceler : Parceler<Duration> {
 
     override fun Duration.write(parcel: Parcel, flags: Int) {
         parcel.writeLong(seconds.value)
-        parcel.writeInt(nanosecondAdjustment.value)
+        parcel.writeInt(nanosecondAdjustment.toInt())
     }
 }
 
@@ -32,7 +32,7 @@ object NullableDurationParceler : Parceler<Duration?> {
         } else {
             parcel.writeByte(NON_NULL_VALUE)
             parcel.writeLong(seconds.value)
-            parcel.writeInt(nanosecondAdjustment.value)
+            parcel.writeInt(nanosecondAdjustment.toInt())
         }
     }
 

--- a/extensions/parcelize/src/main/kotlin/OffsetDateTime.kt
+++ b/extensions/parcelize/src/main/kotlin/OffsetDateTime.kt
@@ -29,7 +29,7 @@ object NullableOffsetDateTimeParceler : Parceler<OffsetDateTime?> {
                     parcel.readByte().toInt(),
                     parcel.readInt()
                 ),
-                UtcOffset(parcel.readInt().seconds)
+                UtcOffset.fromTotalSeconds(parcel.readInt())
             )
         }
     }
@@ -49,5 +49,5 @@ internal fun Parcel.readOffsetDateTime(): OffsetDateTime {
 
 internal fun Parcel.writeOffsetDateTime(offsetDateTime: OffsetDateTime) {
     writeDateTime(offsetDateTime.dateTime)
-    writeInt(offsetDateTime.offset.totalSeconds.value)
+    writeInt(offsetDateTime.offset.totalSecondsValue)
 }

--- a/extensions/parcelize/src/main/kotlin/OffsetTime.kt
+++ b/extensions/parcelize/src/main/kotlin/OffsetTime.kt
@@ -13,7 +13,7 @@ object OffsetTimeParceler : Parceler<OffsetTime> {
             parcel.readByte().toInt(),
             parcel.readByte().toInt(),
             parcel.readInt(),
-            UtcOffset(parcel.readInt().seconds)
+            UtcOffset.fromTotalSeconds(parcel.readInt())
         )
     }
 
@@ -22,7 +22,7 @@ object OffsetTimeParceler : Parceler<OffsetTime> {
         parcel.writeByte(minute.toByte())
         parcel.writeByte(second.toByte())
         parcel.writeInt(nanosecond)
-        parcel.writeInt(offset.totalSeconds.value)
+        parcel.writeInt(offset.totalSecondsValue)
     }
 }
 
@@ -35,7 +35,7 @@ object NullableOffsetTimeParceler : Parceler<OffsetTime?> {
                 parcel.readByte().toInt(),
                 parcel.readByte().toInt(),
                 parcel.readInt(),
-                UtcOffset(parcel.readInt().seconds)
+                UtcOffset.fromTotalSeconds(parcel.readInt())
             )
         }
     }
@@ -48,7 +48,7 @@ object NullableOffsetTimeParceler : Parceler<OffsetTime?> {
             parcel.writeByte(minute.toByte())
             parcel.writeByte(second.toByte())
             parcel.writeInt(nanosecond)
-            parcel.writeInt(offset.totalSeconds.value)
+            parcel.writeInt(offset.totalSecondsValue)
         }
     }
 }

--- a/extensions/parcelize/src/main/kotlin/Period.kt
+++ b/extensions/parcelize/src/main/kotlin/Period.kt
@@ -7,16 +7,16 @@ import kotlinx.parcelize.Parceler
 object PeriodParceler : Parceler<Period> {
     override fun create(parcel: Parcel): Period {
         return periodOf(
-            parcel.readInt().years,
-            parcel.readInt().months,
-            parcel.readInt().days
+            parcel.readLong().years,
+            parcel.readLong().months,
+            parcel.readLong().days
         )
     }
 
     override fun Period.write(parcel: Parcel, flags: Int) {
-        parcel.writeInt(years.value)
-        parcel.writeInt(months.value)
-        parcel.writeInt(days.value)
+        parcel.writeLong(years.value)
+        parcel.writeLong(months.value)
+        parcel.writeLong(days.value)
     }
 }
 
@@ -25,9 +25,9 @@ object NullablePeriodParceler : Parceler<Period?> {
         return when {
             parcel.readByte() == NULL_VALUE -> null
             else -> periodOf(
-                parcel.readInt().years,
-                parcel.readInt().months,
-                parcel.readInt().days
+                parcel.readLong().years,
+                parcel.readLong().months,
+                parcel.readLong().days
             )
         }
     }
@@ -37,9 +37,9 @@ object NullablePeriodParceler : Parceler<Period?> {
             parcel.writeByte(NULL_VALUE)
         } else {
             parcel.writeByte(NON_NULL_VALUE)
-            parcel.writeInt(years.value)
-            parcel.writeInt(months.value)
-            parcel.writeInt(days.value)
+            parcel.writeLong(years.value)
+            parcel.writeLong(months.value)
+            parcel.writeLong(days.value)
         }
     }
 

--- a/extensions/parcelize/src/main/kotlin/ZonedDateTime.kt
+++ b/extensions/parcelize/src/main/kotlin/ZonedDateTime.kt
@@ -31,7 +31,7 @@ object NullableZonedDateTimeParceler : Parceler<ZonedDateTime?> {
                     parcel.readInt()
                 ),
                 TimeZone(parcel.readString().orEmpty()),
-                UtcOffset(parcel.readInt().seconds)
+                UtcOffset.fromTotalSeconds(parcel.readInt())
             )
         }
     }
@@ -49,12 +49,12 @@ internal fun Parcel.readZonedDateTime(): ZonedDateTime {
     return ZonedDateTime.fromLocal(
         readDateTime(),
         TimeZone(readString().orEmpty()),
-        UtcOffset(readInt().seconds)
+        UtcOffset.fromTotalSeconds(readInt())
     )
 }
 
 internal fun Parcel.writeZonedDateTime(zonedDateTime: ZonedDateTime) {
     writeDateTime(zonedDateTime.dateTime)
     writeString(zonedDateTime.zone.id)
-    writeInt(zonedDateTime.offset.totalSeconds.value)
+    writeInt(zonedDateTime.offset.totalSecondsValue)
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tools/code-generator/src/main/kotlin/io/islandtime/codegen/descriptions/TemporalUnitDescription.kt
+++ b/tools/code-generator/src/main/kotlin/io/islandtime/codegen/descriptions/TemporalUnitDescription.kt
@@ -41,15 +41,16 @@ enum class TemporalUnitDescription(
         override val singularName: String = "Century"
     };
 
-    val intName: String get() = "Int$pluralName"
-    val longName: String get() = "Long$pluralName"
+    val deprecatedIntName: String get() = "Int$pluralName"
+    val deprecatedLongName: String get() = "Long$pluralName"
     open val singularName: String get() = pluralName.dropLast(1)
     val lowerSingularName: String get() = singularName.lowercase()
     val lowerPluralName: String get() = pluralName.lowercase()
     val valueName: String get() = "value"
     val inUnitPropertyName: String get() = "in$pluralName"
     val inUnitUncheckedPropertyName: String get() = "${inUnitPropertyName}Unchecked"
-    val inWholeUnitPropertyName: String get() = "in$pluralName"
+    val inWholeUnitPropertyName: String get() = "inWhole$pluralName"
+    val deprecatedInWholeUnitPropertyName: String get() = "in$pluralName"
 
     open val isoPeriodPrefix: String get() = if (isTimeBased) "PT" else "P"
     open val isoPeriodIsFractional: Boolean = false
@@ -85,11 +86,15 @@ data class TemporalUnitConversion(
     fun isNecessary() = operator != ConversionOperator.NONE
 
     @OptIn(ExperimentalStdlibApi::class)
-    val constantName: String
-        get() {
-            val (smallerUnit, largerUnit) = orderedFromSmallerToLargerUnit()
-            return "${smallerUnit.pluralName}_PER_${largerUnit.singularName}".uppercase()
-        }
+    val constantName: String by lazy(LazyThreadSafetyMode.NONE) {
+        val (smallerUnit, largerUnit) = orderedFromSmallerToLargerUnit()
+        "${smallerUnit.pluralName}_PER_${largerUnit.singularName}".uppercase()
+    }
+
+    val id: String by lazy(LazyThreadSafetyMode.NONE) {
+        val (smallerUnit, largerUnit) = orderedFromSmallerToLargerUnit()
+        "${smallerUnit.lowerPluralName}Per${largerUnit.singularName}"
+    }
 
     val operator: ConversionOperator
         get() = when {

--- a/tools/code-generator/src/main/kotlin/io/islandtime/codegen/dsl/CodeWriterDsl.kt
+++ b/tools/code-generator/src/main/kotlin/io/islandtime/codegen/dsl/CodeWriterDsl.kt
@@ -1,6 +1,7 @@
 package io.islandtime.codegen.dsl
 
 import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import kotlin.reflect.KClass
 
 @DslMarker
@@ -16,6 +17,14 @@ class FileBuilder(
         addHeader(jvmName)
     }
 
+    fun aliasedImport(className: ClassName, `as`: String) {
+        builder.addAliasedImport(className, `as`)
+    }
+
+    fun aliasedImports(vararg imports: Pair<ClassName, String>) {
+        imports.forEach { (className, `as`) -> aliasedImport(className, `as`) }
+    }
+
     fun property(name: String, returnType: KClass<*>, block: PropertyBuilder.() -> Unit) {
         property(name, returnType.asTypeName(), block)
     }
@@ -28,6 +37,14 @@ class FileBuilder(
         builder.addFunction(FunctionBuilder(name).apply(block).build())
     }
 
+    fun `class`(name: String, block: ClassBuilder.() -> Unit) {
+        builder.addType(ClassBuilder(name).apply(block).build())
+    }
+
+    fun typeAlias(name: String, type: TypeName, block: TypeAliasBuilder.() -> Unit) {
+        builder.addTypeAlias(TypeAliasBuilder(name, type).apply(block).build())
+    }
+
     fun build(): FileSpec = builder.build()
 }
 
@@ -37,7 +54,6 @@ class PropertyBuilder(
     returnType: TypeName
 ) {
     private val builder = PropertySpec.builder(name, returnType)
-    private val modifiers = mutableListOf<KModifier>()
 
     fun <T> kdoc(block: CodeBlockBuilder.() -> T) {
         builder.addKdoc(CodeBlockBuilder(sanitize = true).apply(block).build())
@@ -45,58 +61,107 @@ class PropertyBuilder(
 
     fun annotation(annotation: KClass<*>) {
         builder.addAnnotation(annotation)
+    }
+
+    fun deprecated(message: String, replaceWith: String? = null, level: DeprecationLevel = DeprecationLevel.WARNING) {
+        builder.addAnnotation(buildDeprecatedAnnotationSpec(message, replaceWith, level))
     }
 
     fun receiver(type: TypeName) {
         builder.receiver(type)
     }
 
-    fun modifiers(vararg modifiers: KModifier) {
-        this.modifiers += modifiers
-    }
-
-    fun <T> initializer(block: CodeBlockBuilder.() -> T) {
-        builder.apply {
-            addModifiers(this@PropertyBuilder.modifiers)
-            initializer(CodeBlockBuilder(insertLineSeparators = false).apply(block).build())
-        }
-    }
-
-    fun <T> getter(block: CodeBlockBuilder.() -> T) {
-        builder.getter(
-            buildGetterFunSpec {
-                addModifiers(this@PropertyBuilder.modifiers)
-                addCode(CodeBlockBuilder().apply(block).build())
-            }
-        )
-    }
-
-    fun delegatesTo(memberName: String) {
-        getter { "return $memberName.${this@PropertyBuilder.name}" }
-    }
-
-    fun build(): PropertySpec = builder.build()
-}
-
-@CodeWriterDsl
-class FunctionBuilder(private val name: String) {
-    private val builder = FunSpec.builder(name)
-    private val parameterSpecs = mutableListOf<ParameterSpec>()
-
-    fun annotation(annotation: KClass<*>) {
-        builder.addAnnotation(annotation)
-    }
-
-    fun <T> kdoc(block: CodeBlockBuilder.() -> T) {
-        builder.addKdoc(CodeBlockBuilder(sanitize = true).apply(block).build())
-    }
-
-    fun receiver(type: TypeName) {
+    fun receiver(type: KClass<*>) {
         builder.receiver(type)
     }
 
     fun modifiers(vararg modifiers: KModifier) {
         builder.addModifiers(*modifiers)
+    }
+
+    fun <T> initializer(block: CodeBlockBuilder.() -> T) {
+        builder.initializer(CodeBlockBuilder(insertLineSeparators = false).apply(block).build())
+    }
+
+    fun getter(block: GetterFunctionBuilder.() -> Unit) {
+        builder.getter(GetterFunctionBuilder().apply(block).build())
+    }
+
+    fun delegatesTo(memberName: String, vararg modifiers: KModifier) {
+        getter {
+            modifiers(*modifiers)
+            code { "return $memberName.${this@PropertyBuilder.name}" }
+        }
+    }
+
+    fun build(): PropertySpec = builder.build()
+}
+
+abstract class AbstractFunctionBuilder(
+    protected val builder: FunSpec.Builder
+) {
+    protected val parameterSpecs = mutableListOf<ParameterSpec>()
+
+    fun annotation(annotation: KClass<*>, block: AnnotationBuilder.() -> Unit = {}) {
+        annotation(annotation.asClassName(), block)
+    }
+
+    fun annotation(annotation: ClassName, block: AnnotationBuilder.() -> Unit = {}) {
+        builder.addAnnotation(AnnotationBuilder(annotation).apply(block).build())
+    }
+
+    fun deprecated(message: String, replaceWith: String? = null, level: DeprecationLevel = DeprecationLevel.WARNING) {
+        builder.addAnnotation(buildDeprecatedAnnotationSpec(message, replaceWith, level))
+    }
+
+    fun <T> kdoc(block: CodeBlockBuilder.() -> T) {
+        builder.addKdoc(CodeBlockBuilder(sanitize = true).apply(block).build())
+    }
+
+    fun modifiers(vararg modifiers: KModifier) {
+        builder.addModifiers(*modifiers)
+    }
+
+    fun <T> code(block: CodeBlockBuilder.() -> T) {
+        builder.addCode(
+            CodeBlockBuilder(parameterSpecs.associateBy { it.name }).apply(block).build()
+        )
+    }
+
+    fun build(): FunSpec = builder.build()
+}
+
+abstract class AbstractFunctionWithArgsBuilder(builder: FunSpec.Builder) : AbstractFunctionBuilder(builder) {
+    fun argument(name: String, type: KClass<*>) {
+        argument(name, type.asTypeName())
+    }
+
+    fun argument(name: String, type: TypeName) {
+        val parameterSpec = buildParameterSpec(name, type)
+        parameterSpecs += parameterSpec
+        builder.addParameter(parameterSpec)
+    }
+}
+
+@CodeWriterDsl
+class GetterFunctionBuilder : AbstractFunctionBuilder(FunSpec.getterBuilder()) {
+    fun returns(type: TypeName) {
+        builder.returns(type)
+    }
+
+    fun returns(type: KClass<*>) {
+        builder.returns(type)
+    }
+}
+
+@CodeWriterDsl
+class FunctionBuilder(private val name: String) : AbstractFunctionWithArgsBuilder(FunSpec.builder(name)) {
+    fun receiver(type: TypeName) {
+        builder.receiver(type)
+    }
+
+    fun receiver(type: KClass<*>) {
+        builder.receiver(type)
     }
 
     fun returns(type: TypeName) {
@@ -107,16 +172,8 @@ class FunctionBuilder(private val name: String) {
         builder.returns(type)
     }
 
-    fun argument(name: String, type: TypeName) {
-        val parameterSpec = buildParameterSpec(name, type)
-        parameterSpecs += parameterSpec
-        builder.addParameter(parameterSpec)
-    }
-
-    fun <T> code(block: CodeBlockBuilder.() -> T) {
-        builder.addCode(
-            CodeBlockBuilder(parameterSpecs.associateBy { it.name }).apply(block).build()
-        )
+    fun typeVariable(name: TypeVariableName) {
+        builder.addTypeVariable(name)
     }
 
     fun delegatesTo(memberName: String) {
@@ -124,8 +181,93 @@ class FunctionBuilder(private val name: String) {
         val joinedArgs = parameterSpecs.joinToString { it.name }
         code { "return $memberName.${funName}($joinedArgs)" }
     }
+}
 
-    fun build(): FunSpec = builder.build()
+@CodeWriterDsl
+class ConstructorBuilder : AbstractFunctionWithArgsBuilder(FunSpec.constructorBuilder()) {
+    fun callThisConstructor(vararg arguments: String) {
+        builder.callThisConstructor(*arguments)
+    }
+}
+
+abstract class AbstractTypeBuilder(protected val builder: TypeSpec.Builder) {
+    fun <T> kdoc(block: CodeBlockBuilder.() -> T) {
+        builder.addKdoc(CodeBlockBuilder(sanitize = true).apply(block).build())
+    }
+
+    fun superInterface(type: TypeName) {
+        builder.addSuperinterface(type)
+    }
+
+    fun property(name: String, returnType: KClass<*>, block: PropertyBuilder.() -> Unit) {
+        property(name, returnType.asTypeName(), block)
+    }
+
+    fun property(name: String, returnType: TypeName, block: PropertyBuilder.() -> Unit) {
+        builder.addProperty(PropertyBuilder(name, returnType).apply(block).build())
+    }
+
+    fun function(name: String, block: FunctionBuilder.() -> Unit) {
+        builder.addFunction(FunctionBuilder(name).apply(block).build())
+    }
+
+    fun build(): TypeSpec = builder.build()
+}
+
+@CodeWriterDsl
+class ClassBuilder(name: String) : AbstractTypeBuilder(TypeSpec.classBuilder(name)) {
+    fun annotation(annotation: KClass<*>) {
+        builder.addAnnotation(annotation)
+    }
+
+    fun modifiers(vararg modifiers: KModifier) {
+        builder.addModifiers(*modifiers)
+    }
+
+    fun primaryConstructor(block: ConstructorBuilder.() -> Unit) {
+        builder.primaryConstructor(ConstructorBuilder().apply(block).build())
+    }
+
+    fun constructor(block: ConstructorBuilder.() -> Unit) {
+        builder.addFunction(ConstructorBuilder().apply(block).build())
+    }
+
+    fun companionObject(block: CompanionObjectBuilder.() -> Unit) {
+        builder.addType(CompanionObjectBuilder().apply(block).build())
+    }
+}
+
+@CodeWriterDsl
+class CompanionObjectBuilder(name: String? = null) : AbstractTypeBuilder(TypeSpec.companionObjectBuilder(name))
+
+@CodeWriterDsl
+class TypeAliasBuilder(name: String, type: TypeName) {
+    private val builder = TypeAliasSpec.builder(name, type)
+
+    fun annotation(annotation: KClass<*>, block: AnnotationBuilder.() -> Unit = {}) {
+        annotation(annotation.asClassName(), block)
+    }
+
+    fun annotation(annotation: ClassName, block: AnnotationBuilder.() -> Unit = {}) {
+        builder.addAnnotation(AnnotationBuilder(annotation).apply(block).build())
+    }
+
+    fun deprecated(message: String, replaceWith: String? = null, level: DeprecationLevel = DeprecationLevel.WARNING) {
+        builder.addAnnotation(buildDeprecatedAnnotationSpec(message, replaceWith, level))
+    }
+
+    fun build(): TypeAliasSpec = builder.build()
+}
+
+@CodeWriterDsl
+class AnnotationBuilder(type: ClassName) {
+    private val builder = AnnotationSpec.builder(type)
+
+    fun member(block: CodeBlockBuilder.() -> Unit) {
+        builder.addMember(CodeBlockBuilder().apply(block).build())
+    }
+
+    fun build(): AnnotationSpec = builder.build()
 }
 
 @CodeWriterDsl
@@ -139,6 +281,10 @@ class CodeBlockBuilder(
 
     fun using(name: String, type: Any?) {
         arguments += name to type
+    }
+
+    fun using(vararg arguments: Pair<String, Any?>) {
+        arguments.forEach { (name, type) -> using(name, type) }
     }
 
     operator fun String.unaryPlus() {
@@ -186,4 +332,14 @@ fun FileSpec.Builder.addHeader(jvmName: String): FileSpec.Builder {
     })
     addComment("\nThis file is auto-generated by 'tools:code-generator'\n")
     return this
+}
+
+private fun buildDeprecatedAnnotationSpec(
+    message: String,
+    replaceWith: String?,
+    level: DeprecationLevel
+): AnnotationSpec = buildAnnotationSpec(Deprecated::class) {
+    addMember("message = %S", message)
+    if (replaceWith != null) addMember("replaceWith = ReplaceWith(%S)", replaceWith)
+    addMember("level = DeprecationLevel.$level")
 }

--- a/tools/code-generator/src/main/kotlin/io/islandtime/codegen/dsl/KotlinPoetExtensions.kt
+++ b/tools/code-generator/src/main/kotlin/io/islandtime/codegen/dsl/KotlinPoetExtensions.kt
@@ -3,71 +3,21 @@ package io.islandtime.codegen.dsl
 import com.squareup.kotlinpoet.*
 import kotlin.reflect.KClass
 
-inline fun buildFileSpec(
-    packageName: String,
-    fileName: String,
-    block: FileSpec.Builder.() -> Unit
-) = FileSpec.builder(packageName, fileName).apply(block).build()
-
-inline fun buildClassTypeSpec(
-    className: ClassName,
-    block: TypeSpec.Builder.() -> Unit
-) = TypeSpec.classBuilder(className).apply(block).build()
-
-inline fun buildCompanionObjectTypeSpec(
-    name: String? = null,
-    block: TypeSpec.Builder.() -> Unit
-) = TypeSpec.companionObjectBuilder(name).apply(block).build()
-
 inline fun buildAnnotationSpec(
     type: KClass<out Annotation>,
     block: AnnotationSpec.Builder.() -> Unit
 ) = AnnotationSpec.builder(type).apply(block).build()
 
-inline fun buildFunSpec(
-    name: String,
-    block: FunSpec.Builder.() -> Unit
-) = FunSpec.builder(name).apply(block).build()
-
-inline fun buildConstructorFunSpec(
-    block: FunSpec.Builder.() -> Unit
-) = FunSpec.constructorBuilder().apply(block).build()
-
-inline fun buildGetterFunSpec(
-    block: FunSpec.Builder.() -> Unit
-) = FunSpec.getterBuilder().apply(block).build()
-
-inline fun buildPropertySpec(
-    name: String,
-    type: TypeName,
-    vararg modifiers: KModifier,
-    block: PropertySpec.Builder.() -> Unit = {}
-) = PropertySpec.builder(name, type, *modifiers).apply(block).build()
-
-inline fun buildPropertySpec(
-    name: String,
-    type: KClass<*>,
-    vararg modifiers: KModifier,
-    block: PropertySpec.Builder.() -> Unit = {}
-) = PropertySpec.builder(name, type, *modifiers).apply(block).build()
-
-inline fun TypeSpec.Builder.property(
-    name: String,
-    type: TypeName,
-    vararg modifiers: KModifier,
-    block: PropertySpec.Builder.() -> Unit = {}
-) = addProperty(buildPropertySpec(name, type, *modifiers) { block(this) })
-
-inline fun TypeSpec.Builder.property(
-    name: String,
-    type: KClass<*>,
-    vararg modifiers: KModifier,
-    block: PropertySpec.Builder.() -> Unit = {}
-) = addProperty(buildPropertySpec(name, type, *modifiers) { block(this) })
-
 inline fun buildParameterSpec(
     name: String,
     type: TypeName,
+    vararg modifiers: KModifier,
+    block: ParameterSpec.Builder.() -> Unit = {}
+) = ParameterSpec.builder(name, type, *modifiers).apply(block).build()
+
+inline fun buildParameterSpec(
+    name: String,
+    type: KClass<*>,
     vararg modifiers: KModifier,
     block: ParameterSpec.Builder.() -> Unit = {}
 ) = ParameterSpec.builder(name, type, *modifiers).apply(block).build()

--- a/tools/code-generator/src/main/kotlin/io/islandtime/codegen/generators/DatePropertiesGenerator.kt
+++ b/tools/code-generator/src/main/kotlin/io/islandtime/codegen/generators/DatePropertiesGenerator.kt
@@ -57,7 +57,9 @@ private fun FileBuilder.buildDatePropertiesForClass(receiverClass: DateTimeDescr
             }
 
             receiver(receiverClass.typeName)
-            getter { intervalOfWeekCode() }
+            getter {
+                code { intervalOfWeekCode() }
+            }
         }
 
         function(name = "week") {
@@ -98,13 +100,14 @@ private fun FileBuilder.buildDatePropertiesForClass(receiverClass: DateTimeDescr
 
         if (receiverClass == Date) {
             getter {
-                using("impl", internal("weekOfMonthImpl"))
-                using("weekSettings", calendar("WeekSettings"))
-                "return %impl:T(%weekSettings:T.ISO)"
+                code {
+                    using("impl", internal("weekOfMonthImpl"))
+                    using("weekSettings", calendar("WeekSettings"))
+                    "return %impl:T(%weekSettings:T.ISO)"
+                }
             }
         } else {
-            modifiers(KModifier.INLINE)
-            delegatesTo(receiverClass.datePropertyName)
+            delegatesTo(receiverClass.datePropertyName, KModifier.INLINE)
         }
     }
 
@@ -166,13 +169,14 @@ private fun FileBuilder.buildDatePropertiesForClass(receiverClass: DateTimeDescr
 
         if (receiverClass == Date) {
             getter {
-                using("impl", internal("weekOfYearImpl"))
-                using("weekSettings", calendar("WeekSettings"))
-                "return %impl:T(%weekSettings:T.ISO)"
+                code {
+                    using("impl", internal("weekOfYearImpl"))
+                    using("weekSettings", calendar("WeekSettings"))
+                    "return %impl:T(%weekSettings:T.ISO)"
+                }
             }
         } else {
-            modifiers(KModifier.INLINE)
-            delegatesTo(receiverClass.datePropertyName)
+            delegatesTo(receiverClass.datePropertyName, KModifier.INLINE)
         }
     }
 
@@ -247,13 +251,14 @@ private fun FileBuilder.buildDatePropertiesForClass(receiverClass: DateTimeDescr
 
         if (receiverClass == Date) {
             getter {
-                using("impl", internal("weekBasedYearImpl"))
-                using("weekSettings", calendar("WeekSettings"))
-                "return %impl:T(%weekSettings:T.ISO)"
+                code {
+                    using("impl", internal("weekBasedYearImpl"))
+                    using("weekSettings", calendar("WeekSettings"))
+                    "return %impl:T(%weekSettings:T.ISO)"
+                }
             }
         } else {
-            modifiers(KModifier.INLINE)
-            delegatesTo(receiverClass.datePropertyName)
+            delegatesTo(receiverClass.datePropertyName, KModifier.INLINE)
         }
     }
 
@@ -322,13 +327,14 @@ private fun FileBuilder.buildDatePropertiesForClass(receiverClass: DateTimeDescr
 
         if (receiverClass == Date) {
             getter {
-                using("impl", internal("weekOfWeekBasedYearImpl"))
-                using("weekSettings", calendar("WeekSettings"))
-                "return %impl:T(%weekSettings:T.ISO)"
+                code {
+                    using("impl", internal("weekOfWeekBasedYearImpl"))
+                    using("weekSettings", calendar("WeekSettings"))
+                    "return %impl:T(%weekSettings:T.ISO)"
+                }
             }
         } else {
-            modifiers(KModifier.INLINE)
-            delegatesTo(receiverClass.datePropertyName)
+            delegatesTo(receiverClass.datePropertyName, KModifier.INLINE)
         }
     }
 
@@ -388,10 +394,11 @@ private fun FileBuilder.buildDatePropertiesForClass(receiverClass: DateTimeDescr
         receiver(receiverClass.typeName)
 
         if (receiverClass == Date) {
-            getter { "return isLeapYear(year)" }
+            getter {
+                code { "return isLeapYear(year)" }
+            }
         } else {
-            modifiers(KModifier.INLINE)
-            delegatesTo(receiverClass.datePropertyName)
+            delegatesTo(receiverClass.datePropertyName, KModifier.INLINE)
         }
     }
 
@@ -409,38 +416,44 @@ private fun FileBuilder.buildDatePropertiesForClass(receiverClass: DateTimeDescr
         receiver(receiverClass.typeName)
 
         if (receiverClass == Date) {
-            getter { "return month == Month.FEBRUARY && dayOfMonth == 29" }
+            getter {
+                code { "return month == Month.FEBRUARY && dayOfMonth == 29" }
+            }
         } else {
-            modifiers(KModifier.INLINE)
-            getter { "return date.isLeapDay" }
+            getter {
+                modifiers(KModifier.INLINE)
+                code { "return date.isLeapDay" }
+            }
         }
     }
 
-    property(name = "lengthOfMonth", returnType = measures("IntDays")) {
+    property(name = "lengthOfMonth", returnType = measures("Days")) {
         kdoc { "The length of this ${receiverClass.simpleName}'s month in days." }
         receiver(receiverClass.typeName)
 
         if (receiverClass == Date) {
-            getter { "return month.lengthIn(year)" }
+            getter {
+                code { "return month.lengthIn(year)" }
+            }
         } else {
-            modifiers(KModifier.INLINE)
-            delegatesTo(receiverClass.datePropertyName)
+            delegatesTo(receiverClass.datePropertyName, KModifier.INLINE)
         }
     }
 
-    property(name = "lengthOfYear", returnType = measures("IntDays")) {
+    property(name = "lengthOfYear", returnType = measures("Days")) {
         kdoc { "The length of this ${receiverClass.simpleName}'s year in days." }
         receiver(receiverClass.typeName)
 
         if (receiverClass == Date) {
-            getter { "return lengthOfYear(year)" }
+            getter {
+                code { "return lengthOfYear(year)" }
+            }
         } else {
-            modifiers(KModifier.INLINE)
-            delegatesTo(receiverClass.datePropertyName)
+            delegatesTo(receiverClass.datePropertyName, KModifier.INLINE)
         }
     }
 
-    property(name = "lengthOfWeekBasedYear", returnType = measures("IntWeeks")) {
+    property(name = "lengthOfWeekBasedYear", returnType = measures("Weeks")) {
         kdoc {
             """
                 The length of the ISO week-based year that this ${receiverClass.simpleName} falls in, either 52 or 53
@@ -452,39 +465,48 @@ private fun FileBuilder.buildDatePropertiesForClass(receiverClass: DateTimeDescr
 
         if (receiverClass == Date) {
             getter {
-                using("impl", internal("lengthOfWeekBasedYear"))
-                "return %impl:T(weekBasedYear)"
+                code {
+                    using("impl", internal("lengthOfWeekBasedYear"))
+                    "return %impl:T(weekBasedYear)"
+                }
             }
         } else {
-            modifiers(KModifier.INLINE)
-            delegatesTo(receiverClass.datePropertyName)
+            delegatesTo(receiverClass.datePropertyName, KModifier.INLINE)
         }
     }
 
-    fun createPreviousNextFunctions(name: String, plusOrMinus: PlusOrMinusOperator) {
-        function(name = name) {
-            kdoc {
-                if (name == "next") {
-                    "The next ${receiverClass.simpleName} after this one that falls on [dayOfWeek]."
-                } else {
-                    "The last ${receiverClass.simpleName} before this one that falls on [dayOfWeek]."
-                }
+    buildPreviousNextFunctions("next", PlusOrMinusOperator.PLUS, receiverClass)
+    buildPreviousNextFunctions("previous", PlusOrMinusOperator.MINUS, receiverClass)
+}
+
+private fun FileBuilder.buildPreviousNextFunctions(
+    name: String,
+    plusOrMinus: PlusOrMinusOperator,
+    receiverClass: DateTimeDescription
+) {
+    function(name = name) {
+        kdoc {
+            if (name == "next") {
+                "The next ${receiverClass.simpleName} after this one that falls on [dayOfWeek]."
+            } else {
+                "The last ${receiverClass.simpleName} before this one that falls on [dayOfWeek]."
             }
-            receiver(receiverClass.typeName)
-            argument("dayOfWeek", base("DayOfWeek"))
-            returns(receiverClass.typeName)
+        }
+        receiver(receiverClass.typeName)
+        argument("dayOfWeek", base("DayOfWeek"))
+        returns(receiverClass.typeName)
 
-            if (receiverClass == Date) {
-                code {
-                    using("days", measures("days"))
+        if (receiverClass == Date) {
+            code {
+                using("days", measures("days"))
 
-                    val dayDiffCode = if (plusOrMinus == PlusOrMinusOperator.PLUS) {
-                        "this.dayOfWeek.ordinal - dayOfWeek.ordinal"
-                    } else {
-                        "dayOfWeek.ordinal - this.dayOfWeek.ordinal"
-                    }
+                val dayDiffCode = if (plusOrMinus == PlusOrMinusOperator.PLUS) {
+                    "this.dayOfWeek.ordinal - dayOfWeek.ordinal"
+                } else {
+                    "dayOfWeek.ordinal - this.dayOfWeek.ordinal"
+                }
 
-                    """
+                """
                         val dayDiff = $dayDiffCode
     
                         return if (dayDiff >= 0) {
@@ -493,31 +515,27 @@ private fun FileBuilder.buildDatePropertiesForClass(receiverClass: DateTimeDescr
                             this ${plusOrMinus.uncheckedOperator} (-dayDiff).%days:T
                         }
                     """.trimIndent()
-                }
-            } else {
-                val propertyName = receiverClass.datePropertyName
-
-                code {
-                    "return copy($propertyName = $propertyName.$name(%dayOfWeek:N))"
-                }
             }
-        }
+        } else {
+            val propertyName = receiverClass.datePropertyName
 
-        function(name = "${name}OrSame") {
-            kdoc {
-                """
-                    The $name ${receiverClass.simpleName} that falls on [dayOfWeek], or this ${receiverClass.simpleName}
-                    if it falls on the same day.
-                """.trimIndent()
+            code {
+                "return copy($propertyName = $propertyName.$name(%dayOfWeek:N))"
             }
-
-            receiver(receiverClass.typeName)
-            argument("dayOfWeek", base("DayOfWeek"))
-            returns(receiverClass.typeName)
-            code { "return if (dayOfWeek == this.dayOfWeek) this else $name(dayOfWeek)" }
         }
     }
 
-    createPreviousNextFunctions("next", PlusOrMinusOperator.PLUS)
-    createPreviousNextFunctions("previous", PlusOrMinusOperator.MINUS)
+    function(name = "${name}OrSame") {
+        kdoc {
+            """
+                    The $name ${receiverClass.simpleName} that falls on [dayOfWeek], or this ${receiverClass.simpleName}
+                    if it falls on the same day.
+                """.trimIndent()
+        }
+
+        receiver(receiverClass.typeName)
+        argument("dayOfWeek", base("DayOfWeek"))
+        returns(receiverClass.typeName)
+        code { "return if (dayOfWeek == this.dayOfWeek) this else $name(dayOfWeek)" }
+    }
 }

--- a/tools/code-generator/src/main/kotlin/io/islandtime/codegen/generators/TemporalUnitGenerator.kt
+++ b/tools/code-generator/src/main/kotlin/io/islandtime/codegen/generators/TemporalUnitGenerator.kt
@@ -12,518 +12,13 @@ import io.islandtime.codegen.internal
 import io.islandtime.codegen.javamath2kmp
 import io.islandtime.codegen.measures
 import io.islandtime.codegen.util.zero
-import java.util.*
 import kotlin.reflect.KClass
-
-private val KOTLIN_DURATION_CLASS_NAME = ClassName("kotlin.time", "Duration")
-private val KOTLIN_DURATION_UNIT_CLASS_NAME = ClassName("kotlin.time", "DurationUnit")
-private val EXPERIMENTAL_TIME_CLASS_NAME = ClassName("kotlin.time", "ExperimentalTime")
-private val INT_TYPE_NAME = Int::class.asTypeName()
-private val LONG_TYPE_NAME = Long::class.asTypeName()
-
-private val TypeName.zeroValueString
-    get() = when (this) {
-        INT_TYPE_NAME -> Int::class.zero
-        LONG_TYPE_NAME -> Long::class.zero
-        else -> throw IllegalStateException("Unsupported primitive type")
-    }
-
-private fun KClass<*>.literalValueString(value: Long) = when (this) {
-    Int::class -> "$value"
-    Long::class -> "${value}L"
-    else -> throw IllegalStateException("Unsupported primitive type")
-}
-
-private val TemporalUnitDescription.intClassName get() = measures(intName)
-private val TemporalUnitDescription.longClassName get() = measures(longName)
-
-private val TemporalUnitDescription.nextBiggest get() = TemporalUnitDescription.values()[this.ordinal + 1]
-
-private fun TemporalUnitDescription.classNameFor(primitiveType: KClass<*>): ClassName {
-    return when (primitiveType) {
-        Int::class -> intClassName
-        Long::class -> longClassName
-        else -> throw java.lang.IllegalArgumentException("Unsupported primitive type")
-    }
-}
 
 object TemporalUnitGenerator : Generator {
     override fun generate(): List<FileSpec> {
-        return TemporalUnitDescription.values().map { it.toFileSpec() }
+        return TemporalUnitDescription.values().map { buildTemporalUnitFile(it) }
     }
 }
-
-fun TemporalUnitDescription.toFileSpec(): FileSpec {
-    return io.islandtime.codegen.dsl.buildFileSpec(
-        "io.islandtime.measures",
-        "_$pluralName"
-    ) {
-        addHeader("${pluralName}Kt")
-
-        if (isTimeBased) {
-            addAliasedImport(KOTLIN_DURATION_CLASS_NAME, "KotlinDuration")
-            addAliasedImport(KOTLIN_DURATION_UNIT_CLASS_NAME, "KotlinDurationUnit")
-        }
-
-        listOf(
-            IntTemporalUnitClassGenerator(this@toFileSpec),
-            LongTemporalUnitClassGenerator(this@toFileSpec)
-        )
-            .flatMap { it.build() }
-            .forEach {
-                when (it) {
-                    is TypeSpec -> addType(it)
-                    is PropertySpec -> addProperty(it)
-                    is FunSpec -> addFunction(it)
-                    else -> throw IllegalStateException("Invalid type '${it.javaClass.simpleName}' encountered!")
-                }
-            }
-    }
-}
-
-abstract class TemporalUnitClassGenerator(
-    val description: TemporalUnitDescription,
-    val primitive: KClass<*>
-) {
-    val className = description.classNameFor(primitive)
-    val primitiveTypeName = primitive.asTypeName()
-
-    val constructorFunSpec by lazy(::buildConstructorFunSpec)
-
-    val valuePropertySpec by lazy(::buildValuePropertySpec)
-    val absoluteValuePropertySpec by lazy(::buildAbsoluteValuePropertySpec)
-
-    val isZeroFunSpec by lazy(::buildIsZeroFunSpec)
-    val isNegativeFunSpec by lazy(::buildIsNegativeFunSpec)
-    val isPositiveFunSpec by lazy(::buildIsPositiveFunSpec)
-    val compareToFunSpec by lazy(::buildCompareToFunSpec)
-    val toStringFunSpec by lazy(::buildToStringFunSpec)
-    val toKotlinDurationFunSpec by lazy(::buildToKotlinDurationFunSpec)
-
-    val unaryMinusFunSpec by lazy(::buildUnaryMinusFunSpec)
-    val negateUncheckedFunSpec by lazy(::buildNegateUncheckedFunSpec)
-    val timesIntFunSpec by lazy { buildTimesFunSpec(Int::class) }
-    val timesLongFunSpec by lazy { buildTimesFunSpec(Long::class) }
-    val divIntFunSpec by lazy { buildDivFunSpec(Int::class) }
-    val divLongFunSpec by lazy { buildDivFunSpec(Long::class) }
-    val remIntFunSpec by lazy { buildRemFunSpec(Int::class) }
-    val remLongFunSpec by lazy { buildRemFunSpec(Long::class) }
-
-    val companionObjectTypeSpec by lazy(::buildCompanionObjectTypeSpec)
-
-    val primitiveExtensionPropertySpec by lazy(::buildPrimitiveExtensionPropertySpec)
-    val timesIntExtensionFunSpec by lazy { buildTimesExtensionFunSpec(Int::class) }
-    val timesLongExtensionFunSpec by lazy { buildTimesExtensionFunSpec(Long::class) }
-
-    private val baseClassSpecList: List<Any>
-        get() {
-            val list = listOf(
-                valuePropertySpec,
-                absoluteValuePropertySpec,
-                isZeroFunSpec,
-                isNegativeFunSpec,
-                isPositiveFunSpec,
-                compareToFunSpec,
-                toStringFunSpec,
-                unaryMinusFunSpec,
-                negateUncheckedFunSpec,
-                timesIntFunSpec,
-                timesLongFunSpec,
-                divIntFunSpec,
-                divLongFunSpec,
-                remIntFunSpec,
-                remLongFunSpec,
-                companionObjectTypeSpec
-            ) +
-                buildPlusMinusOperatorFunSpecs() +
-                buildUnitConversionSpecs() +
-                buildToComponentsFunctions()
-
-            return if (description.isTimeBased) {
-                list + toKotlinDurationFunSpec
-            } else {
-                list
-            }
-        }
-
-    protected open fun allClassSpecs(): List<Any> {
-        return baseClassSpecList
-    }
-
-    protected open fun allExtensionSpecs(): List<Any> {
-        return listOf(
-            primitiveExtensionPropertySpec,
-            timesIntExtensionFunSpec,
-            timesLongExtensionFunSpec
-        )
-    }
-
-    fun build() = listOf(buildClass()) + allExtensionSpecs()
-
-    fun buildClass() = io.islandtime.codegen.dsl.buildClassTypeSpec(className) {
-        addKdoc("A number of ${description.lowerPluralName}.")
-        addAnnotation(JvmInline::class)
-        addModifiers(KModifier.VALUE)
-        primaryConstructor(constructorFunSpec)
-        addSuperinterface(ClassName("kotlin", "Comparable").parameterizedBy(className))
-
-        allClassSpecs().forEach {
-            when (it) {
-                is PropertySpec -> addProperty(it)
-                is FunSpec -> addFunction(it)
-                is TypeSpec -> addType(it)
-            }
-        }
-    }
-}
-
-class IntTemporalUnitClassGenerator(
-    description: TemporalUnitDescription
-) : TemporalUnitClassGenerator(description, Int::class) {
-
-    val toLongUnitFunSpec by lazy(::buildToLongUnitFunSpec)
-    val toLongFunSpec by lazy(::buildToLongFunSpec)
-
-    override fun allClassSpecs(): List<Any> {
-        return super.allClassSpecs() + listOf(
-            toLongUnitFunSpec,
-            toLongFunSpec
-        )
-    }
-}
-
-class LongTemporalUnitClassGenerator(
-    description: TemporalUnitDescription
-) : TemporalUnitClassGenerator(description, Long::class) {
-
-    val toIntUnitFunSpec by lazy(::buildToIntUnitFunSpec)
-    val toIntUnitUncheckedFunSpec by lazy(::buildToIntUnitUncheckedFunSpec)
-    val toIntFunSpec by lazy(::buildToIntFunSpec)
-    val toIntUncheckedFunSpec by lazy(::buildToIntUncheckedFunSpec)
-    val toLongFunSpec by lazy(::buildToLongFunSpec)
-
-    val kotlinDurationExtensionFunSpec by lazy(::buildKotlinDurationExtensionFunSpec)
-
-    override fun allClassSpecs(): List<Any> {
-        return super.allClassSpecs() + listOf(
-            toIntUnitFunSpec,
-            toIntUnitUncheckedFunSpec,
-            toIntFunSpec,
-            toIntUncheckedFunSpec,
-            toLongFunSpec
-        )
-    }
-
-    override fun allExtensionSpecs(): List<Any> {
-        return if (description.isTimeBased) {
-            super.allExtensionSpecs() + listOf(kotlinDurationExtensionFunSpec)
-        } else {
-            super.allExtensionSpecs()
-        }
-    }
-}
-
-fun TemporalUnitClassGenerator.buildValuePropertySpec() = buildPropertySpec(
-    description.valueName,
-    primitiveTypeName
-) {
-    addKdoc("The underlying value.")
-    initializer(description.valueName)
-}
-
-fun TemporalUnitClassGenerator.buildAbsoluteValuePropertySpec() = buildPropertySpec(
-    "absoluteValue",
-    className
-) {
-    addKdoc(
-        """
-            The absolute value of this duration.
-            @throws ArithmeticException if overflow occurs
-        """.trimIndent()
-    )
-    getter(
-        buildGetterFunSpec {
-            val arguments = mapOf(
-                "className" to className,
-                "value" to valuePropertySpec,
-                "absExact" to javamath2kmp("absExact")
-            )
-
-            addNamedCode(
-                "return %className:T(%absExact:T(%value:N))",
-                arguments
-            )
-        }
-    )
-}
-
-fun TemporalUnitClassGenerator.buildConstructorFunSpec() = buildConstructorFunSpec {
-    addParameter(valuePropertySpec.name, valuePropertySpec.type)
-}
-
-fun TemporalUnitClassGenerator.buildIsZeroFunSpec() = buildFunSpec("isZero") {
-    addKdoc("Checks if this duration is zero.")
-    addAnnotation(
-        buildAnnotationSpec(Deprecated::class) {
-            addMember("message = %S", "Replace with direct comparison.")
-            addMember(
-                "replaceWith = ReplaceWith(%S)",
-                "this == ${valuePropertySpec.type.zeroValueString}.${description.lowerPluralName}"
-            )
-            addMember("level = DeprecationLevel.ERROR")
-        }
-    )
-    returns(Boolean::class)
-    addStatement("return %N == ${valuePropertySpec.type.zeroValueString}", valuePropertySpec)
-}
-
-fun TemporalUnitClassGenerator.buildIsNegativeFunSpec() = buildFunSpec("isNegative") {
-    addKdoc("Checks if this duration is negative.")
-    addAnnotation(
-        buildAnnotationSpec(Deprecated::class) {
-            addMember("message = %S", "Replace with direct comparison.")
-            addMember(
-                "replaceWith = ReplaceWith(%S)",
-                "this < ${valuePropertySpec.type.zeroValueString}.${description.lowerPluralName}"
-            )
-            addMember("level = DeprecationLevel.ERROR")
-        }
-    )
-    returns(Boolean::class)
-    addStatement("return %N < ${valuePropertySpec.type.zeroValueString}", valuePropertySpec)
-}
-
-fun TemporalUnitClassGenerator.buildIsPositiveFunSpec() = buildFunSpec("isPositive") {
-    addKdoc("Checks if this duration is positive.")
-    addAnnotation(
-        buildAnnotationSpec(Deprecated::class) {
-            addMember("message = %S", "Replace with direct comparison.")
-            addMember(
-                "replaceWith = ReplaceWith(%S)",
-                "this > ${valuePropertySpec.type.zeroValueString}.${description.lowerPluralName}"
-            )
-            addMember("level = DeprecationLevel.ERROR")
-        }
-    )
-    returns(Boolean::class)
-    addStatement("return %N > ${valuePropertySpec.type.zeroValueString}", valuePropertySpec)
-}
-
-fun TemporalUnitClassGenerator.buildCompareToFunSpec() = buildFunSpec("compareTo") {
-    addModifiers(KModifier.OVERRIDE)
-    addParameter("other", className)
-    returns(Int::class)
-    addStatement("return %N.compareTo(other.%N)", valuePropertySpec, valuePropertySpec)
-}
-
-fun TemporalUnitClassGenerator.buildToStringFunSpec() = buildFunSpec("toString") {
-    addKdoc("Converts this duration to an ISO-8601 time interval representation.")
-    addModifiers(KModifier.OVERRIDE)
-    returns(String::class)
-
-    addCode(
-        if (description.isoPeriodIsFractional) {
-            buildFractionalToStringCodeBlock()
-        } else {
-            buildWholeToStringCodeBlock()
-        }
-    )
-}
-
-fun TemporalUnitClassGenerator.buildToKotlinDurationFunSpec() =
-    buildFunSpec("toKotlinDuration") {
-        addAnnotation(EXPERIMENTAL_TIME_CLASS_NAME)
-        addKdoc("Converts this duration to a [${KOTLIN_DURATION_CLASS_NAME.canonicalName}].")
-        returns(KOTLIN_DURATION_CLASS_NAME)
-
-        addStatement(
-            "return %T.${description.lowerPluralName}(%N)",
-            KOTLIN_DURATION_CLASS_NAME,
-            valuePropertySpec
-        )
-    }
-
-fun TemporalUnitClassGenerator.buildFractionalToStringCodeBlock() = io.islandtime.codegen.dsl.buildCodeBlock {
-    var fractionalPartConversion = "%value:N %% ${description.isoPeriodUnitConversion.constantValue}"
-
-    if (primitive == Long::class) {
-        fractionalPartConversion = "($fractionalPartConversion).toInt()"
-    }
-
-    val arguments = mapOf(
-        "value" to valuePropertySpec,
-        "absoluteValue" to ClassName("kotlin.math", "absoluteValue"),
-        "toZeroPaddedString" to internal("toZeroPaddedString")
-    )
-
-    addNamed(
-        """
-            | return if (%value:N == ${primitive.zero}) {
-            |   "${description.isoPeriodZeroString}"
-            | } else {
-            |   buildString {
-            |     val wholePart = (%value:N / ${description.isoPeriodUnitConversion.constantValue}).%absoluteValue:T
-            |     val fractionalPart = (${fractionalPartConversion}).%absoluteValue:T
-            |     if (%value:N < 0) { append('-') }
-            |     append("${description.isoPeriodPrefix}")
-            |     append(wholePart)
-            |     if (fractionalPart > 0) {
-            |       append('.')
-            |       append(fractionalPart.%toZeroPaddedString:T(${description.isoPeriodDecimalPlaces}).dropLastWhile { it == '0' })
-            |     }
-            |     append('${description.isoPeriodUnit}')
-            |   }
-            | }
-        """.trimMargin(),
-        arguments
-    )
-}
-
-fun TemporalUnitClassGenerator.buildWholeToStringCodeBlock() = io.islandtime.codegen.dsl.buildCodeBlock {
-    val arguments = mapOf(
-        "value" to valuePropertySpec,
-        "absoluteValue" to ClassName("kotlin.math", "absoluteValue"),
-        "timesExact" to javamath2kmp("timesExact"),
-        "minValue" to "${primitiveTypeName.simpleName}.MIN_VALUE"
-    )
-
-    val convertedValueString = buildString {
-        append("%value:N.%absoluteValue:T")
-
-        if (description.isoPeriodUnitConversion.isNecessary()) {
-            append(" %timesExact:T ${description.isoPeriodUnitConversion.constantValue}")
-        }
-    }
-
-    val absoluteValueOfMinValue = if (primitive == Long::class) {
-        Long.MIN_VALUE.toBigInteger().abs()
-    } else {
-        Int.MIN_VALUE.toBigInteger().abs()
-    }
-
-    addNamed(
-        """
-            | return when (%value:N) {
-            |   ${primitive.zero} -> "${description.isoPeriodZeroString}"
-            |   %minValue:L -> "-${description.isoPeriodPrefix}${absoluteValueOfMinValue}${description.isoPeriodUnit}"
-            |   else -> buildString {
-            |     if (%value:N < 0) { append('-') }
-            |     append("${description.isoPeriodPrefix}")
-            |     append($convertedValueString)
-            |     append('${description.isoPeriodUnit}')
-            |   }
-            | }
-        """.trimMargin(),
-        arguments
-    )
-}
-
-fun TemporalUnitClassGenerator.buildCompanionObjectTypeSpec() = io.islandtime.codegen.dsl.buildCompanionObjectTypeSpec {
-    property("MIN", className) {
-        addKdoc("The smallest supported value.")
-        initializer("%T(%T.MIN_VALUE)", className, primitive)
-    }
-    property("MAX", className) {
-        addKdoc("The largest supported value.")
-        initializer("%T(%T.MAX_VALUE)", className, primitive)
-    }
-}
-
-fun IntTemporalUnitClassGenerator.buildToLongUnitFunSpec() = buildFunSpec(
-    "to${description.longName}"
-) {
-    addKdoc("Converts this duration to [${description.longName}].")
-    returns(description.longClassName)
-    addStatement("return %T(%N.toLong())", description.longClassName, valuePropertySpec)
-}
-
-fun IntTemporalUnitClassGenerator.buildToLongFunSpec() = buildFunSpec("toLong") {
-    addKdoc("Converts this duration to a `Long` value.")
-    returns(Long::class)
-    addStatement("return %N.toLong()", valuePropertySpec)
-}
-
-fun LongTemporalUnitClassGenerator.buildToIntFunSpec() = buildFunSpec("toInt") {
-    addKdoc(
-        """
-            Converts this duration to an `Int` value.
-            @throws ArithmeticException if overflow occurs
-        """.trimIndent()
-    )
-    returns(Int::class)
-    addStatement("return %N.%T()", valuePropertySpec, javamath2kmp("toIntExact"))
-}
-
-fun LongTemporalUnitClassGenerator.buildToIntUncheckedFunSpec() = buildFunSpec(
-    "toIntUnchecked"
-) {
-    addModifiers(KModifier.INTERNAL)
-    addKdoc("Converts this duration to an `Int` value without checking for overflow.")
-    returns(Int::class)
-    addStatement("return %N.toInt()", valuePropertySpec)
-}
-
-fun LongTemporalUnitClassGenerator.buildToIntUnitFunSpec() = buildFunSpec(
-    "to${description.intName}"
-) {
-    addKdoc(
-        """
-            Converts this duration to [${description.intName}].
-            @throws ArithmeticException if overflow occurs
-        """.trimIndent()
-    )
-
-    returns(description.intClassName)
-
-    addStatement(
-        "return %T(%N.%T())",
-        description.intClassName,
-        valuePropertySpec,
-        javamath2kmp("toIntExact")
-    )
-}
-
-fun LongTemporalUnitClassGenerator.buildToIntUnitUncheckedFunSpec() = buildFunSpec(
-    "to${description.intName}Unchecked"
-) {
-    addModifiers(KModifier.INTERNAL)
-    addKdoc("Converts this duration to [${description.intName}] without checking for overflow.")
-    addAnnotation(PublishedApi::class)
-    returns(description.intClassName)
-    addStatement("return %T(%N.toInt())", description.intClassName, valuePropertySpec)
-}
-
-fun LongTemporalUnitClassGenerator.buildToLongFunSpec() = buildFunSpec("toLong") {
-    addKdoc("Converts this duration to a `Long` value.")
-    returns(Long::class)
-    addStatement("return %N", valuePropertySpec)
-}
-
-fun TemporalUnitClassGenerator.buildUnaryMinusFunSpec() = buildFunSpec("unaryMinus") {
-    addModifiers(KModifier.OPERATOR)
-    addKdoc(
-        """
-            Negates this duration.
-            @throws ArithmeticException if overflow occurs
-        """.trimIndent()
-    )
-    returns(className)
-
-    addStatement(
-        "return %T(%N.%T())",
-        className,
-        valuePropertySpec,
-        javamath2kmp("negateExact")
-    )
-}
-
-fun TemporalUnitClassGenerator.buildNegateUncheckedFunSpec() =
-    buildFunSpec("negateUnchecked") {
-        addModifiers(KModifier.INTERNAL)
-        addKdoc("Negates this duration without checking for overflow.")
-        returns(className)
-        addStatement("return %T(-%N)", className, valuePropertySpec)
-    }
 
 enum class PlusOrMinusOperator(
     val functionName: String,
@@ -542,539 +37,644 @@ enum class PlusOrMinusOperator(
     )
 }
 
-fun TemporalUnitClassGenerator.buildPlusMinusOperatorFunSpecs() = TemporalUnitDescription.values()
-    .map { description per it }
-    .filter { it.isSupported() }
-    .flatMap { conversion ->
-        listOf(
-            buildIntPlusMinusOperatorFunSpec(conversion, PlusOrMinusOperator.PLUS),
-            buildIntPlusMinusOperatorFunSpec(conversion, PlusOrMinusOperator.MINUS),
-            buildLongPlusMinusOperatorFunSpec(conversion, PlusOrMinusOperator.PLUS),
-            buildLongPlusMinusOperatorFunSpec(conversion, PlusOrMinusOperator.MINUS)
+private val KOTLIN_DURATION_CLASS_NAME = ClassName("kotlin.time", "Duration")
+private val KOTLIN_DURATION_UNIT_CLASS_NAME = ClassName("kotlin.time", "DurationUnit")
+private val EXPERIMENTAL_TIME_CLASS_NAME = ClassName("kotlin.time", "ExperimentalTime")
+
+private fun KClass<*>.literalValueString(value: Long) = when (this) {
+    Int::class -> "$value"
+    Long::class -> "${value}L"
+    else -> throw IllegalStateException("Unsupported primitive type")
+}
+
+private val TemporalUnitDescription.className get() = measures(pluralName)
+private val TemporalUnitDescription.nextBiggest get() = TemporalUnitDescription.values()[this.ordinal + 1]
+
+private val TemporalUnitConversion.propertyClassName get() = internal(constantName)
+
+private fun buildTemporalUnitFile(description: TemporalUnitDescription) = file(
+    packageName = "io.islandtime.measures",
+    fileName = "_${description.pluralName}",
+    jvmName = "${description.pluralName}Kt"
+) {
+    if (description.isTimeBased) {
+        aliasedImports(
+            KOTLIN_DURATION_CLASS_NAME to "KotlinDuration",
+            KOTLIN_DURATION_UNIT_CLASS_NAME to "KotlinDurationUnit"
         )
     }
 
-fun TemporalUnitClassGenerator.buildIntPlusMinusOperatorFunSpec(
-    conversion: TemporalUnitConversion,
-    plusOrMinusOperator: PlusOrMinusOperator
-) = buildFunSpec(plusOrMinusOperator.functionName) {
-    addModifiers(KModifier.OPERATOR)
+    typeAlias(description.deprecatedIntName, description.className) {
+        deprecated(
+            message = "Replace with ${description.pluralName}.",
+            replaceWith = description.pluralName,
+            level = DeprecationLevel.ERROR
+        )
+    }
 
-    val amount = ParameterSpec(conversion.toUnit.lowerPluralName, conversion.toUnit.intClassName)
-    addParameter(amount)
+    typeAlias(description.deprecatedLongName, description.className) {
+        deprecated(
+            message = "Replace with ${description.pluralName}.",
+            replaceWith = description.pluralName,
+            level = DeprecationLevel.ERROR
+        )
+    }
 
-    when (conversion.operator) {
-        ConversionOperator.DIV -> {
-            if (this@buildIntPlusMinusOperatorFunSpec is IntTemporalUnitClassGenerator &&
-                description.forceLongInOperators
-            ) {
-                returns(conversion.fromUnit.longClassName)
+    `class`(description.pluralName) {
+        annotation(JvmInline::class)
+        modifiers(KModifier.VALUE)
+        superInterface(
+            ClassName("kotlin", "Comparable").parameterizedBy(description.className)
+        )
 
-                addStatement(
-                    "return this.%N() %L %N.${description.inUnitPropertyName}",
-                    toLongUnitFunSpec,
-                    plusOrMinusOperator.uncheckedOperator,
-                    amount
-                )
-            } else {
-                returns(className)
+        primaryConstructor {
+            argument(description.valueName, Long::class)
+        }
 
-                addStatement(
-                    "return this %L %N.${description.inUnitPropertyName}",
-                    plusOrMinusOperator.uncheckedOperator,
-                    amount
-                )
+        property(description.valueName, Long::class) {
+            kdoc { "The underlying value." }
+            initializer { description.valueName }
+        }
+
+        property("absoluteValue", description.className) {
+            kdoc {
+                """
+                    The absolute value of this duration.
+                    @throws ArithmeticException if overflow occurs
+                """.trimIndent()
+            }
+            getter {
+                code {
+                    using("absExact", javamath2kmp("absExact"))
+                    "return ${description.pluralName}(%absExact:T(${description.valueName}))"
+                }
             }
         }
-        ConversionOperator.TIMES -> {
-            if (this@buildIntPlusMinusOperatorFunSpec is IntTemporalUnitClassGenerator &&
-                description.forceLongInOperators
-            ) {
-                returns(conversion.toUnit.longClassName)
 
-                addStatement(
-                    "return this.%N().${conversion.toUnit.inUnitPropertyName} %L %N.to${conversion.toUnit.longName}()",
-                    toLongUnitFunSpec,
-                    plusOrMinusOperator.uncheckedOperator,
-                    amount
-                )
-            } else {
-                returns(
-                    if (conversion.toUnit.forceLongInOperators) {
-                        conversion.toUnit.longClassName
-                    } else {
-                        conversion.toUnit.classNameFor(primitive)
-                    }
-                )
+        buildUnitConversionProperties(description)
 
-                addStatement(
-                    "return this.${conversion.toUnit.inUnitPropertyName} %L %N",
-                    plusOrMinusOperator.uncheckedOperator,
-                    amount
-                )
+        constructor {
+            argument(description.valueName, Int::class)
+            callThisConstructor("${description.valueName}.toLong()")
+        }
+
+        function("isZero") {
+            kdoc { "Checks if this duration is zero." }
+            deprecated(
+                message = "Replace with direct comparison.",
+                replaceWith = "this == 0L.${description.lowerPluralName}",
+                level = DeprecationLevel.ERROR
+            )
+            returns(Boolean::class)
+            code { "return ${description.valueName} == 0L" }
+        }
+
+        function("isNegative") {
+            kdoc { "Checks if this duration is negative." }
+            deprecated(
+                message = "Replace with direct comparison.",
+                replaceWith = "this < 0L.${description.lowerPluralName}",
+                level = DeprecationLevel.ERROR
+            )
+            returns(Boolean::class)
+            code { "return ${description.valueName} < 0L" }
+        }
+
+        function("isPositive") {
+            kdoc { "Checks if this duration is positive." }
+            deprecated(
+                message = "Replace with direct comparison.",
+                replaceWith = "this > 0L.${description.lowerPluralName}",
+                level = DeprecationLevel.ERROR
+            )
+            returns(Boolean::class)
+            code { "return ${description.valueName} > 0L" }
+        }
+
+        function("compareTo") {
+            modifiers(KModifier.OVERRIDE)
+            argument("other", description.className)
+            returns(Int::class)
+            code { "return ${description.valueName}.compareTo(other.${description.valueName})" }
+        }
+
+        if (description.isTimeBased) {
+            function("toKotlinDuration") {
+                kdoc { "Converts this duration to a [${KOTLIN_DURATION_CLASS_NAME.canonicalName}]." }
+                annotation(EXPERIMENTAL_TIME_CLASS_NAME)
+                returns(KOTLIN_DURATION_CLASS_NAME)
+
+                code {
+                    using("kotlinDuration", KOTLIN_DURATION_CLASS_NAME)
+                    "return %kotlinDuration:T.${description.lowerPluralName}(${description.valueName})"
+                }
             }
         }
-        ConversionOperator.NONE -> {
-            if (primitive == Int::class && description.forceLongInOperators) {
-                returns(description.longClassName)
 
-                addStatement(
-                    "return %T(%N.toLong()·%T %N.${description.valueName})",
-                    description.longClassName,
-                    valuePropertySpec,
-                    plusOrMinusOperator.operator,
-                    amount
-                )
-            } else {
-                returns(className)
+        function("toString") {
+            kdoc { "Converts this duration to an ISO-8601 time interval representation." }
+            modifiers(KModifier.OVERRIDE)
+            returns(String::class)
 
-                addStatement(
-                    "return %T(%N·%T %N.${description.valueName})",
-                    className,
-                    valuePropertySpec,
-                    plusOrMinusOperator.operator,
-                    amount
-                )
+            code {
+                if (description.isoPeriodIsFractional) {
+                    buildFractionalToStringCodeBlock(description)
+                } else {
+                    buildWholeToStringCodeBlock(description)
+                }
+            }
+        }
+
+        function("unaryMinus") {
+            kdoc {
+                """
+                    Negates this duration.
+                    @throws ArithmeticException if overflow occurs
+                """.trimIndent()
+            }
+            modifiers(KModifier.OPERATOR)
+            returns(description.className)
+
+            code {
+                using("negateExact", javamath2kmp("negateExact"))
+                "return ${description.pluralName}(${description.valueName}.%negateExact:T())"
+            }
+        }
+
+        function("negateUnchecked") {
+            kdoc { "Negates this duration without checking for overflow." }
+            modifiers(KModifier.INTERNAL)
+            returns(description.className)
+            code { "return ${description.pluralName}(-${description.valueName})" }
+        }
+
+        buildPlusAndMinusOperatorFunctions(description)
+
+        listOf(Int::class, Long::class).forEach { primitive ->
+            buildTimesFunction(primitive, description)
+            buildDivFunction(primitive, description)
+            buildRemFunction(primitive, description)
+        }
+
+        buildToComponentValuesFunctions(description)
+
+        function("toInt") {
+            kdoc {
+                """
+                    Converts this duration to an `Int` value.
+                    @throws ArithmeticException if overflow occurs
+                """.trimIndent()
+            }
+            returns(Int::class)
+            code {
+                using("toIntExact", javamath2kmp("toIntExact"))
+                "return ${description.valueName}.%toIntExact:T()"
+            }
+        }
+
+        function("toIntUnchecked") {
+            kdoc { "Converts this duration to an `Int` value without checking for overflow." }
+            modifiers(KModifier.INTERNAL)
+            returns(Int::class)
+            code { "return ${description.valueName}.toInt()" }
+        }
+
+        function("to${description.deprecatedIntName}") {
+            kdoc {
+                """
+                    Converts this duration to [${description.deprecatedIntName}].
+                    @throws ArithmeticException if overflow occurs
+                """.trimIndent()
+            }
+            deprecated(
+                message = "The 'Int' class no longer exists.",
+                replaceWith = "this",
+                level = DeprecationLevel.ERROR
+            )
+            returns(description.className)
+            code { "return this" }
+        }
+
+        function("to${description.deprecatedIntName}Unchecked") {
+            kdoc { "Converts this duration to [${description.deprecatedIntName}] without checking for overflow." }
+            modifiers(KModifier.INTERNAL)
+            deprecated(
+                message = "The 'Int' class no longer exists.",
+                replaceWith = "this",
+                level = DeprecationLevel.ERROR
+            )
+            annotation(PublishedApi::class)
+            returns(description.className)
+            code { "return this" }
+        }
+
+        function("toLong") {
+            kdoc { "Converts this duration to a `Long` value." }
+            returns(Long::class)
+            code { "return ${description.valueName}" }
+        }
+
+        function("toDouble") {
+            kdoc { "Converts this duration to a `Double` value." }
+            returns(Double::class)
+            code { "return ${description.valueName}.toDouble()" }
+        }
+
+        companionObject {
+            property("MIN", description.className) {
+                kdoc { "The smallest supported value." }
+                initializer { "${description.pluralName}(Long.MIN_VALUE)" }
+            }
+            property("MAX", description.className) {
+                kdoc { "The largest supported value." }
+                initializer { "${description.pluralName}(Long.MAX_VALUE)" }
+            }
+        }
+    }
+
+    listOf(Int::class, Long::class).forEach { primitive ->
+        buildPrimitiveConstructorProperty(primitive, description)
+        buildTimesExtensionFunction(primitive, description)
+    }
+
+    if (description.isTimeBased) {
+        function("toIsland${description.pluralName}") {
+            kdoc { "Converts this duration to Island Time [${description.pluralName}]." }
+            annotation(EXPERIMENTAL_TIME_CLASS_NAME)
+            receiver(KOTLIN_DURATION_CLASS_NAME)
+            returns(description.className)
+            code {
+                using("kotlinDurationUnit", KOTLIN_DURATION_UNIT_CLASS_NAME)
+                "return ${description.pluralName}(this.toLong(%kotlinDurationUnit:T.${description.pluralName.uppercase()}))"
             }
         }
     }
 }
 
-fun TemporalUnitClassGenerator.buildLongPlusMinusOperatorFunSpec(
-    conversion: TemporalUnitConversion,
-    plusOrMinusOperator: PlusOrMinusOperator
-) = buildFunSpec(plusOrMinusOperator.functionName) {
-    addModifiers(KModifier.OPERATOR)
+private fun CodeBlockBuilder.buildFractionalToStringCodeBlock(description: TemporalUnitDescription) {
+    val value = description.valueName
 
-    val amount = ParameterSpec(conversion.toUnit.lowerPluralName, conversion.toUnit.longClassName)
-    addParameter(amount)
+    using(
+        "absoluteValue" to ClassName("kotlin.math", "absoluteValue"),
+        "toZeroPaddedString" to internal("toZeroPaddedString")
+    )
+
+    +"""
+        | return if ($value == 0L) {
+        |   "${description.isoPeriodZeroString}"
+        | } else {
+        |   buildString {
+        |     val wholePart = ($value / ${description.isoPeriodUnitConversion.constantValue}).%absoluteValue:T
+        |     val fractionalPart = ($value %% ${description.isoPeriodUnitConversion.constantValue}).toInt().%absoluteValue:T
+        |     if ($value < 0) { append('-') }
+        |     append("${description.isoPeriodPrefix}")
+        |     append(wholePart)
+        |     if (fractionalPart > 0) {
+        |       append('.')
+        |       append(fractionalPart.%toZeroPaddedString:T(${description.isoPeriodDecimalPlaces}).dropLastWhile { it == '0' })
+        |     }
+        |     append('${description.isoPeriodUnit}')
+        |   }
+        | }
+    """.trimMargin()
+}
+
+private fun CodeBlockBuilder.buildWholeToStringCodeBlock(description: TemporalUnitDescription) {
+    val value = description.valueName
+
+    using(
+        "absoluteValue" to ClassName("kotlin.math", "absoluteValue"),
+        "timesExact" to javamath2kmp("timesExact")
+    )
+
+    val convertedValueString = buildString {
+        append("$value.%absoluteValue:T")
+
+        if (description.isoPeriodUnitConversion.isNecessary()) {
+            append(" %timesExact:T ${description.isoPeriodUnitConversion.constantValue}")
+        }
+    }
+
+    val absoluteValueOfMinValue = Long.MIN_VALUE.toBigInteger().abs()
+
+    +"""
+        | return when ($value) {
+        |   0L -> "${description.isoPeriodZeroString}"
+        |   Long.MIN_VALUE -> "-${description.isoPeriodPrefix}${absoluteValueOfMinValue}${description.isoPeriodUnit}"
+        |   else -> buildString {
+        |     if ($value < 0) { append('-') }
+        |     append("${description.isoPeriodPrefix}")
+        |     append($convertedValueString)
+        |     append('${description.isoPeriodUnit}')
+        |   }
+        | }
+    """.trimMargin()
+}
+
+fun ClassBuilder.buildPlusAndMinusOperatorFunctions(description: TemporalUnitDescription) =
+    TemporalUnitDescription.values()
+        .map { description per it }
+        .filter { it.isSupported() }
+        .forEach { conversion ->
+            PlusOrMinusOperator.values().forEach { operator ->
+                buildPlusOrMinusOperatorFunction(conversion, operator, description)
+            }
+        }
+
+fun ClassBuilder.buildPlusOrMinusOperatorFunction(
+    conversion: TemporalUnitConversion,
+    plusOrMinusOperator: PlusOrMinusOperator,
+    description: TemporalUnitDescription
+) = function(plusOrMinusOperator.functionName) {
+    modifiers(KModifier.OPERATOR)
+    val amount = conversion.toUnit.lowerPluralName
+    argument(amount, conversion.toUnit.className)
 
     when (conversion.operator) {
         ConversionOperator.DIV -> {
-            if (this@buildLongPlusMinusOperatorFunSpec is IntTemporalUnitClassGenerator) {
-                returns(conversion.fromUnit.longClassName)
+            returns(description.className)
 
-                addStatement(
-                    "return this.%N() %L %N.${description.inUnitPropertyName}",
-                    toLongUnitFunSpec,
-                    plusOrMinusOperator.uncheckedOperator,
-                    amount
-                )
-            } else {
-                returns(className)
-
-                addStatement(
-                    "return this %L %N.${description.inUnitPropertyName}",
-                    plusOrMinusOperator.uncheckedOperator,
-                    amount
-                )
+            code {
+                val operator = plusOrMinusOperator.uncheckedOperator
+                "return this $operator %$amount:N.${description.inUnitPropertyName}"
             }
         }
         ConversionOperator.TIMES -> {
-            if (this@buildLongPlusMinusOperatorFunSpec is IntTemporalUnitClassGenerator) {
-                returns(conversion.toUnit.longClassName)
+            returns(conversion.toUnit.className)
 
-                addStatement(
-                    "return this.%N().${conversion.toUnit.inUnitPropertyName} %L %N",
-                    toLongUnitFunSpec,
-                    plusOrMinusOperator.uncheckedOperator,
-                    amount
-                )
-            } else {
-                returns(conversion.toUnit.classNameFor(primitive))
-
-                addStatement(
-                    "return this.${conversion.toUnit.inUnitPropertyName} %L %N",
-                    plusOrMinusOperator.uncheckedOperator,
-                    amount
-                )
+            code {
+                val operator = plusOrMinusOperator.uncheckedOperator
+                "return this.${conversion.toUnit.inUnitPropertyName} $operator %$amount:N"
             }
         }
         ConversionOperator.NONE -> {
-            if (primitive == Int::class) {
-                returns(conversion.toUnit.longClassName)
+            returns(description.className)
 
-                addStatement(
-                    "return %T(%N.toLong()·%T %N.${description.valueName})",
-                    description.longClassName,
-                    valuePropertySpec,
-                    plusOrMinusOperator.operator,
-                    amount
-                )
-            } else {
-                returns(className)
-
-                addStatement(
-                    "return %T(%N·%T %N.${description.valueName})",
-                    className,
-                    valuePropertySpec,
-                    plusOrMinusOperator.operator,
-                    amount
-                )
+            code {
+                using("operator", plusOrMinusOperator.operator)
+                "return ${description.pluralName}(${description.valueName}·%operator:T %$amount:N.${description.valueName})"
             }
         }
     }
 }
 
-fun TemporalUnitClassGenerator.buildTimesFunSpec(
-    scalarPrimitive: KClass<*>
-) = buildFunSpec("times") {
-    addModifiers(KModifier.OPERATOR)
-    addKdoc(
-        """
+private fun ClassBuilder.buildTimesFunction(scalarPrimitive: KClass<*>, description: TemporalUnitDescription) {
+    function("times") {
+        kdoc {
+            """
             Multiplies this duration by a scalar value.
             @throws ArithmeticException if overflow occurs
         """.trimIndent()
-    )
+        }
 
-    val scalar = ParameterSpec("scalar", scalarPrimitive.asTypeName())
-    addParameter(scalar)
+        modifiers(KModifier.OPERATOR)
+        argument("scalar", scalarPrimitive)
+        returns(description.className)
 
-    if (this@buildTimesFunSpec is IntTemporalUnitClassGenerator &&
-        (scalarPrimitive == Long::class || description.forceLongInOperators)
-    ) {
-        returns(description.longClassName)
-
-        addStatement(
-            "return this.%N() * %N",
-            toLongUnitFunSpec,
-            scalar
-        )
-    } else {
-        returns(className)
-
-        addStatement(
-            "return %T(%N·%T %N)",
-            className,
-            valuePropertySpec,
-            javamath2kmp("timesExact"),
-            scalar
-        )
+        code {
+            using("timesExact", javamath2kmp("timesExact"))
+            "return ${description.pluralName}(${description.valueName}·%timesExact:T·%scalar:N)"
+        }
     }
 }
 
-fun TemporalUnitClassGenerator.buildDivFunSpec(
-    scalarPrimitive: KClass<*>
-) = buildFunSpec("div") {
-    addModifiers(KModifier.OPERATOR)
-    returns(
-        if (primitive == Long::class) {
-            className
-        } else {
-            description.classNameFor(scalarPrimitive)
-        }
-    )
-
-    val scalar = ParameterSpec("scalar", scalarPrimitive.asTypeName())
-    addParameter(scalar)
-
-    val arguments = mutableMapOf(
-        "scalar" to scalar,
-        "className" to className,
-        "value" to valuePropertySpec,
-        "negateUnchecked" to negateUncheckedFunSpec
-    )
-
-    if (this@buildDivFunSpec is IntTemporalUnitClassGenerator && scalarPrimitive == Long::class) {
-        addKdoc(
+private fun ClassBuilder.buildDivFunction(scalarPrimitive: KClass<*>, description: TemporalUnitDescription) {
+    function("div") {
+        kdoc {
             """
-                Divides this duration by a scalar value.
-                @throws ArithmeticException if the scalar is zero
-            """.trimIndent()
-        )
-        arguments += "toLongUnit" to toLongUnitFunSpec
-        addNamedCode("return this.%toLongUnit:N() / %scalar:N", arguments)
-    } else {
-        addKdoc(
-            """
-                Divides this duration by a scalar value.
+                Returns this duration divided by a scalar value.
                 @throws ArithmeticException if overflow occurs or the scalar is zero
             """.trimIndent()
-        )
-        addNamedCode(
+        }
+
+        modifiers(KModifier.OPERATOR)
+        argument("scalar", scalarPrimitive)
+        returns(description.className)
+
+        code {
             """
                 | return if (%scalar:N == ${scalarPrimitive.literalValueString(-1)}) {
                 |   -this
                 | } else {
-                |   %className:T(%value:N / %scalar:N)
+                |   ${description.pluralName}(${description.valueName}·/·%scalar:N)
                 | }
-            """.trimMargin(),
-            arguments
-        )
-    }
-}
-
-fun TemporalUnitClassGenerator.buildRemFunSpec(
-    scalarPrimitive: KClass<*>
-) = buildFunSpec("rem") {
-    addModifiers(KModifier.OPERATOR)
-
-    val scalar = ParameterSpec("scalar", scalarPrimitive.asTypeName())
-    addParameter(scalar)
-
-    if (this@buildRemFunSpec is IntTemporalUnitClassGenerator && scalarPrimitive == Long::class) {
-        returns(description.longClassName)
-        addStatement("return this.%N() %% %N", toLongUnitFunSpec, scalar)
-    } else {
-        returns(className)
-        addStatement("return %T(%N %% %N)", className, valuePropertySpec, scalar)
-    }
-}
-
-val TemporalUnitConversion.propertyClassName get() = internal(constantName)
-
-fun TemporalUnitDescription.operatorReturnClassNameFor(primitiveType: KClass<*>): ClassName {
-    return when (primitiveType) {
-        Int::class -> if (forceLongInOperators) longClassName else intClassName
-        Long::class -> longClassName
-        else -> throw IllegalArgumentException("Unsupported class type")
-    }
-}
-
-fun TemporalUnitClassGenerator.buildUnitConversionSpecs() = TemporalUnitDescription.values()
-    .map { otherUnit -> description per otherUnit }
-    .filter { conversion -> conversion.isSupportedAndNecessary() }
-    .flatMap { conversion ->
-        when (conversion.operator) {
-            ConversionOperator.DIV -> buildInBiggerUnitConversionSpecs(conversion)
-            ConversionOperator.TIMES -> buildInSmallerUnitConversionSpecs(conversion)
-            else -> throw IllegalStateException("Invalid operator")
+            """.trimMargin()
         }
     }
+}
 
-fun TemporalUnitClassGenerator.buildInBiggerUnitConversionSpecs(
-    conversion: TemporalUnitConversion
-) = listOf(
-    buildPropertySpec(
-        conversion.toUnit.inWholeUnitPropertyName,
-        conversion.toUnit.classNameFor(primitive)
-    ) {
-        addKdoc("Converts this duration to the number of whole ${conversion.toUnit.lowerPluralName}.")
-        getter(
-            buildGetterFunSpec {
-                val statement = buildString {
-                    append("return (%N / %T)")
+private fun ClassBuilder.buildRemFunction(scalarPrimitive: KClass<*>, description: TemporalUnitDescription) {
+    function("rem") {
+        kdoc { "Returns the remainder of this duration divided by a scalar value." }
+        modifiers(KModifier.OPERATOR)
+        argument("scalar", scalarPrimitive)
+        returns(description.className)
+        code { "return ${description.pluralName}(${description.valueName}·%%·%scalar:N)" }
+    }
+}
 
-                    if (primitive == Int::class && !conversion.valueFitsInInt) {
-                        append(".toInt()")
-                    }
-
-                    append(".${conversion.toUnit.lowerPluralName}")
-                }
-
-                addStatement(statement, valuePropertySpec, conversion.propertyClassName)
+private fun ClassBuilder.buildUnitConversionProperties(description: TemporalUnitDescription) {
+    TemporalUnitDescription.values()
+        .map { otherUnit -> description per otherUnit }
+        .filter { conversion -> conversion.isSupportedAndNecessary() }
+        .forEach { conversion ->
+            when (conversion.operator) {
+                ConversionOperator.DIV -> buildInBiggerUnitConversionProperties(conversion, description)
+                ConversionOperator.TIMES -> buildInSmallerUnitConversionProperties(conversion, description)
+                else -> throw IllegalStateException("Invalid operator")
             }
-        )
-    }
-)
-
-fun TemporalUnitClassGenerator.buildInSmallerUnitConversionSpecs(
-    conversion: TemporalUnitConversion
-): List<Any> {
-    val operators = mutableListOf<Any>()
-
-    val overflowSafeMethodRequired = primitive == Long::class ||
-        !conversion.toUnit.forceLongInOperators ||
-        conversion.requiresSafeMultiplicationForInt()
-
-    if (overflowSafeMethodRequired) {
-        operators += buildPropertySpec(
-            conversion.toUnit.inUnitPropertyName,
-            conversion.toUnit.operatorReturnClassNameFor(primitive)
-        ) {
-            addKdoc(
-                """
-                    Converts this duration to ${conversion.toUnit.lowerPluralName}.
-                    @throws ArithmeticException if overflow occurs
-                """.trimIndent()
-            )
-            getter(
-                buildGetterFunSpec {
-                    addStatement(
-                        if (primitive == Int::class && conversion.toUnit.forceLongInOperators) {
-                            "return (%N.toLong()·%T %T).${conversion.toUnit.lowerPluralName}"
-                        } else {
-                            "return (%N·%T %T).${conversion.toUnit.lowerPluralName}"
-                        },
-                        valuePropertySpec,
-                        javamath2kmp("timesExact"),
-                        conversion.propertyClassName
-                    )
-                }
-            )
         }
-    }
-
-    operators += buildPropertySpec(
-        if (overflowSafeMethodRequired) {
-            conversion.toUnit.inUnitUncheckedPropertyName
-        } else {
-            conversion.toUnit.inUnitPropertyName
-        },
-        conversion.toUnit.operatorReturnClassNameFor(primitive)
-    ) {
-        if (overflowSafeMethodRequired) {
-            addModifiers(KModifier.INTERNAL)
-            addKdoc("Converts this duration to ${conversion.toUnit.lowerPluralName} without checking for overflow.")
-        } else {
-            addKdoc("Converts this duration to ${conversion.toUnit.lowerPluralName}.")
-        }
-
-        getter(
-            buildGetterFunSpec {
-                if (primitive == Int::class && conversion.toUnit.forceLongInOperators) {
-                    addStatement(
-                        "return (%N.toLong() * %T).${conversion.toUnit.lowerPluralName}",
-                        valuePropertySpec,
-                        conversion.propertyClassName
-                    )
-                } else {
-                    addStatement(
-                        "return (%N * %T).${conversion.toUnit.lowerPluralName}",
-                        valuePropertySpec,
-                        conversion.propertyClassName
-                    )
-                }
-            }
-        )
-    }
-
-    return operators
 }
 
-fun TemporalUnitClassGenerator.buildPrimitiveExtensionPropertySpec() = buildPropertySpec(
-    description.lowerPluralName,
-    className
+private fun ClassBuilder.buildInBiggerUnitConversionProperties(
+    conversion: TemporalUnitConversion,
+    description: TemporalUnitDescription
 ) {
-    addKdoc("Converts this value to a duration of ${description.lowerPluralName}.", className)
-    receiver(primitive)
-    getter(buildGetterFunSpec {
-        addStatement("return %T(this)", className)
-    })
-}
-
-fun TemporalUnitClassGenerator.buildTimesExtensionFunSpec(
-    scalarPrimitive: KClass<*>
-) = buildFunSpec("times") {
-    receiver(scalarPrimitive)
-    addModifiers(KModifier.OPERATOR)
-    addKdoc(
-        """
-            Multiplies this value by a duration of ${description.lowerPluralName}.
-            @throws ArithmeticException if overflow occurs
-        """.trimIndent()
-    )
-
-    val unit = ParameterSpec(description.lowerPluralName, className)
-    addParameter(unit)
-
-    returns(
-        if (this@buildTimesExtensionFunSpec is IntTemporalUnitClassGenerator &&
-            (scalarPrimitive == Long::class || description.forceLongInOperators)
-        ) {
-            description.longClassName
-        } else {
-            className
+    property(conversion.toUnit.inWholeUnitPropertyName, conversion.toUnit.className) {
+        kdoc { "Converts this duration to the number of whole ${conversion.toUnit.lowerPluralName}." }
+        getter {
+            code {
+                using(
+                    "toUnit" to conversion.toUnit.className,
+                    "conversionProperty" to conversion.propertyClassName
+                )
+                "return %toUnit:T(${description.valueName}·/·%conversionProperty:T)"
+            }
         }
-    )
-
-    addStatement("return %N * this", unit)
-}
-
-@OptIn(ExperimentalStdlibApi::class)
-fun TemporalUnitClassGenerator.buildKotlinDurationExtensionFunSpec() =
-    buildFunSpec("toIsland${description.pluralName}") {
-        receiver(KOTLIN_DURATION_CLASS_NAME)
-        addAnnotation(EXPERIMENTAL_TIME_CLASS_NAME)
-        addKdoc("Converts this duration to Island Time [%T].", className)
-        returns(className)
-        addStatement(
-            "return %T(this.toLong(%T.${description.pluralName.uppercase()}))",
-            className,
-            KOTLIN_DURATION_UNIT_CLASS_NAME
-        )
     }
 
-fun TemporalUnitClassGenerator.buildToComponentsFunctions(): List<FunSpec> {
-    val thisUnit = this.description
+    property(conversion.toUnit.deprecatedInWholeUnitPropertyName, conversion.toUnit.className) {
+        deprecated(
+            message = "Use ${conversion.toUnit.inWholeUnitPropertyName} instead.",
+            replaceWith = "this.${conversion.toUnit.inWholeUnitPropertyName}",
+            level = DeprecationLevel.ERROR
+        )
 
-    return TemporalUnitDescription.values()
+        getter {
+            code {
+                using("deprecated", internal("deprecatedToError"))
+                "return %deprecated:T()"
+            }
+        }
+    }
+}
+
+private fun ClassBuilder.buildInSmallerUnitConversionProperties(
+    conversion: TemporalUnitConversion,
+    description: TemporalUnitDescription
+) {
+    property(conversion.toUnit.inUnitPropertyName, conversion.toUnit.className) {
+        kdoc {
+            """
+                Converts this duration to ${conversion.toUnit.lowerPluralName}.
+                @throws ArithmeticException if overflow occurs
+            """.trimIndent()
+        }
+        getter {
+            code {
+                using(
+                    "toUnit" to conversion.toUnit.className,
+                    "timesExact" to javamath2kmp("timesExact"),
+                    "conversionProperty" to conversion.propertyClassName
+                )
+                "return %toUnit:T(${description.valueName}·%timesExact:T·%conversionProperty:T)"
+            }
+        }
+    }
+
+    property(conversion.toUnit.inUnitUncheckedPropertyName, conversion.toUnit.className) {
+        kdoc { "Converts this duration to ${conversion.toUnit.lowerPluralName} without checking for overflow." }
+        modifiers(KModifier.INTERNAL)
+
+        getter {
+            code {
+                using(
+                    "toUnit" to conversion.toUnit.className,
+                    "timesExact" to javamath2kmp("timesExact"),
+                    "conversionProperty" to conversion.propertyClassName
+                )
+                "return %toUnit:T(${description.valueName}·*·%conversionProperty:T)"
+            }
+        }
+    }
+}
+
+private fun ClassBuilder.buildToComponentValuesFunctions(thisUnit: TemporalUnitDescription) {
+    TemporalUnitDescription.values()
         .filter { it > thisUnit && thisUnit.per(it).isSupported() }
         .map { biggestUnit ->
             val allComponentUnits = TemporalUnitDescription.values()
                 .filter { it in thisUnit..biggestUnit }
                 .sortedDescending()
 
-            buildFunSpec("toComponents") {
-                addTypeVariable(TypeVariableName("T"))
-                addModifiers(KModifier.INLINE)
-                returns(TypeVariableName("T"))
+            val typeVariable = TypeVariableName("T")
+
+            function("toComponentValues") {
+                modifiers(KModifier.INLINE)
+                typeVariable(typeVariable)
 
                 val lambdaParameters = allComponentUnits.map { currentUnit ->
                     buildParameterSpec(
                         currentUnit.lowerPluralName,
-                        if (currentUnit == biggestUnit && primitive == Long::class) {
-                            currentUnit.longClassName
-                        } else {
-                            currentUnit.intClassName
-                        }
+                        if (currentUnit == biggestUnit) Long::class else Int::class
                     )
                 }
 
-                addParameter(
+                argument(
                     "action",
-                    LambdaTypeName.get(parameters = lambdaParameters, returnType = TypeVariableName("T"))
+                    LambdaTypeName.get(parameters = lambdaParameters, returnType = typeVariable)
                 )
 
-                for (currentUnit in allComponentUnits) {
-                    val arguments = mutableMapOf<String, Any>(
-                        "value" to valuePropertySpec
-                    )
+                returns(typeVariable)
 
-                    val conversionString = when (currentUnit) {
-                        biggestUnit -> buildString {
-                            val conversion = thisUnit per currentUnit
-                            arguments["conversion"] = conversion.propertyClassName
-                            append("(%value:N / %conversion:T)")
+                code {
+                    for (currentUnit in allComponentUnits) {
+                        val conversionString = when (currentUnit) {
+                            biggestUnit -> buildString {
+                                val conversion = thisUnit per currentUnit
+                                using(conversion.id, conversion.propertyClassName)
+                                append("(${thisUnit.valueName} / %${conversion.id}:T)")
+                            }
+                            thisUnit -> buildString {
+                                val conversion = thisUnit per thisUnit.nextBiggest
+                                using(conversion.id, conversion.propertyClassName)
+                                append("(${thisUnit.valueName} %% %${conversion.id}:T).toInt()")
+                            }
+                            else -> buildString {
+                                val conversion1 = thisUnit per currentUnit.nextBiggest
+                                val conversion2 = thisUnit per currentUnit
 
-                            if (primitive == Int::class && !conversion.valueFitsInInt) {
-                                append(".toInt()")
+                                using(
+                                    conversion1.id to conversion1.propertyClassName,
+                                    conversion2.id to conversion2.propertyClassName
+                                )
+
+                                append("((${thisUnit.valueName} %% %${conversion1.id}:T) / %${conversion2.id}:T).toInt()")
                             }
                         }
-                        thisUnit -> buildString {
-                            val conversion = thisUnit per thisUnit.nextBiggest
-                            arguments["conversion"] = conversion.propertyClassName
-                            append("(%value:N %% %conversion:T)")
 
-                            if (primitive == Long::class || !conversion.valueFitsInInt) {
-                                append(".toInt()")
-                            }
-                        }
-                        else -> buildString {
-                            val conversion1 = thisUnit per currentUnit.nextBiggest
-                            val conversion2 = thisUnit per currentUnit
-
-                            arguments += mapOf(
-                                "conversion1" to conversion1.propertyClassName,
-                                "conversion2" to conversion2.propertyClassName
-                            )
-
-                            append("((%value:N %% %conversion1:T) / %conversion2:T)")
-
-                            if (primitive == Long::class || !conversion1.valueFitsInInt) {
-                                append(".toInt()")
-                            }
-                        }
+                        +"val ${currentUnit.lowerPluralName} = $conversionString\n"
                     }
 
-                    addNamedCode(
-                        "val ${currentUnit.lowerPluralName} = ${conversionString}.${currentUnit.lowerPluralName}\n",
-                        arguments
-                    )
+                    val allVariableNames = allComponentUnits.joinToString(separator = ", ") { it.lowerPluralName }
+                    "return action($allVariableNames)"
+                }
+            }
+
+            function("toComponents") {
+                modifiers(KModifier.INLINE)
+                typeVariable(typeVariable)
+
+                val lambdaParameters = allComponentUnits.map { currentUnit ->
+                    buildParameterSpec(currentUnit.lowerPluralName, currentUnit.className)
                 }
 
-                val allVariableNames = allComponentUnits.joinToString(", ") { it.lowerPluralName }
-                addStatement("return action($allVariableNames)")
+                argument(
+                    "action",
+                    LambdaTypeName.get(parameters = lambdaParameters, returnType = typeVariable)
+                )
+
+                returns(typeVariable)
+
+                code {
+                    val allVariableNames = allComponentUnits.joinToString(separator = ", ") { it.lowerPluralName }
+                    val allConvertedVariables = allComponentUnits.joinToString(separator = ", ") {
+                        "${it.pluralName}(${it.lowerPluralName})"
+                    }
+
+                    """
+                        | return toComponentValues { $allVariableNames ->
+                        |     action($allConvertedVariables)
+                        | }
+                    """.trimMargin()
+                }
             }
         }
+}
+
+fun FileBuilder.buildPrimitiveConstructorProperty(primitive: KClass<*>, description: TemporalUnitDescription) {
+    property(description.lowerPluralName, description.className) {
+        kdoc { "Converts this value to a duration of ${description.lowerPluralName}." }
+        receiver(primitive)
+        getter {
+            code { "return ${description.pluralName}(this)" }
+        }
+    }
+}
+
+fun FileBuilder.buildTimesExtensionFunction(scalarPrimitive: KClass<*>, description: TemporalUnitDescription) {
+    function("times") {
+        kdoc {
+            """
+                Multiplies this value by a duration of ${description.lowerPluralName}.
+                @throws ArithmeticException if overflow occurs
+            """.trimIndent()
+        }
+        receiver(scalarPrimitive)
+        modifiers(KModifier.OPERATOR)
+        val unit = description.lowerPluralName
+        argument(unit, description.className)
+        returns(description.className)
+        code { "return $unit * this" }
+    }
 }

--- a/tools/code-generator/src/main/kotlin/io/islandtime/codegen/generators/TemporalUnitGenerator.kt
+++ b/tools/code-generator/src/main/kotlin/io/islandtime/codegen/generators/TemporalUnitGenerator.kt
@@ -200,6 +200,7 @@ class LongTemporalUnitClassGenerator(
     val toIntUnitUncheckedFunSpec by lazy(::buildToIntUnitUncheckedFunSpec)
     val toIntFunSpec by lazy(::buildToIntFunSpec)
     val toIntUncheckedFunSpec by lazy(::buildToIntUncheckedFunSpec)
+    val toLongFunSpec by lazy(::buildToLongFunSpec)
 
     val kotlinDurationExtensionFunSpec by lazy(::buildKotlinDurationExtensionFunSpec)
 
@@ -208,7 +209,8 @@ class LongTemporalUnitClassGenerator(
             toIntUnitFunSpec,
             toIntUnitUncheckedFunSpec,
             toIntFunSpec,
-            toIntUncheckedFunSpec
+            toIntUncheckedFunSpec,
+            toLongFunSpec
         )
     }
 
@@ -261,18 +263,48 @@ fun TemporalUnitClassGenerator.buildConstructorFunSpec() = buildConstructorFunSp
 
 fun TemporalUnitClassGenerator.buildIsZeroFunSpec() = buildFunSpec("isZero") {
     addKdoc("Checks if this duration is zero.")
+    addAnnotation(
+        buildAnnotationSpec(Deprecated::class) {
+            addMember("message = %S", "Replace with direct comparison.")
+            addMember(
+                "replaceWith = ReplaceWith(%S)",
+                "this == ${valuePropertySpec.type.zeroValueString}.${description.lowerPluralName}"
+            )
+            addMember("level = DeprecationLevel.ERROR")
+        }
+    )
     returns(Boolean::class)
     addStatement("return %N == ${valuePropertySpec.type.zeroValueString}", valuePropertySpec)
 }
 
 fun TemporalUnitClassGenerator.buildIsNegativeFunSpec() = buildFunSpec("isNegative") {
     addKdoc("Checks if this duration is negative.")
+    addAnnotation(
+        buildAnnotationSpec(Deprecated::class) {
+            addMember("message = %S", "Replace with direct comparison.")
+            addMember(
+                "replaceWith = ReplaceWith(%S)",
+                "this < ${valuePropertySpec.type.zeroValueString}.${description.lowerPluralName}"
+            )
+            addMember("level = DeprecationLevel.ERROR")
+        }
+    )
     returns(Boolean::class)
     addStatement("return %N < ${valuePropertySpec.type.zeroValueString}", valuePropertySpec)
 }
 
 fun TemporalUnitClassGenerator.buildIsPositiveFunSpec() = buildFunSpec("isPositive") {
     addKdoc("Checks if this duration is positive.")
+    addAnnotation(
+        buildAnnotationSpec(Deprecated::class) {
+            addMember("message = %S", "Replace with direct comparison.")
+            addMember(
+                "replaceWith = ReplaceWith(%S)",
+                "this > ${valuePropertySpec.type.zeroValueString}.${description.lowerPluralName}"
+            )
+            addMember("level = DeprecationLevel.ERROR")
+        }
+    )
     returns(Boolean::class)
     addStatement("return %N > ${valuePropertySpec.type.zeroValueString}", valuePropertySpec)
 }
@@ -459,6 +491,12 @@ fun LongTemporalUnitClassGenerator.buildToIntUnitUncheckedFunSpec() = buildFunSp
     addAnnotation(PublishedApi::class)
     returns(description.intClassName)
     addStatement("return %T(%N.toInt())", description.intClassName, valuePropertySpec)
+}
+
+fun LongTemporalUnitClassGenerator.buildToLongFunSpec() = buildFunSpec("toLong") {
+    addKdoc("Converts this duration to a `Long` value.")
+    returns(Long::class)
+    addStatement("return %N", valuePropertySpec)
 }
 
 fun TemporalUnitClassGenerator.buildUnaryMinusFunSpec() = buildFunSpec("unaryMinus") {


### PR DESCRIPTION
To make things simpler, the duration unit classes backed by `Int` have been removed, leaving only the `Long` versions, which are now renamed to `Hours`, `Minutes`, etc. This is a fairly significant change that may require some code adjustments.

Functions such as `toComponentValues ()` have also been added to make it easier to get at non-unitized values.

Closes #11 