### PR TITLE
Re-enable compatibility metadata variant

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ releaseRepositoryUrl=https://oss.sonatype.org/service/local/staging/deploy/maven
 
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
+kotlin.mpp.enableCompatibilityMetadataVariant=true
 
 android.useAndroidX=true
 android.disableAutomaticComponentCreation=true


### PR DESCRIPTION
Seems to be working again in Kotlin 1.6.21