### PR TITLE
Fix date copy() issue due to default argument for dayOfYear

### DIFF
--- a/core/src/commonMain/kotlin/io/islandtime/Date.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/Date.kt
@@ -294,7 +294,7 @@ class Date(
      */
     fun copy(
         year: Int = this.year,
-        dayOfYear: Int = this.dayOfYear
+        dayOfYear: Int
     ): Date = Date(year, dayOfYear)
 
     companion object {

--- a/core/src/commonMain/kotlin/io/islandtime/DateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/DateTime.kt
@@ -538,7 +538,7 @@ class DateTime(
      */
     fun copy(
         year: Int = this.year,
-        dayOfYear: Int = this.dayOfYear,
+        dayOfYear: Int,
         hour: Int = this.hour,
         minute: Int = this.minute,
         second: Int = this.second,

--- a/core/src/commonMain/kotlin/io/islandtime/OffsetDateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/OffsetDateTime.kt
@@ -378,7 +378,7 @@ class OffsetDateTime(
      */
     fun copy(
         year: Int = this.year,
-        dayOfYear: Int = this.dayOfYear,
+        dayOfYear: Int,
         hour: Int = this.hour,
         minute: Int = this.minute,
         second: Int = this.second,

--- a/core/src/commonMain/kotlin/io/islandtime/ZonedDateTime.kt
+++ b/core/src/commonMain/kotlin/io/islandtime/ZonedDateTime.kt
@@ -351,7 +351,7 @@ class ZonedDateTime private constructor(
      */
     fun copy(
         year: Int = this.year,
-        dayOfYear: Int = this.dayOfYear,
+        dayOfYear: Int,
         hour: Int = this.hour,
         minute: Int = this.minute,
         second: Int = this.second,

--- a/core/src/commonTest/kotlin/io/islandtime/DateTest.kt
+++ b/core/src/commonTest/kotlin/io/islandtime/DateTest.kt
@@ -40,6 +40,7 @@ class DateTest : AbstractIslandTimeTest() {
     fun `dates can be constructed from year and day of year`() {
         assertEquals(Date(2019, Month.DECEMBER, 1), Date(2019, 335))
         assertEquals(Date(2020, Month.DECEMBER, 1), Date(2020, 336))
+        assertEquals(Date(20200, Month.MARCH, 15), Date(20200, 74))
     }
 
     @Test
@@ -47,6 +48,11 @@ class DateTest : AbstractIslandTimeTest() {
         assertEquals(
             Date(2017, Month.NOVEMBER, 19),
             Date(2018, Month.NOVEMBER, 19).copy(year = 2017)
+        )
+
+        assertEquals(
+            Date(20200, Month.MARCH, 15),
+            Date(2020, Month.MARCH, 15).copy(year = 20200)
         )
 
         assertEquals(


### PR DESCRIPTION
The date copy() methods accepting dayOfYear take precedence over the month/day variants, causing the day to be off by one if the year is changed between a common and leap year. The default value has been removed so that the month/day variant takes precedence, as intended.