### PR TITLE
Remove KMP compatibility metadata

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ releaseRepositoryUrl=https://oss.sonatype.org/service/local/staging/deploy/maven
 
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
-kotlin.mpp.enableCompatibilityMetadataVariant=true
 
 android.useAndroidX=true
 android.disableAutomaticComponentCreation=true


### PR DESCRIPTION
This works around build issues when using Kotlin 1.6.20-compiled libraries, though will require consumers to enable HMPP going forward. Since this is the default setting starting in 1.6.20, that seems fine.